### PR TITLE
ci: build on windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, macos-13]
+                os: [ubuntu-20.04, ubuntu-22.04, macos-12, macos-13, windows-2019, windows-2022]
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
@@ -43,7 +43,6 @@ jobs:
               if: contains(matrix.os, 'ubuntu')
               run: >
                 sudo apt install
-                ninja-build
                 qtbase5-dev
                 qtchooser
                 qt5-qmake
@@ -52,14 +51,17 @@ jobs:
             - name: Install dependencies (MacOS)
               if: contains(matrix.os, 'macos')
               run: >
-                brew install
-                ninja
-                qt5
+                brew install qt5
+            - name: Install dependencies (Windows)
+              if: contains(matrix.os, 'windows')
+              uses: jurplel/install-qt-action@2d518188e746defd451af981c3c901f463d99e29
             - name: Build
+              shell: bash
               run: |
                 if [ ${{ contains(matrix.os, 'macos') }} ]; then
                   export PATH=/usr/local/opt/qt5/bin:$PATH;
                 fi
-                mkdir build && cd build
-                cmake .. -GNinja -DCMAKE_BUILD_TYPE=release -DCMAKE_INSTALL_PREFIX=/tmp
-                ninja install
+
+                # see https://stackoverflow.com/a/24470998/5843895 and https://cliutils.gitlab.io/modern-cmake/chapters/intro/running.html
+                cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/tmp
+                cmake --build build --config Release --target install -j 2

--- a/common.cmake
+++ b/common.cmake
@@ -34,4 +34,4 @@ set(CMAKE_CXX_EXTENSIONS False)
 find_package(Threads REQUIRED)
 find_package(Qt5 COMPONENTS Network REQUIRED)
 
-add_compile_options(-Wall -Wextra -pedantic -fvisibility=hidden)
+add_compile_options("$<$<PLATFORM_ID:UNIX>:-Wall -Wextra -pedantic -fvisibility=hidden>")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,4 +94,3 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
 
 install(TARGETS ${PROJECT_NAME}
         RUNTIME DESTINATION OpenImageDebugger)
-

--- a/src/io/buffer_exporter.cpp
+++ b/src/io/buffer_exporter.cpp
@@ -23,11 +23,12 @@
  * IN THE SOFTWARE.
  */
 
+#include "buffer_exporter.h"
+
+#include <limits>
 #include <memory>
 
 #include <QPixmap>
-
-#include "buffer_exporter.h"
 
 #include "math/assorted.h"
 
@@ -38,7 +39,7 @@ using namespace std;
 template <typename T>
 float get_multiplier()
 {
-    return 255.f / static_cast<float>(std::numeric_limits<T>::max());
+    return 255.f / static_cast<float>((std::numeric_limits<T>::max)());
 }
 
 
@@ -52,7 +53,7 @@ float get_multiplier<float>()
 template <typename T>
 T get_max_intensity()
 {
-    return std::numeric_limits<T>::max();
+    return (std::numeric_limits<T>::max)();
 }
 
 

--- a/src/math/assorted.h
+++ b/src/math/assorted.h
@@ -31,7 +31,7 @@
 template <typename T>
 int clamp(T value, T lower, T upper)
 {
-    return std::min(std::max(value, lower), upper);
+    return (std::min)((std::max)(value, lower), upper);
 }
 
 #endif // ASSORTED_H_

--- a/src/ui/gl_text_renderer.cpp
+++ b/src/ui/gl_text_renderer.cpp
@@ -106,8 +106,8 @@ void GLTextRenderer::generate_glyphs_texture()
                                      GL_UNSIGNED_BYTE,
                                      nullptr);
 
-            tex_level_width = std::max(1, tex_level_width / 2);
-            tex_level_height = std::max(1, tex_level_height / 2);
+            tex_level_width = (std::max)(1, tex_level_width / 2);
+            tex_level_height = (std::max)(1, tex_level_height / 2);
         }
     }
 
@@ -177,7 +177,7 @@ void GLTextRenderer::generate_glyphs_texture()
         text_texture_tls[*p][1]      = cropped_bitmap_height;
 
         box_w += advance_x + 2 * border_size;
-        box_h = std::max(box_h, (float)bitmap_height + 2 * border_size);
+        box_h = (std::max)(box_h, (float)bitmap_height + 2 * border_size);
     }
 
     // Clears generated buffer

--- a/src/ui/main_window/ui_events.cpp
+++ b/src/ui/main_window/ui_events.cpp
@@ -24,6 +24,7 @@
  */
 
 #include <QFileDialog>
+#include <QtMath> // for portable definition of M_PI
 
 #include "main_window.h"
 

--- a/src/visualization/components/buffer.cpp
+++ b/src/visualization/components/buffer.cpp
@@ -119,33 +119,33 @@ void Buffer::recompute_min_color_values()
     float* lowest = min_buffer_values();
 
     for (int i = 0; i < 4; ++i)
