### PR TITLE
feat: use c++20

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -27,7 +27,7 @@ set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type")
 set(CMAKE_INSTALL_PREFIX /usr/local CACHE PATH "Install path")
 
 # We want to be as strict as possible with the standards
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_EXTENSIONS False)
 


### PR DESCRIPTION
Compilers' and CMake support of the c++20 standard has been a tricky issue especially regarding modules and coroutines, but we are giving it a try anyways.

See https://en.cppreference.com/w/cpp/compiler_support/20