### PR TITLE
feat: wire oidcompose window

### DIFF
--- a/resources/oidscripts/debuggers/lldbbridge.py
+++ b/resources/oidscripts/debuggers/lldbbridge.py
@@ -33,6 +33,7 @@ class LldbBridge(BridgeInterface):
         self._event_handler = None
         self._last_thread_id = 0
         self._last_frame_idx = 0
+        self._process_was_stopped = False
 
         # Store debugger from the main thread since it isn't available from an event loop.
         self._debugger = lldb.debugger
@@ -47,6 +48,16 @@ class LldbBridge(BridgeInterface):
 
     def get_backend_name(self):
         return 'lldb'
+
+    def _check_stop_transition(self):
+        process = self._get_process(self.get_lldb_backend())
+        is_stopped = process.is_stopped
+        # GDB fires stop on every halt; LLDB's stop-hook is not always installed.
+        # Detect running→stopped so repeat breakpoints at the same frame still refresh.
+        if is_stopped and not self._process_was_stopped:
+            with self._lock:
+                self._event_queue.append('stop')
+        self._process_was_stopped = is_stopped
 
     def _check_frame_modification(self):
         process = self._get_process(self.get_lldb_backend())
@@ -69,6 +80,7 @@ class LldbBridge(BridgeInterface):
 
     def event_loop(self):
         while True:
+            self._check_stop_transition()
             self._check_frame_modification()
 
             requests_to_process = []

--- a/resources/oidscripts/oidwindow.py
+++ b/resources/oidscripts/oidwindow.py
@@ -180,9 +180,13 @@ class OpenImageDebuggerWindow(object):
 
     def initialize_window(self):
         # Initialize OID lib
+        init_params = {'oid_path': self._script_path}
+        ui_binary = os.environ.get('OID_UI_BINARY')
+        if ui_binary:
+            init_params['ui_binary'] = ui_binary
         self._native_handler = self._lib.oid_initialize(
             self._plot_variable_c_callback,
-            {'oid_path': self._script_path})
+            init_params)
 
         # Launch UI
         self._lib.oid_exec(self._native_handler)

--- a/src/oidbridge/oid_bridge.cpp
+++ b/src/oidbridge/oid_bridge.cpp
@@ -104,7 +104,12 @@ class OidBridge {
             return false;
         }
 
-        const auto windowBinaryPath = this->oid_path_ + "/oidwindow";
+        // Honor a custom UI binary (OID_UI_BINARY, passed as the "ui_binary"
+        // init param) so an external window such as OidCompose can replace the
+        // bundled Qt oidwindow. The extra Qt args (-style fusion) are harmless to
+        // a non-Qt binary that ignores unknown flags.
+        const auto windowBinaryPath =
+            ui_binary_.empty() ? (this->oid_path_ + "/oidwindow") : ui_binary_;
         const auto portStdString = std::to_string(server_.serverPort());
 
         std::vector<std::string> command{
@@ -121,6 +126,10 @@ class OidBridge {
 
     void set_path(const std::string_view& oid_path) {
         oid_path_ = oid_path;
+    }
+
+    void set_ui_binary(const std::string_view& ui_binary) {
+        ui_binary_ = ui_binary;
     }
 
     [[nodiscard]] bool is_window_ready() const {
@@ -207,6 +216,7 @@ class OidBridge {
     QTcpServer server_{};
     QPointer<QTcpSocket> client_{}; // Qt-managed non-owning pointer
     std::string oid_path_{};
+    std::string ui_binary_{};
 
     std::function<int(const char*)> plot_callback_{};
 
@@ -324,6 +334,8 @@ oid_initialize_impl(std::function<int(const char*)> plot_callback,
      */
     const auto py_oid_path =
         PyDict_GetItemString(optional_parameters, "oid_path");
+    const auto py_ui_binary =
+        PyDict_GetItemString(optional_parameters, "ui_binary");
 
     auto app = std::make_unique<OidBridge>(std::move(plot_callback));
 
@@ -331,6 +343,12 @@ oid_initialize_impl(std::function<int(const char*)> plot_callback,
         auto oid_path_str = std::string{};
         oid::copy_py_string(oid_path_str, py_oid_path);
         app->set_path(oid_path_str);
+    }
+
+    if (py_ui_binary) {
+        auto ui_binary_str = std::string{};
+        oid::copy_py_string(ui_binary_str, py_ui_binary);
+        app->set_ui_binary(ui_binary_str);
     }
 
     return app;


### PR DESCRIPTION
Pass OID_UI_BINARY through to oid_initialize so an external window
(e.g. OidCompose) can replace the bundled UI.

Detect running->stopped transitions in the LLDB event loop and enqueue a
stop event, so repeated breakpoints at the same frame still trigger a
buffer refresh even when LLDB's stop-hook is not installed.