### PR TITLE
Fixes the float buffer size if double precision is used

### DIFF
--- a/src/ipc/raw_data_decode.cpp
+++ b/src/ipc/raw_data_decode.cpp
@@ -31,7 +31,7 @@ std::vector<std::uint8_t>
     make_float_buffer_from_double(const std::vector<std::uint8_t>& buff_double)
 {
     int element_count = buff_double.size() / sizeof(double);
-    std::vector<std::uint8_t> buff_float(element_count);
+    std::vector<std::uint8_t> buff_float(element_count * sizeof(float));
 
     // Cast from double to float
     const double* src = reinterpret_cast<const double*>(buff_double.data());


### PR DESCRIPTION
The buffer for the conversion to float values is too small, this fixes it. May also be related to issue #23 .
