### PR TITLE
fix: simplify and improve `LLDBBridge.__getitem__`

### DIFF
--- a/resources/oidscripts/debuggers/lldbbridge.py
+++ b/resources/oidscripts/debuggers/lldbbridge.py
@@ -230,20 +230,13 @@ class SymbolWrapper(DebuggerSymbolReference):
         return float(string_value)
 
     def __getitem__(self, member):
-        num_children = self._symbol.GetNumChildren()
-        if isinstance(member, int):
-            invalid_member_requested = member > num_children
-            get_symbol_child = self._symbol.GetChildAtIndex
-        elif isinstance(member, str):
-            invalid_member_requested = self._symbol.GetIndexOfChildWithName(
-                member) > num_children
-            get_symbol_child = self._symbol.GetChildMemberWithName
+        child = self._symbol.GetChildAtIndex(member) if isinstance(member, int) \
+                else selg._symbol.GetChildMemberWithName(str(member))
 
-        if invalid_member_requested:
+        if not child.IsValid():
             raise KeyError
 
-        symbol_child = get_symbol_child(member)
-        return SymbolWrapper(symbol_child)
+        return SymbolWrapper(child)
 
     def get_casted_pointer(self):
         if self._symbol.TypeIsPointerType():

--- a/resources/oidscripts/debuggers/lldbbridge.py
+++ b/resources/oidscripts/debuggers/lldbbridge.py
@@ -231,7 +231,7 @@ class SymbolWrapper(DebuggerSymbolReference):
 
     def __getitem__(self, member):
         child = self._symbol.GetChildAtIndex(member) if isinstance(member, int) \
-                else selg._symbol.GetChildMemberWithName(str(member))
+                else self._symbol.GetChildMemberWithName(str(member))
 
         if not child.IsValid():
             raise KeyError


### PR DESCRIPTION
Use the fact that `GetChildAtIndex` and `GetChildMemberWithName` always return `SBValue`, even if there is no children with requested index or name.

Validity of returned value can be checked by its method `IsValid`

