### PR TITLE
Get the stride if given in Eigen::Map

### DIFF
--- a/resources/oidscripts/oidtypes/eigen3.py
+++ b/resources/oidscripts/oidtypes/eigen3.py
@@ -82,7 +82,9 @@ class EigenXX(interface.TypeInspectorInterface):
 
         # Set row stride and pixel layout
         pixel_layout = 'bgra'
-        row_stride = width
+
+        eigen_stride = int(picked_obj.type.template_argument(2).template_argument(1))
+        row_stride = eigen_stride if eigen_stride > 0 else width
 
         return {
             'display_name': obj_name + ' (' + str(matrix_type_obj) + ')',


### PR DESCRIPTION
Hey, 
This PR enables visualizing strided data using Eigen, which can simplify things with respect to e.g. OpenCV as Eigen is header only.

I did not test thoroughly, however, my first impression was that it is working fine. Of course, you can suggest improvements or simply commit them yourself :slightly_smiling_face: .  