### PR TITLE
chore: const correctness

### DIFF
--- a/src/ui/main_window/main_window_initializer.cpp
+++ b/src/ui/main_window/main_window_initializer.cpp
@@ -191,7 +191,7 @@ void MainWindowInitializer::initialize_timers()
 void MainWindowInitializer::initialize_shortcuts()
 {
     // Qt parent-child ownership: parent deletes children automatically
-    auto* symbol_list_focus_shortcut =
+    const auto* symbol_list_focus_shortcut =
         new QShortcut(QKeySequence::fromString("Ctrl+K"), &deps_.main_window);
     QObject::connect(
         symbol_list_focus_shortcut,
@@ -199,7 +199,7 @@ void MainWindowInitializer::initialize_shortcuts()
         deps_.ui_components.ui->symbolList,
         [this]() { deps_.ui_components.ui->symbolList->setFocus(); });
 
-    auto* buffer_removal_shortcut = new QShortcut(
+    const auto* buffer_removal_shortcut = new QShortcut(
         QKeySequence{Qt::Key_Delete}, deps_.ui_components.ui->imageList);
     QObject::connect(
         buffer_removal_shortcut,
@@ -207,7 +207,7 @@ void MainWindowInitializer::initialize_shortcuts()
         &deps_.main_window,
         [this]() { deps_.event_handler.remove_selected_buffer(); });
 
-    auto* go_to_shortcut =
+    const auto* go_to_shortcut =
         new QShortcut(QKeySequence::fromString("Ctrl+L"), &deps_.main_window);
     QObject::connect(go_to_shortcut,
                      &QShortcut::activated,


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add const correctness to pointer variables in initialize_shortcuts()

- Three QShortcut pointers changed from auto* to const auto*


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["auto* pointers"] -- "const qualifier added" --> B["const auto* pointers"]
  B -- "applied to" --> C["symbol_list_focus_shortcut<br/>buffer_removal_shortcut<br/>go_to_shortcut"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main_window_initializer.cpp</strong><dd><code>Add const qualifier to shortcut pointers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ui/main_window/main_window_initializer.cpp

<ul><li>Changed three QShortcut pointer variables from <code>auto*</code> to <code>const auto*</code><br> <li> Affected variables: <code>symbol_list_focus_shortcut</code>, <br><code>buffer_removal_shortcut</code>, <code>go_to_shortcut</code><br> <li> Improves const correctness by marking pointers as non-modifiable</ul>


</details>


  </td>
  <td><a href="https://github.com/OpenImageDebugger/OpenImageDebugger/pull/814/files#diff-515c41186c4286e450e9329918cf15f4fec323097ac614017a8f004f6ec688d4">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

