### PR TITLE
ci: Revert "ci: workaround to re-enable proper commit messages"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,6 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "fix"
-      include: "scope"
 
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
@@ -42,4 +41,3 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "ci"
-      include: "scope"


### PR DESCRIPTION
This reverts commit 0de2b502e4d40a96db531f12cf60a6c6e3dad2db.