-        lowest[i] = std::numeric_limits<float>::max();
+        lowest[i] = (std::numeric_limits<float>::max)();
 
     for (int y = 0; y < buffer_height_i; ++y) {
         for (int x = 0; x < buffer_width_i; ++x) {
             int i = y * step + x;
             for (int c = 0; c < channels; ++c) {
                 if (type == BufferType::Float32 || type == BufferType::Float64)
-                    lowest[c] = std::min(
+                    lowest[c] = (std::min)(
                         lowest[c],
                         reinterpret_cast<const float*>(buffer)[channels * i + c]);
                 else if (type == BufferType::UnsignedByte)
                     lowest[c] =
-                        std::min(lowest[c],
+                        (std::min)(lowest[c],
                                  static_cast<float>(buffer[channels * i + c]));
                 else if (type == BufferType::Short)
                     lowest[c] =
-                        std::min(lowest[c],
+                        (std::min)(lowest[c],
                                  static_cast<float>(reinterpret_cast<const short*>(
                                      buffer)[channels * i + c]));
                 else if (type == BufferType::UnsignedShort)
-                    lowest[c] = std::min(
+                    lowest[c] = (std::min)(
                         lowest[c],
                         static_cast<float>(reinterpret_cast<const unsigned short*>(
                             buffer)[channels * i + c]));
                 else if (type == BufferType::Int32)
                     lowest[c] =
-                        std::min(lowest[c],
+                        (std::min)(lowest[c],
                                  static_cast<float>(reinterpret_cast<const int*>(
                                      buffer)[channels * i + c]));
             }
@@ -172,25 +172,25 @@ void Buffer::recompute_max_color_values()
             int i = y * step + x;
             for (int c = 0; c < channels; ++c) {
                 if (type == BufferType::Float32 || type == BufferType::Float64)
-                    upper[c] = std::max(
+                    upper[c] = (std::max)(
                         upper[c],
                         reinterpret_cast<const float*>(buffer)[channels * i + c]);
                 else if (type == BufferType::UnsignedByte)
-                    upper[c] = std::max(
+                    upper[c] = (std::max)(
                         upper[c], static_cast<float>(buffer[channels * i + c]));
                 else if (type == BufferType::Short)
                     upper[c] =
-                        std::max(upper[c],
+                        (std::max)(upper[c],
                                  static_cast<float>(reinterpret_cast<const short*>(
                                      buffer)[channels * i + c]));
                 else if (type == BufferType::UnsignedShort)
-                    upper[c] = std::max(
+                    upper[c] = (std::max)(
                         upper[c],
                         static_cast<float>(reinterpret_cast<const unsigned short*>(
                             buffer)[channels * i + c]));
                 else if (type == BufferType::Int32)
                     upper[c] =
-                        std::max(upper[c],
+                        (std::max)(upper[c],
                                  static_cast<float>(reinterpret_cast<const int*>(
                                      buffer)[channels * i + c]));
             }
@@ -226,11 +226,11 @@ void Buffer::compute_contrast_brightness_parameters()
             maxIntensity = 255.0f;
         } else if (type ==
                  BufferType::Short) {// All non-real values have max color 255
-            maxIntensity = static_cast<float>(std::numeric_limits<short>::max());
+            maxIntensity = static_cast<float>((std::numeric_limits<short>::max)());
         } else if (type == BufferType::UnsignedShort) {
-            maxIntensity = static_cast<float>(std::numeric_limits<unsigned short>::max());
+            maxIntensity = static_cast<float>((std::numeric_limits<unsigned short>::max)());
         } else if (type == BufferType::Int32) {
-            maxIntensity = static_cast<float>(std::numeric_limits<int>::max());
+            maxIntensity = static_cast<float>((std::numeric_limits<int>::max)());
         } else if (type == BufferType::Float32 || type == BufferType::Float64) {
             maxIntensity = 1.0f;
         }
@@ -445,7 +445,7 @@ void Buffer::draw(const mat4& projection, const mat4& viewInv)
     }
 
     for (int ty = 0; ty < num_textures_y; ++ty) {
-        int buff_h = std::min(remaining_h, max_texture_size);
+        int buff_h = (std::min)(remaining_h, max_texture_size);
         remaining_h -= buff_h;
 
         py += buff_h / 2;
@@ -461,7 +461,7 @@ void Buffer::draw(const mat4& projection, const mat4& viewInv)
         }
 
         for (int tx = 0; tx < num_textures_x; ++tx) {
-            int buff_w = std::min(remaining_w, max_texture_size);
+            int buff_w = (std::min)(remaining_w, max_texture_size);
             remaining_w -= buff_w;
 
             glBindTexture(GL_TEXTURE_2D, buff_tex[ty * num_textures_x + tx]);
@@ -557,12 +557,12 @@ void Buffer::setup_gl_buffer()
     glPixelStorei(GL_UNPACK_ROW_LENGTH, step);
 
     for (int ty = 0; ty < num_textures_y; ++ty) {
-        int buff_h = std::min(remaining_h, max_texture_size);
+        int buff_h = (std::min)(remaining_h, max_texture_size);
         remaining_h -= buff_h;
 
         int remaining_w = buffer_width_i;
         for (int tx = 0; tx < num_textures_x; ++tx) {
-            int buff_w = std::min(remaining_w, max_texture_size);
+            int buff_w = (std::min)(remaining_w, max_texture_size);
             remaining_w -= buff_w;
 
             int tex_id = ty * num_textures_x + tx;


### PR DESCRIPTION
- Building using the default versions of MSVC on both `windows-2019` and `windows-2022` runners.
- Qt installed via www.github.com/jurplel/install-qt-action
- Changed build call from explicit `ninja` invocation to `cmake --build`
- Fixed some issues with `max()` and `min()` being treated as macros on Windows. Ugly workaround: wrap the function names with parentheses - see https://stackoverflow.com/a/2561377/5843895