### PR TITLE
cv::Mat regex also matches to templated cv::Mat_<T>

### DIFF
--- a/resources/oidscripts/oidtypes/opencv.py
+++ b/resources/oidscripts/oidtypes/opencv.py
@@ -72,7 +72,7 @@ class Mat(interface.TypeInspectorInterface):
         """
         # Check if symbol type is the expected buffer
         symbol_type = str(symbol.type)
-        type_regex = r'(const\s+)?cv::Mat(\s+?[*&])?$'
+        type_regex = r'(const\s+)?cv::Mat_?\s*(<[^>]+>)?(\s*[*&])?$'
         return re.match(type_regex, symbol_type) is not None
 
 class CvMat(interface.TypeInspectorInterface):


### PR DESCRIPTION
Adds possibility to also view e.g. cv::Mat_<uint8_t>