### PR TITLE
improvement: better CMake scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,19 @@ cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/path/to/installation/folder
 cmake --build build --config Release --target install -j 4
 ```
 
+CMake build script tries to automatically find suitable python installation using 
+internal module [FindPython3](https://cmake.org/cmake/help/latest/module/FindPython3.html).
+
+You can help it by adding `-DPython3_ROOT_DIR=/path` to command line, like below
+
+```bash
+cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/path/to/installation/folder -DPython3_ROOT_DIR=/usr
+```
+
+If you have LLDB installed, then CMake will try to retrieve this information from it, \
+by running command `lldb --print-script-interpreter-info` and parsing its output.
+
+
 **GDB integration:** Edit the file `~/.gdbinit` (create it if it doesn't exist)
 and append the following line:
 
@@ -99,9 +112,10 @@ command script import /path/to/OpenImageDebugger/oid.py
 
 ### MacOS Installation
 
-For information on how to build the plugin on MacOS, refer to the wiki page
-[Building on
-MacOS](https://github.com/OpenImageDebugger/OpenImageDebugger/wiki/Building-on-MacOS).
+CMake scripts rely on LLDB output. 
+
+They execute command `lldb --print-script-interpreter-info` that prints all necessary 
+information about embedded python and parse its output.
 
 ### Testing your installation
 

--- a/resources/deployscripts.cmake
+++ b/resources/deployscripts.cmake
@@ -6,7 +6,10 @@ set(DEBUGGER_SCRIPTS ${CMAKE_CURRENT_SOURCE_DIR}/../../resources/oidscripts)
 set(OID_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/../../resources/oid.py)
 
 install(DIRECTORY ${MATLAB_SCRIPTS} ${DEBUGGER_SCRIPTS}
-        DESTINATION OpenImageDebugger)
+        DESTINATION OpenImageDebugger
+        FILES_MATCHING PATTERN "*pycache*" EXCLUDE
+                       PATTERN "*.m"
+                       PATTERN "*.py")
 
 install(PROGRAMS ${OID_SCRIPT}
         DESTINATION OpenImageDebugger)

--- a/src/oidbridge/CMakeLists.txt
+++ b/src/oidbridge/CMakeLists.txt
@@ -50,42 +50,44 @@ if (NOT Python3_ROOT_DIR)
         endif()
     endif()
 
-    # Make GDB to print script interpreter info, similar to LLDB
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/gdbcomm" "py
+    if (UNIX)
+        # Make GDB to print script interpreter info, similar to LLDB
+        file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/gdbcomm" "py
 import sys
 import gdb
 print(f'{{\"version\": \"{sys.version_info.major}.{sys.version_info.minor}\", \"executable\": \"{sys.executable}\", \"prefix\": \"{sys.prefix}\"}}')
 gdb.execute(\"quit\")
 ")
 
-    execute_process(COMMAND "gdb" "-q" "--command=${CMAKE_CURRENT_BINARY_DIR}/gdbcomm"
-        OUTPUT_VARIABLE gdb_output RESULT_VARIABLE gdb_result)
+        execute_process(COMMAND "gdb" "-q" "--command=${CMAKE_CURRENT_BINARY_DIR}/gdbcomm"
+            OUTPUT_VARIABLE gdb_output RESULT_VARIABLE gdb_result)
 
-    if (gdb_result EQUAL 0)
-        string(JSON gdb_python_version GET ${gdb_output} "version")
-        string(JSON gdb_python_root GET ${gdb_output} "prefix")
-        string(JSON gdb_python_exe GET ${gdb_output} "executable")
+        if (gdb_result EQUAL 0)
+            string(JSON gdb_python_version GET ${gdb_output} "version")
+            string(JSON gdb_python_root GET ${gdb_output} "prefix")
+            string(JSON gdb_python_exe GET ${gdb_output} "executable")
 
-        message(STATUS "GDB was configured with Python ${gdb_python_version} at ${gdb_python_exe} (root is ${gdb_python_root})")
-    endif()
-
-    if (gdb_python_root AND lldb_python_root)
-        if(NOT gdb_python_root PATH_EQUAL lldb_python_root)
-            message(FATAL_ERROR
-"CMake determined that you have installed both GDB and LLDB and they are configured to use python at different locations (${gdb_python_root} and ${lldb_python_root} respectively)
-Please rerun configuration explicitly specifying python root path
-              cmake .... -DPython3_ROOT_DIR=/path
-")
+            message(STATUS "GDB was configured with Python ${gdb_python_version} at ${gdb_python_exe} (root is ${gdb_python_root})")
         endif()
-    endif()
 
-    if (gdb_python_version AND lldb_python_version)
-        if(NOT gdb_python_version VERSION_EQUAL lldb_python_version)
-            message(FATAL_ERROR
-"CMake determined that you have installed both GDB and LLDB and they are configured to use different python versions (${gdb_python_version} and ${lldb_python_version} respectively).
-Please rerun configuration explicitly specifying python root path
-              cmake .... -DPython3_ROOT_DIR=/path
-")
+        if (gdb_python_root AND lldb_python_root)
+            if(NOT gdb_python_root PATH_EQUAL lldb_python_root)
+                message(FATAL_ERROR
+                    "CMake determined that you have installed both GDB and LLDB and they are configured to use python at different locations (${gdb_python_root} and ${lldb_python_root} respectively)
+                    Please rerun configuration explicitly specifying python root path
+                    cmake .... -DPython3_ROOT_DIR=/path
+                    ")
+            endif()
+        endif()
+
+        if (gdb_python_version AND lldb_python_version)
+            if(NOT gdb_python_version VERSION_EQUAL lldb_python_version)
+                message(FATAL_ERROR
+                        "CMake determined that you have installed both GDB and LLDB and they are configured to use different python versions (${gdb_python_version} and ${lldb_python_version} respectively).
+                        Please rerun configuration explicitly specifying python root path
+                        cmake .... -DPython3_ROOT_DIR=/path
+                        ")
+            endif()
         endif()
     endif()
 

--- a/src/oidbridge/CMakeLists.txt
+++ b/src/oidbridge/CMakeLists.txt
@@ -72,21 +72,23 @@ gdb.execute(\"quit\")
 
         if (gdb_python_root AND lldb_python_root)
             if(NOT gdb_python_root PATH_EQUAL lldb_python_root)
-                message(FATAL_ERROR
-                    "CMake determined that you have installed both GDB and LLDB and they are configured to use python at different locations (${gdb_python_root} and ${lldb_python_root} respectively)
-                    Please rerun configuration explicitly specifying python root path
-                    cmake .... -DPython3_ROOT_DIR=/path
-                    ")
+                message(FATAL_ERROR "
+CMake determined that you have installed both GDB and LLDB and they are configured to use python at different locations
+${gdb_python_root} and ${lldb_python_root} respectively
+Please rerun configuration explicitly specifying python root path
+   cmake .... -DPython3_ROOT_DIR=/path
+")
             endif()
         endif()
 
         if (gdb_python_version AND lldb_python_version)
             if(NOT gdb_python_version VERSION_EQUAL lldb_python_version)
-                message(FATAL_ERROR
-                        "CMake determined that you have installed both GDB and LLDB and they are configured to use different python versions (${gdb_python_version} and ${lldb_python_version} respectively).
-                        Please rerun configuration explicitly specifying python root path
-                        cmake .... -DPython3_ROOT_DIR=/path
-                        ")
+                message(FATAL_ERROR "
+CMake determined that you have installed both GDB and LLDB and they are configured to use different python versions
+${gdb_python_version} and ${lldb_python_version} respectively
+Please rerun configuration explicitly specifying python root path
+    cmake .... -DPython3_ROOT_DIR=/path
+")
             endif()
         endif()
     endif()

--- a/src/oidbridge/CMakeLists.txt
+++ b/src/oidbridge/CMakeLists.txt
@@ -21,11 +21,89 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-cmake_minimum_required(VERSION 3.22.1)
+cmake_minimum_required(VERSION 3.24.0)
 
 project(oidbridge_python3)
 
-find_package(PythonLibs 3.10.12 REQUIRED)
+if (NOT Python3_ROOT_DIR)
+    execute_process(COMMAND "lldb" "--print-script-interpreter-info"
+        OUTPUT_VARIABLE lldb_output ERROR_VARIABLE lldb_err RESULT_VARIABLE lldb_result)
+    if (lldb_result EQUAL 0)
+        string(JSON lldb_python_exe GET ${lldb_output} "executable")
+        string(JSON lldb_python_root GET ${lldb_output} "prefix")
+
+        execute_process(COMMAND "${lldb_python_exe}" "--version" OUTPUT_VARIABLE python_full_version RESULT_VARIABLE python_result)
+        if (python_result EQUAL 0)
+            string(REGEX MATCH "Python +([0-9]+\.[0-9]+).*" python_text_version "${python_full_version}")
+            if (python_text_version)
+                set(lldb_python_version ${CMAKE_MATCH_1})
+                message(STATUS "LLDB was configured with Python ${lldb_python_version} at ${lldb_python_exe} (root is ${lldb_python_root})")
+            else()
+                set(lldb_python_exe FALSE)
+                set(lldb_python_root FALSE)
+                set(lldb_python_version FALSE)
+            endif()
+        else()
+            set(lldb_python_exe FALSE)
+            set(lldb_python_root FALSE)
+            set(lldb_python_version FALSE)
+        endif()
+    endif()
+
+    # Make GDB to print script interpreter info, similar to LLDB
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/gdbcomm" "py
+import sys
+import gdb
+print(f'{{\"version\": \"{sys.version_info.major}.{sys.version_info.minor}\", \"executable\": \"{sys.executable}\", \"prefix\": \"{sys.prefix}\"}}')
+gdb.execute(\"quit\")
+")
+
+    execute_process(COMMAND "gdb" "-q" "--command=${CMAKE_CURRENT_BINARY_DIR}/gdbcomm"
+        OUTPUT_VARIABLE gdb_output RESULT_VARIABLE gdb_result)
+
+    if (gdb_result EQUAL 0)
+        string(JSON gdb_python_version GET ${gdb_output} "version")
+        string(JSON gdb_python_root GET ${gdb_output} "prefix")
+        string(JSON gdb_python_exe GET ${gdb_output} "executable")
+
+        message(STATUS "GDB was configured with Python ${gdb_python_version} at ${gdb_python_exe} (root is ${gdb_python_root})")
+    endif()
+
+    if (gdb_python_root AND lldb_python_root)
+        if(NOT gdb_python_root PATH_EQUAL lldb_python_root)
+            message(FATAL_ERROR
+"CMake determined that you have installed both GDB and LLDB and they are configured to use python at different locations (${gdb_python_root} and ${lldb_python_root} respectively)
+Please rerun configuration explicitly specifying python root path
+              cmake .... -DPython3_ROOT_DIR=/path
+")
+        endif()
+    endif()
+
+    if (gdb_python_version AND lldb_python_version)
+        if(NOT gdb_python_version VERSION_EQUAL lldb_python_version)
+            message(FATAL_ERROR
+"CMake determined that you have installed both GDB and LLDB and they are configured to use different python versions (${gdb_python_version} and ${lldb_python_version} respectively).
+Please rerun configuration explicitly specifying python root path
+              cmake .... -DPython3_ROOT_DIR=/path
+")
+        endif()
+    endif()
+
+    if (lldb_python_root)
+        set(Python3_ROOT_DIR ${lldb_python_root})
+        set(python_version ${lldb_python_version})
+    elseif(gdb_python_root)
+        set(Python3_ROOT_DIR ${gdb_python_root})
+        set(python_version ${gdb_python_version})
+    endif()
+
+
+    find_package(Python3 ${python_version} EXACT COMPONENTS Development)
+else()
+    # rely on user input
+    # assume that user runs cmake .. -DPython3_ROOT_DIR=/path/to/python
+    find_package(Python3 3.8 COMPONENTS Development)
+endif()
 
 add_library(${PROJECT_NAME} SHARED
             oid_bridge.cpp
@@ -43,13 +121,13 @@ target_include_directories(${PROJECT_NAME}
                            PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../)
 
 target_include_directories(${PROJECT_NAME} SYSTEM
-                           PRIVATE ${PYTHON_INCLUDE_DIR})
+                           PRIVATE ${Python3_INCLUDE_DIRS})
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
                       Qt5::Core
                       Qt5::Network
                       Threads::Threads
-                      ${PYTHON_LIBRARY})
+                      ${Python3_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME} DESTINATION OpenImageDebugger)
 


### PR DESCRIPTION
Skip installing temporary files (like .swp and .pyc)

Use `FindPython3` CMake module to find python instead of deprecated `FindPythonLibs`

This module uses `Python3_ROOT_DIR` variable as a hint to find python, give an option to use it.
If this variable is set (from command line, for example), then rely on it.
Otherwise new code in `src/oidbridge/CMakeLists` polls lldb, then gdb and tries to detect configurations of the embedded pythons.

If on Windows, then poll only lldb.

Added respective note in README