### PR TITLE
docs: add Qt 6.11 WASM + VS Code design spec

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
         name: Install Qt (Windows)
         uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730 # 4.3.1
         with:
-          version: "6.10.*"
+          version: "6.11.*"
           aqtversion: "==3.3.*"
           setup-python: false
           cache: true

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,61 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2015-2026 OpenImageDebugger contributors
+# (https://github.com/OpenImageDebugger/OpenImageDebugger)
+
+name: WASM Build
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  wasm:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install emsdk 4.0.7
+        run: |
+          git clone --depth 1 https://github.com/emscripten-core/emsdk.git /opt/emsdk
+          /opt/emsdk/emsdk install 4.0.7
+          /opt/emsdk/emsdk activate 4.0.7
+          echo "EMSDK=/opt/emsdk" >> "$GITHUB_ENV"
+          echo "/opt/emsdk" >> "$GITHUB_PATH"
+          echo "/opt/emsdk/upstream/emscripten" >> "$GITHUB_PATH"
+
+      - name: Install Qt 6.11 desktop (WASM host)
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: "6.11.0"
+          host: "linux"
+          target: "desktop"
+          arch: "linux_gcc_64"
+          cache: true
+
+      - name: Install Qt 6.11 WASM
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: "6.11.0"
+          host: "all_os"
+          target: "wasm"
+          arch: "wasm_singlethread"
+          cache: true
+
+      - name: Build WASM
+        env:
+          EMSDK: /opt/emsdk
+          QT_WASM_DIR: ${{ env.QT_ROOT_DIR }}/6.11.0/wasm_singlethread
+          QT_HOST_PATH: ${{ env.QT_ROOT_DIR }}/6.11.0/gcc_64
+        run: bash wasm/scripts/build-wasm.sh --reconfigure
+
+      - name: Pack artifact
+        run: bash wasm/scripts/pack-viewer-wasm.sh
+
+      - name: Upload dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: viewer-wasm
+          path: wasm/dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,12 @@
 # CMake build directory
 build/
+build-wasm/
 
 # Git worktrees
 .worktrees/
+
+# WASM npm pack output
+wasm/dist/
 
 # Visual Studio Code project settings
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # CMake build directory
 build/
 
+# Git worktrees
+.worktrees/
+
 # Visual Studio Code project settings
 .vscode/
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,11 +29,13 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/common.cmake)
 
 add_subdirectory(src)
 add_subdirectory(src/ipc)
-add_subdirectory(src/oidbridge)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  add_subdirectory(src/oidbridge)
+endif()
 
 # Add tests if enabled
 option(BUILD_TESTS "Build unit tests" ON)
-if(BUILD_TESTS)
+if(BUILD_TESTS AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     enable_testing()
     add_subdirectory(tests)
 endif()

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ customized to work with any arbitrary data structure.
 
 * A C++20 compliant compiler
 * GDB **15.0.50+** or LLDB **18.1.3+**
-* Qt **6.4.2+**
+* Qt **6.11+**
 * CMake **3.28.3+**
 * Python **3.12.3+** development packages
 * OpenGL **2.1+** support

--- a/cmake/EmscriptenWasm.cmake
+++ b/cmake/EmscriptenWasm.cmake
@@ -11,3 +11,14 @@ if(NOT Qt6_DIR)
 endif()
 
 add_compile_definitions(OID_TRANSPORT_POSTMESSAGE)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  set(OID_IPC_LIBRARY_TYPE STATIC CACHE INTERNAL "oidipc library type on Emscripten")
+  # Desktop -Werror is too strict for Emscripten/EM_JS glue.
+  add_compile_options(-Wno-error)
+endif()
+# oidipc is linked into oidwindow; static avoids shared-library overhead on WASM.
+set(OID_IPC_LIBRARY_TYPE SHARED)
+if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  set(OID_IPC_LIBRARY_TYPE STATIC)
+endif()

--- a/cmake/EmscriptenWasm.cmake
+++ b/cmake/EmscriptenWasm.cmake
@@ -12,11 +12,6 @@ endif()
 
 add_compile_definitions(OID_TRANSPORT_POSTMESSAGE)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
-  set(OID_IPC_LIBRARY_TYPE STATIC CACHE INTERNAL "oidipc library type on Emscripten")
-  # Desktop -Werror is too strict for Emscripten/EM_JS glue.
-  add_compile_options(-Wno-error)
-endif()
 # oidipc is linked into oidwindow; static avoids shared-library overhead on WASM.
 set(OID_IPC_LIBRARY_TYPE SHARED)
 if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")

--- a/cmake/EmscriptenWasm.cmake
+++ b/cmake/EmscriptenWasm.cmake
@@ -1,0 +1,13 @@
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  return()
+endif()
+
+if(NOT DEFINED ENV{EMSDK})
+  message(FATAL_ERROR "EMSDK not set. Run: source emsdk_env.sh")
+endif()
+
+if(NOT Qt6_DIR)
+  message(FATAL_ERROR "Set -DQt6_DIR=/path/to/qt6-wasm/lib/cmake/Qt6")
+endif()
+
+add_compile_definitions(OID_TRANSPORT_POSTMESSAGE)

--- a/common.cmake
+++ b/common.cmake
@@ -32,7 +32,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_EXTENSIONS False)
 
 find_package(Threads REQUIRED)
-find_package(Qt6 6.4.2 REQUIRED COMPONENTS Network)
+find_package(Qt6 6.11 REQUIRED COMPONENTS Network)
 
 add_compile_options("$<$<CXX_COMPILER_ID:AppleClang,Clang,GNU>:-Wall;-Wextra;-pedantic;-Werror>")
 add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/W4;/WX>")

--- a/docs/superpowers/plans/2026-06-23-oid-wasm-vscode.md
+++ b/docs/superpowers/plans/2026-06-23-oid-wasm-vscode.md
@@ -1,0 +1,769 @@
+# OID WASM + VS Code Extension — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver full OID parity in VS Code on macOS/Linux by publishing a Qt6 WASM `oidwindow` artifact from this repo and a separate CodeLLDB-based TypeScript extension that speaks OBP v1 over `postMessage`.
+
+**Architecture:** OID repo gains `ITransport` (TCP desktop / postMessage WASM), completes OBP v1 control messages, and builds `oidwindow` for Emscripten. A separate `openimagedebugger-vscode` repo hosts the DAP bridge, TypeBridge port, and webview loader consuming `@openimagedebugger/viewer-wasm`.
+
+**Tech stack:** C++20, Qt 6.4+ (desktop + WASM kit), Emscripten 3.x, Protobuf 3, CMake 3.28+, GTest; extension: TypeScript, VS Code Extension API, `@bufbuild/protobuf` or `protobufjs`, CodeLLDB DAP.
+
+**Design spec:** `docs/superpowers/specs/2026-06-23-oid-wasm-vscode-design.md`
+
+---
+
+## File map — OID repository (Part I)
+
+| File | Role |
+|------|------|
+| `docs/protocol/obp/v1/control.proto` | Add `PlotBufferRequest`; extend `Envelope` |
+| `src/ipc/transport.h` | `ITransport` interface |
+| `src/ipc/tcp_transport.h` / `.cpp` | `QTcpSocket` adapter (desktop) |
+| `src/ipc/postmessage_transport.h` / `.cpp` | Emscripten `EM_ASM` adapter (WASM) |
+| `src/ipc/obp_channel.h` / `.cpp` | Serialize/deserialize `oid.obp.v1.Envelope` over `ITransport` |
+| `src/ipc/message_exchange.h` / `.cpp` | Refactor to use `ITransport*` |
+| `src/ui/messaging/message_handler.h` / `.cpp` | Accept `ITransport&` in `Dependencies` |
+| `src/ui/main_window/main_window.h` | Replace `QTcpSocket socket_` with transport ownership |
+| `src/oid_window.cpp` | `__EMSCRIPTEN__` entry: no TCP connect, postMessage handshake |
+| `wasm/loader.html` | Qt WASM bootstrap + `window.oidSend` / `window.oidOnMessage` glue |
+| `wasm/package.json` | `@openimagedebugger/viewer-wasm` npm metadata |
+| `cmake/EmscriptenWasm.cmake` | Qt6 WASM toolchain helpers |
+| `src/CMakeLists.txt` | Conditional `oidwindow` WASM target |
+| `tests/test_transport.cpp` | `TcpTransport` round-trip tests |
+| `tests/test_obp_channel.cpp` | Envelope encode/decode tests |
+| `.github/workflows/wasm.yml` | Emscripten + Qt WASM CI build |
+
+## File map — extension repository (Part II, separate repo)
+
+| File | Role |
+|------|------|
+| `package.json` | Extension manifest, commands, `activationEvents` |
+| `src/extension.ts` | Activation, debug session tracking |
+| `src/debugger/codelldb-bridge.ts` | `BridgeInterface` port |
+| `src/debugger/dap-client.ts` | `evaluate`, `readMemory`, stop events |
+| `src/typebridge/opencv-mat.ts` | OpenCV `Mat` metadata extraction |
+| `src/obp/` | Generated TS from OID protos |
+| `src/webview/panel.ts` | `WebviewPanel` host + postMessage relay |
+| `src/session/session-manager.ts` | Stop handler, watched buffers |
+| `media/` | Copied WASM artifacts from npm package |
+
+---
+
+# Part I — OID repository (P0–P1)
+
+### Task 1: Add `PlotBufferRequest` to OBP v1
+
+**Files:**
+- Modify: `docs/protocol/obp/v1/control.proto`
+- Modify: `docs/protocol/obp/v1/conformance/README.md` (document new message)
+- Test: `tests/test_obp_conformance.cpp`
+
+- [ ] **Step 1: Add message and envelope field**
+
+```protobuf
+message PlotBufferRequest {
+  string variable_name = 1;
+}
+
+// Inside Envelope.oneof body, add:
+//   PlotBufferRequest plot_buffer_request = 18;
+```
+
+- [ ] **Step 2: Rebuild and run existing OBP tests**
+
+Run: `cmake -S . -B build -DBUILD_TESTS=ON && cmake --build build --target test_obp_conformance && ctest --test-dir build -R ObpConformance -V`
+
+Expected: PASS (no regression)
+
+- [ ] **Step 3: Add conformance case** — create `docs/protocol/obp/v1/conformance/cases/plot_buffer_request.pb` (binary fixture) and assert decode in `tests/test_obp_conformance.cpp`:
+
+```cpp
+TEST(ObpConformance, PlotBufferRequestRoundTrip) {
+  oid::obp::v1::Envelope env;
+  env.set_protocol_version("1");
+  env.mutable_plot_buffer_request()->set_variable_name("img");
+  std::string bytes;
+  ASSERT_TRUE(env.SerializeToString(&bytes));
+  oid::obp::v1::Envelope parsed;
+  ASSERT_TRUE(parsed.ParseFromString(bytes));
+  EXPECT_EQ(parsed.plot_buffer_request().variable_name(), "img");
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/protocol/obp/v1/control.proto docs/protocol/obp/v1/conformance/ tests/test_obp_conformance.cpp
+git commit -m "feat(obp): add PlotBufferRequest envelope message"
+```
+
+---
+
+### Task 2: Introduce `ITransport` interface
+
+**Files:**
+- Create: `src/ipc/transport.h`
+- Create: `src/ipc/tcp_transport.h`
+- Create: `src/ipc/tcp_transport.cpp`
+- Modify: `src/ipc/CMakeLists.txt`
+- Test: `tests/test_transport.cpp`
+- Modify: `tests/CMakeLists.txt`
+
+- [ ] **Step 1: Write failing transport test**
+
+```cpp
+// tests/test_transport.cpp
+#include <gtest/gtest.h>
+#include <QCoreApplication>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <thread>
+#include "ipc/tcp_transport.h"
+
+TEST(TcpTransport, SendsAndReceivesBytes) {
+  int argc = 0;
+  char* argv = nullptr;
+  QCoreApplication app(argc, argv);
+  QTcpServer server;
+  ASSERT_TRUE(server.listen(QHostAddress::LocalHost));
+  const auto port = server.serverPort();
+
+  std::vector<std::byte> received;
+  std::thread server_thread([&] {
+    if (!server.waitForNewConnection(5000)) return;
+    auto* sock = server.nextPendingConnection();
+    sock->waitForReadyRead(5000);
+    const auto data = sock->readAll();
+    received.assign(reinterpret_cast<const std::byte*>(data.constData()),
+                    reinterpret_cast<const std::byte*>(data.constData()) + data.size());
+    sock->write(data);
+    sock->waitForBytesWritten(5000);
+    sock->close();
+  });
+
+  QTcpSocket client;
+  client.connectToHost(QHostAddress::LocalHost, port);
+  ASSERT_TRUE(client.waitForConnected(5000));
+  oid::TcpTransport transport(client);
+
+  const std::vector<std::byte> payload{std::byte{0x01}, std::byte{0x02}};
+  transport.send(payload);
+  ASSERT_TRUE(client.waitForReadyRead(5000));
+  std::vector<std::byte> out;
+  ASSERT_TRUE(transport.receive(out));
+  EXPECT_EQ(out, payload);
+
+  server_thread.join();
+}
+```
+
+- [ ] **Step 2: Run test — expect link failure**
+
+Run: `cmake --build build --target test_transport 2>&1 | tail -5`
+
+Expected: undefined reference / file not found
+
+- [ ] **Step 3: Implement `transport.h` and `TcpTransport`**
+
+```cpp
+// src/ipc/transport.h
+#pragma once
+#include <cstddef>
+#include <span>
+#include <vector>
+
+namespace oid {
+
+class ITransport {
+ public:
+  virtual ~ITransport() = default;
+  virtual void send(std::span<const std::byte> data) = 0;
+  virtual bool receive(std::vector<std::byte>& out) = 0;
+};
+
+}  // namespace oid
+```
+
+```cpp
+// src/ipc/tcp_transport.h
+#pragma once
+#include "ipc/transport.h"
+class QTcpSocket;
+
+namespace oid {
+class TcpTransport final : public ITransport {
+ public:
+  explicit TcpTransport(QTcpSocket& socket);
+  void send(std::span<const std::byte> data) override;
+  bool receive(std::vector<std::byte>& out) override;
+ private:
+  QTcpSocket& socket_;
+};
+}  // namespace oid
+```
+
+`send` writes length-prefixed or raw bytes matching existing `MessageComposer` wire format (match current `MessageComposer::send(QTcpSocket*)` framing exactly — read `message_exchange.h:169` before implementing).
+
+- [ ] **Step 4: Wire into `src/ipc/CMakeLists.txt` and `tests/CMakeLists.txt`**
+
+- [ ] **Step 5: Run test — expect PASS**
+
+Run: `ctest --test-dir build -R TcpTransport -V`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "feat(ipc): add ITransport and TcpTransport"
+```
+
+---
+
+### Task 3: Refactor `MessageComposer` / `MessageDecoder` to use `ITransport`
+
+**Files:**
+- Modify: `src/ipc/message_exchange.h`
+- Modify: `src/ipc/message_exchange.cpp` (if split from header)
+- Test: `tests/test_message_exchange.cpp`
+
+- [ ] **Step 1: Add overloads without removing old API yet**
+
+```cpp
+void send(ITransport* transport) const;
+explicit MessageDecoder(ITransport* transport);
+```
+
+Keep `send(QTcpSocket*)` as inline wrapper:
+
+```cpp
+void send(QTcpSocket* socket) const {
+  TcpTransport transport(*socket);
+  send(&transport);
+}
+```
+
+- [ ] **Step 2: Run existing message exchange tests**
+
+Run: `ctest --test-dir build -R MessageExchange -V`
+
+Expected: PASS (no behavior change)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "refactor(ipc): MessageComposer accepts ITransport"
+```
+
+---
+
+### Task 4: Add `ObpChannel` for Envelope over transport
+
+**Files:**
+- Create: `src/ipc/obp_channel.h`
+- Create: `src/ipc/obp_channel.cpp`
+- Modify: `src/ipc/CMakeLists.txt`
+- Test: `tests/test_obp_channel.cpp`
+
+- [ ] **Step 1: Write failing test**
+
+```cpp
+TEST(ObpChannel, RoundTripPlotBufferRequest) {
+  // Use two TcpTransport ends over QTcpSocket pair (see test_transport pattern)
+  oid::obp::v1::Envelope env;
+  env.set_protocol_version("1");
+  env.set_sequence(1);
+  env.mutable_plot_buffer_request()->set_variable_name("frame");
+
+  oid::ObpChannel sender(transport_a);
+  oid::ObpChannel receiver(transport_b);
+  sender.send(env);
+
+  oid::obp::v1::Envelope got;
+  ASSERT_TRUE(receiver.receive(got));
+  EXPECT_EQ(got.plot_buffer_request().variable_name(), "frame");
+}
+```
+
+- [ ] **Step 2: Implement `ObpChannel`** — length-prefix `uint32_t` + serialized `Envelope` bytes; link `obp` proto lib.
+
+- [ ] **Step 3: Run test — expect PASS**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(ipc): add ObpChannel for OBP Envelope transport"
+```
+
+---
+
+### Task 5: Wire `MessageHandler` to OBP for control messages (WASM path)
+
+**Files:**
+- Modify: `src/ui/messaging/message_handler.h` — add `ITransport* obp_transport` to `Dependencies`
+- Modify: `src/ui/messaging/message_handler.cpp` — handle inbound `Envelope`:
+  - `symbol_list` → existing `decode_set_available_symbols` logic
+  - `plot_buffer` → call existing OBP decode path (`obp_decode.cpp`)
+  - `session_state` → restore watched buffers
+  - outbound `plot_buffer_request` → send `Envelope` instead of legacy `MessageType::PlotBufferRequest`
+- Modify: `src/ui/main_window/main_window.h` / `main_window_initializer.cpp`
+- Test: extend `tests/test_obp_conformance.cpp` or add integration test with mock transport
+
+- [ ] **Step 1: Add compile flag `OID_ENABLE_OBP_TRANSPORT` (default ON for WASM, optional on desktop)**
+
+- [ ] **Step 2: Implement inbound `Envelope` dispatch in `MessageHandler::process_messages`**
+
+- [ ] **Step 3: Desktop TCP path still works** — run full test suite:
+
+Run: `ctest --test-dir build -V`
+
+Expected: all existing tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(ui): route control messages through OBP Envelope"
+```
+
+---
+
+### Task 6: `PostMessageTransport` (Emscripten)
+
+**Files:**
+- Create: `src/ipc/postmessage_transport.h`
+- Create: `src/ipc/postmessage_transport.cpp`
+- Create: `wasm/oid_postmessage.js` — `window.oidSend = Module.cwrap(...)` glue
+- Modify: `wasm/loader.html`
+- Test: `tests/test_postmessage_transport.cpp` (host-only mock; skip on Emscripten)
+
+- [ ] **Step 1: Implement ring buffer + `EM_ASM` send/receive**
+
+```cpp
+#ifdef __EMSCRIPTEN__
+void PostMessageTransport::send(std::span<const std::byte> data) {
+  EM_ASM({
+    window.oidHostSend(HEAPU8.slice($0, $0 + $1));
+  }, data.data(), data.size());
+}
+#endif
+```
+
+- [ ] **Step 2: Host-side mock test** — inject bytes via test hook without browser
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat(ipc): add PostMessageTransport for WASM"
+```
+
+---
+
+### Task 7: Emscripten CMake toolchain + WASM `oidwindow` target
+
+**Files:**
+- Create: `cmake/EmscriptenWasm.cmake`
+- Create: `cmake/toolchains/emscripten-qt6.cmake` (document Qt WASM kit path via `Qt6_DIR`)
+- Modify: `src/CMakeLists.txt`
+- Modify: `src/oid_window.cpp`
+
+- [ ] **Step 1: Add option `OID_BUILD_WASM` (default OFF)**
+
+```cmake
+option(OID_BUILD_WASM "Build oidwindow for WebAssembly" OFF)
+if(OID_BUILD_WASM)
+  include(${CMAKE_SOURCE_DIR}/cmake/EmscriptenWasm.cmake)
+  add_subdirectory(wasm)
+endif()
+```
+
+- [ ] **Step 2: WASM-specific compile defs**
+
+```cmake
+target_compile_definitions(oidwindow PRIVATE OID_TRANSPORT_POSTMESSAGE)
+```
+
+- [ ] **Step 3: Modify `oid_window.cpp` for Emscripten**
+
+```cpp
+#ifdef __EMSCRIPTEN__
+  // No QCommandLineParser TCP connect
+  // Construct PostMessageTransport, pass to MainWindow
+  // EM_ASM({ window.parent.postMessage({type:'oid-ready'}, '*'); });
+#else
+  // existing TCP path
+#endif
+```
+
+- [ ] **Step 4: Document local build in `README.md` (WASM section)**
+
+```bash
+# Prerequisites: Qt 6.x WASM kit, emsdk 3.x
+source /path/to/emsdk/emsdk_env.sh
+cmake -S . -B build-wasm -DOID_BUILD_WASM=ON \
+  -DCMAKE_TOOLCHAIN_FILE=/path/to/emscripten.cmake \
+  -DQt6_DIR=/path/to/qt6-wasm/lib/cmake/Qt6
+cmake --build build-wasm --target oidwindow -j
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "build: add Emscripten WASM target for oidwindow"
+```
+
+---
+
+### Task 8: npm package `@openimagedebugger/viewer-wasm`
+
+**Files:**
+- Create: `wasm/package.json`
+- Create: `wasm/loader.html`
+- Create: `scripts/pack-viewer-wasm.sh`
+- Modify: `.github/workflows/wasm.yml`
+
+- [ ] **Step 1: `wasm/package.json`**
+
+```json
+{
+  "name": "@openimagedebugger/viewer-wasm",
+  "version": "0.0.0-dev",
+  "description": "Qt6 WASM build of oidwindow for VS Code",
+  "files": ["dist/"],
+  "oid": {
+    "protocol_version": "1",
+    "min_extension_version": "0.1.0"
+  }
+}
+```
+
+- [ ] **Step 2: `pack-viewer-wasm.sh`** copies `build-wasm/oidwindow.{wasm,js}`, Qt runtime, `loader.html` → `wasm/dist/`
+
+- [ ] **Step 3: CI workflow** — Ubuntu job installs emsdk + Qt WASM, builds, runs `npm pack` artifact upload
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "ci: package viewer-wasm npm artifact"
+```
+
+---
+
+### Task 9: WASM smoke test (headless)
+
+**Files:**
+- Create: `wasm/smoke/playwright.config.ts`
+- Create: `wasm/smoke/render.spec.ts`
+- Modify: `.github/workflows/wasm.yml`
+
+- [ ] **Step 1: Playwright test loads `loader.html`, posts sample `PlotBuffer` fixture from `docs/protocol/obp/v1/conformance/cases/`**
+
+```typescript
+test('wasm viewer accepts PlotBuffer', async ({ page }) => {
+  await page.goto('http://localhost:8765/loader.html');
+  await page.waitForFunction(() => (window as any).oidViewerReady === true);
+  const fixture = fs.readFileSync('cases/sample_uint8_4x4.pb');
+  await page.evaluate((bytes) => {
+    window.oidHostSend(new Uint8Array(bytes));
+  }, fixture);
+  await expect(page.locator('#qtcanvas')).toBeVisible();
+});
+```
+
+- [ ] **Step 2: Wire into CI after WASM build**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "test(wasm): add Playwright smoke test for PlotBuffer render"
+```
+
+---
+
+# Part II — Extension repository (P2–P6)
+
+> Implement in **`openimagedebugger-vscode`** (new repo). Pin `@openimagedebugger/viewer-wasm` to OID release tags.
+
+### Task 10: Scaffold extension repo
+
+**Files:**
+- Create: `openimagedebugger-vscode/package.json`
+- Create: `openimagedebugger-vscode/tsconfig.json`
+- Create: `openimagedebugger-vscode/src/extension.ts`
+- Create: `openimagedebugger-vscode/.vscode/launch.json`
+
+- [ ] **Step 1: `package.json` manifest**
+
+```json
+{
+  "name": "openimagedebugger",
+  "displayName": "Open Image Debugger",
+  "version": "0.1.0",
+  "engines": { "vscode": "^1.85.0" },
+  "activationEvents": ["onDebug"],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      { "command": "oid.openPanel", "title": "Open Image Debugger" },
+      { "command": "oid.plot", "title": "Plot Image Buffer" }
+    ]
+  },
+  "dependencies": {
+    "@openimagedebugger/viewer-wasm": "1.0.0"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.85.0",
+    "typescript": "^5.4.0",
+    "@vscode/test-electron": "^2.3.0"
+  }
+}
+```
+
+- [ ] **Step 2: Minimal `extension.ts` activates and registers `oid.openPanel`**
+
+- [ ] **Step 3: Verify F5 launch opens Extension Development Host**
+
+- [ ] **Step 4: Commit in extension repo**
+
+```bash
+git commit -m "chore: scaffold openimagedebugger-vscode extension"
+```
+
+---
+
+### Task 11: OBP TypeScript codegen
+
+**Files:**
+- Create: `openimagedebugger-vscode/buf.gen.yaml` or `scripts/gen-obp.sh`
+- Create: `openimagedebugger-vscode/src/obp/envelope.ts` (generated)
+- Create: `openimagedebugger-vscode/src/obp/codec.ts`
+
+- [ ] **Step 1: Vendor protos from OID** — git submodule `proto/` → `docs/protocol/obp/v1/*.proto`
+
+- [ ] **Step 2: Generate TS with `@bufbuild/protobuf`**
+
+```typescript
+// src/obp/codec.ts
+export interface OidMessage {
+  type: 'obp';
+  sequence: number;
+  payload: Uint8Array;
+}
+
+export function encodeEnvelope(env: Envelope): OidMessage {
+  return { type: 'obp', sequence: Number(env.sequence), payload: env.toBinary() };
+}
+```
+
+- [ ] **Step 3: Unit test round-trip `PlotBufferRequest`**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(obp): add TypeScript protobuf codec"
+```
+
+---
+
+### Task 12: Webview panel + WASM loader
+
+**Files:**
+- Create: `openimagedebugger-vscode/src/webview/panel.ts`
+- Create: `openimagedebugger-vscode/src/webview/loader.html` (from npm package template)
+- Modify: `openimagedebugger-vscode/src/extension.ts`
+
+- [ ] **Step 1: `OidWebviewPanel.create()`** — `retainContextWhenHidden: true`, copy wasm assets to `media/`
+
+- [ ] **Step 2: postMessage relay**
+
+```typescript
+panel.webview.onDidReceiveMessage((msg: OidMessage) => {
+  if (msg.type === 'oid-ready') sessionManager.onViewerReady();
+  else if (msg.type === 'obp') sessionManager.handleEnvelope(decodeEnvelope(msg));
+});
+```
+
+- [ ] **Step 3: Manual test** — command opens panel, WASM loads, console shows `oid-ready`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(webview): load viewer-wasm in WebviewPanel"
+```
+
+---
+
+### Task 13: CodeLLDB DAP bridge
+
+**Files:**
+- Create: `openimagedebugger-vscode/src/debugger/dap-client.ts`
+- Create: `openimagedebugger-vscode/src/debugger/codelldb-bridge.ts`
+- Test: `openimagedebugger-vscode/test/fixtures/evaluate-mat.json`
+- Test: `openimagedebugger-vscode/test/codelldb-bridge.test.ts`
+
+- [ ] **Step 1: Write failing test with fixture**
+
+```typescript
+test('getBufferMetadata parses cv::Mat evaluate result', async () => {
+  const bridge = new CodeLldbBridge(mockDapClient(fixtures.matEvaluate));
+  const meta = await bridge.getBufferMetadata('img');
+  expect(meta.width).toBe(640);
+  expect(meta.height).toBe(480);
+  expect(meta.channels).toBe(3);
+});
+```
+
+- [ ] **Step 2: Implement `evaluate` + `readMemory` in `dap-client.ts`**
+
+Port logic from `resources/oidscripts/debuggers/lldbbridge.py` `get_buffer_metadata`.
+
+- [ ] **Step 3: Implement `queueRequest` as microtask queue on extension host**
+
+- [ ] **Step 4: Run test — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(debugger): add CodeLLDB DAP bridge"
+```
+
+---
+
+### Task 14: OpenCV Mat TypeBridge + PlotBuffer serializer
+
+**Files:**
+- Create: `openimagedebugger-vscode/src/typebridge/opencv-mat.ts`
+- Create: `openimagedebugger-vscode/src/obp/plot-buffer.ts`
+- Port from: `resources/oidscripts/obp/wire_encode.py`, `resources/oidscripts/types/mat.py`
+
+- [ ] **Step 1: Port tile splitter** — reuse test vectors from `tests/test_obp_tile_splitter.py`
+
+```typescript
+export function encodePlotBuffer(metadata: BufferMetadata, maxTextureSize = 8192): Uint8Array {
+  // mirror Python encode_plot_buffer
+}
+```
+
+- [ ] **Step 2: Unit test against `docs/protocol/obp/v1/conformance/cases/sample_uint8_4x4.pb`**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat(typebridge): OpenCV Mat to OBP PlotBuffer"
+```
+
+---
+
+### Task 15: Session manager — stop handler + auto-update (P2/P3)
+
+**Files:**
+- Create: `openimagedebugger-vscode/src/session/session-manager.ts`
+- Create: `openimagedebugger-vscode/src/session/persistence.ts`
+- Modify: `openimagedebugger-vscode/src/extension.ts`
+
+- [ ] **Step 1: Register `vscode.debug.onDidReceiveDebugSessionCustomEvent` or `DebugAdapterTracker` for `stopped`**
+
+- [ ] **Step 2: Port `OpenImageDebuggerEvents.stop_handler`**
+
+```typescript
+async onStopped(session: vscode.DebugSession) {
+  await this.ensurePanelReady();
+  const symbols = await this.bridge.getAvailableSymbols();
+  this.webview.postEnvelope(symbolListUpdate(symbols));
+  for (const name of this.watchedBuffers) {
+    const meta = await this.bridge.getBufferMetadata(name);
+    this.webview.postEnvelope(plotBuffer(encodePlotBuffer(meta)));
+  }
+}
+```
+
+- [ ] **Step 3: Handle inbound `plot_buffer_request` from WASM**
+
+- [ ] **Step 4: Integration test** — debug `testbench` binary, hit breakpoint, assert webview received `PlotBuffer`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(session): auto-update buffers on breakpoint"
+```
+
+---
+
+### Task 16: UI parity features (P4)
+
+**Files:**
+- WASM/OBP only — no extension changes for zoom/pan (already in `oidwindow`)
+- Modify: `openimagedebugger-vscode/src/session/session-manager.ts` — handle `session_state` sync
+- Modify: `src/ui/messaging/message_handler.cpp` (OID) — emit `session_state` on UI changes
+
+- [ ] **Step 1: Bidirectional `SessionState` sync** (contrast, rotation, link-views, watched list)
+
+- [ ] **Step 2: Manual test checklist** — zoom, pan, go-to, pixel values, link views, rotate, auto-contrast
+
+- [ ] **Step 3: Commit (both repos as needed)**
+
+---
+
+### Task 17: Export + persistence (P5)
+
+**Files:**
+- Modify: `openimagedebugger-vscode/src/session/session-manager.ts`
+- OID: ensure `ExportRequest` / `ExportResult` wired in `message_handler.cpp`
+
+- [ ] **Step 1: WASM sends `ExportRequest`; extension shows `showSaveDialog` and writes PNG**
+
+- [ ] **Step 2: Persist `SessionState` to `context.globalState`**
+
+- [ ] **Step 3: Port Eigen + custom types** — `src/typebridge/eigen-matrix.ts`, workspace `oid.customTypes` config
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat: export buffers and persist session state"
+```
+
+---
+
+### Task 18: Ship (P6)
+
+**Files:**
+- Create: `openimagedebugger-vscode/README.md`
+- Modify: `.github/workflows/release.yml` (extension repo)
+- Modify: OID `README.md` — link to extension
+
+- [ ] **Step 1: `vsce package` produces `.vsix`**
+
+- [ ] **Step 2: Manual test matrix** — macOS + Linux, CodeLLDB, OpenCV Mat
+
+- [ ] **Step 3: Publish extension to VS Code Marketplace**
+
+- [ ] **Step 4: Tag OID release + npm `@openimagedebugger/viewer-wasm`**
+
+---
+
+## Verify commands (OID repo)
+
+```bash
+cmake -S . -B build -DBUILD_TESTS=ON -G Ninja
+cmake --build build -j
+ctest --test-dir build -V
+# WASM (when toolchain available):
+cmake -S . -B build-wasm -DOID_BUILD_WASM=ON -DCMAKE_TOOLCHAIN_FILE=$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake
+cmake --build build-wasm --target oidwindow -j
+```
+
+## Verify commands (extension repo)
+
+```bash
+npm install
+npm test
+npm run compile
+# F5 in VS Code → Extension Development Host
+# launch.json debugs testbench with CodeLLDB
+```
+
+---
+
+## Plan self-review
+
+- **Spec coverage:** P0 → Tasks 1–6; P1 → Tasks 7–9; P2 → Tasks 10–15; P3 → Task 15; P4 → Task 16; P5 → Task 17; P6 → Task 18. All spec sections mapped.
+- **Placeholder scan:** No TBD steps; each task names concrete files and commands.
+- **Type consistency:** `OidMessage`, `Envelope`, `ITransport`, `ObpChannel` used consistently across OID and extension tasks.
+- **Scope:** Part I delivers testable WASM artifact; Part II delivers working extension against that artifact.

--- a/docs/superpowers/plans/2026-06-24-oid-vscode-p2-codelldb.md
+++ b/docs/superpowers/plans/2026-06-24-oid-vscode-p2-codelldb.md
@@ -1,0 +1,1030 @@
+# OID VS Code P2: CodeLLDB → WASM viewer bridge — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Plot a live OpenCV `cv::Mat` from a CodeLLDB debug session into the existing WASM viewer, replacing the hardcoded smoke-test buffer with a real CodeLLDB → metadata → pixels → IPC pipeline.
+
+**Architecture:** Pure functions decode `cv::Mat` flags into buffer metadata; a thin DAP client issues `evaluate`/`readMemory`; a bridge orchestrates one plot; a session manager runs the watch list on `stopped`; a viewer controller forwards the existing legacy `PlotBufferContents` binary frame to the webview. Extension-only — no OID C++/WASM repo changes.
+
+**Tech Stack:** TypeScript 5.4, VS Code Extension API (Debug `customRequest`), Node 16 module resolution, `node:test` + `node:assert`.
+
+**Design spec:** `docs/superpowers/specs/2026-06-24-oid-vscode-p2-codelldb-design.md`
+
+## Global Constraints
+
+- **Repo:** all paths and `git` commands run in `openimagedebugger-vscode/` (sibling of the OID repo). Paths below are relative to that repo root.
+- **Module system:** `module: Node16` — every relative import MUST carry a `.js` extension (e.g. `from '../ipc/message-exchange.js'`), even in `.ts` source.
+- **Tests:** `node:test` + `node:assert/strict` only. Run via `npm run compile && npm test` (`tsc -p .` then `node --test out/test/*.js`). No extra test deps.
+- **Wire format:** legacy binary `PlotBufferContents` via the existing `buildPlotBufferContents(params, 'wasm32')`. Do not introduce OBP/protobuf.
+- **Debug type:** CodeLLDB registers as debug type `lldb`.
+- **OID buffer-type values** (mirror OpenCV depth codes): `UINT8=0, UINT16=2, INT16=3, INT32=4, FLOAT32=5, FLOAT64=6`.
+- **`transpose` is always `false`** in P2.
+
+---
+
+## File map
+
+| File | Role |
+|------|------|
+| `src/typebridge/buffer-metadata.ts` | `bytesPerChannel(typeValue)` helper; OID type constants |
+| `src/typebridge/opencv-mat.ts` | Pure `decodeMat(fields) → MatMetadata` (flags decode) |
+| `src/debugger/dap-client.ts` | `IDapClient` + `DapClient` over a debug session; `parseIntResult` |
+| `src/debugger/codelldb-bridge.ts` | `CodeLldbBridge.getBufferMetadata(variable, frameId) → PlotBufferParams` |
+| `src/session/session-manager.ts` | `SessionManager` — watch loop + `plotVariable` (injected deps) |
+| `src/webview/panel.ts` | `ViewerController` (singleton panel, `sendPlotBuffer`, smoke-test off by default) |
+| `src/extension.ts` | Commands `oid.plot`/`oid.openPanel`, `lldb` tracker, `oid.watchOnStop` |
+| `package.json` | Manifest: commands, `onDebug`, `oid.watchOnStop` config |
+
+---
+
+### Task 1: Buffer-type size helper
+
+**Files:**
+- Create: `src/typebridge/buffer-metadata.ts`
+- Test: `test/buffer-metadata.test.ts`
+
+**Interfaces:**
+- Produces: `enum OidBufferType`; `function bytesPerChannel(typeValue: number): number`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// test/buffer-metadata.test.ts
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { OidBufferType, bytesPerChannel } from '../src/typebridge/buffer-metadata.js';
+
+test('bytesPerChannel maps OID buffer types to byte widths', () => {
+  assert.equal(bytesPerChannel(OidBufferType.Uint8), 1);
+  assert.equal(bytesPerChannel(OidBufferType.Uint16), 2);
+  assert.equal(bytesPerChannel(OidBufferType.Int16), 2);
+  assert.equal(bytesPerChannel(OidBufferType.Int32), 4);
+  assert.equal(bytesPerChannel(OidBufferType.Float32), 4);
+  assert.equal(bytesPerChannel(OidBufferType.Float64), 8);
+});
+
+test('bytesPerChannel defaults unknown depth codes to 1 byte', () => {
+  assert.equal(bytesPerChannel(1), 1); // CV_8S — unsupported, treated as 1 byte
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run compile`
+Expected: FAIL — `Cannot find module '../src/typebridge/buffer-metadata.js'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// src/typebridge/buffer-metadata.ts
+
+/** OID buffer type values, mirroring OpenCV depth codes (CV_8U=0 ... CV_64F=6). */
+export enum OidBufferType {
+  Uint8 = 0,
+  Uint16 = 2,
+  Int16 = 3,
+  Int32 = 4,
+  Float32 = 5,
+  Float64 = 6,
+}
+
+/** Bytes per channel for an OpenCV depth code (flags & 7). Unknown codes → 1. */
+export function bytesPerChannel(typeValue: number): number {
+  switch (typeValue) {
+    case OidBufferType.Uint16:
+    case OidBufferType.Int16:
+      return 2;
+    case OidBufferType.Int32:
+    case OidBufferType.Float32:
+      return 4;
+    case OidBufferType.Float64:
+      return 8;
+    default:
+      return 1;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run compile && npm test`
+Expected: PASS (this file's tests + existing `message-exchange.test.ts`)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/typebridge/buffer-metadata.ts test/buffer-metadata.test.ts
+git commit -m "feat(typebridge): add OID buffer-type size helper"
+```
+
+---
+
+### Task 2: OpenCV Mat flags decode
+
+**Files:**
+- Create: `src/typebridge/opencv-mat.ts`
+- Test: `test/opencv-mat.test.ts`
+
+**Interfaces:**
+- Consumes: `bytesPerChannel` from `buffer-metadata.js`
+- Produces:
+  - `interface MatFields { flags: number; cols: number; rows: number; step0: number }`
+  - `interface MatMetadata { width: number; height: number; channels: number; bufferType: number; stride: number; pixelLayout: 'bgra' | 'rgba'; byteCount: number }`
+  - `function decodeMat(f: MatFields): MatMetadata`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// test/opencv-mat.test.ts
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { decodeMat } from '../src/typebridge/opencv-mat.js';
+
+const MAGIC = 0x42ff0000; // Mat::MAGIC_VAL high bits; ignored by the decode masks
+
+test('decodeMat handles CV_8UC3 (BGR, 1 byte/channel)', () => {
+  const m = decodeMat({ flags: MAGIC | 16, cols: 4, rows: 2, step0: 12 });
+  assert.equal(m.channels, 3);
+  assert.equal(m.bufferType, 0);            // uint8
+  assert.equal(m.width, 4);
+  assert.equal(m.height, 2);
+  assert.equal(m.stride, 4);                // 12 / 3 / 1
+  assert.equal(m.pixelLayout, 'bgra');
+  assert.equal(m.byteCount, 24);            // rows * step0
+});
+
+test('decodeMat handles CV_8UC1 (grayscale)', () => {
+  const m = decodeMat({ flags: MAGIC | 0, cols: 5, rows: 3, step0: 5 });
+  assert.equal(m.channels, 1);
+  assert.equal(m.bufferType, 0);
+  assert.equal(m.stride, 5);
+  assert.equal(m.pixelLayout, 'rgba');
+});
+
+test('decodeMat handles CV_32FC1 (float, 4 bytes/channel)', () => {
+  const m = decodeMat({ flags: MAGIC | 5, cols: 4, rows: 2, step0: 16 });
+  assert.equal(m.channels, 1);
+  assert.equal(m.bufferType, 5);            // float32
+  assert.equal(m.stride, 4);                // 16 / 1 / 4
+  assert.equal(m.byteCount, 32);
+});
+
+test('decodeMat handles CV_16UC1 (2 bytes/channel)', () => {
+  const m = decodeMat({ flags: MAGIC | 2, cols: 3, rows: 1, step0: 6 });
+  assert.equal(m.bufferType, 2);            // uint16
+  assert.equal(m.stride, 3);                // 6 / 1 / 2
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run compile`
+Expected: FAIL — `Cannot find module '../src/typebridge/opencv-mat.js'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// src/typebridge/opencv-mat.ts
+import { bytesPerChannel } from './buffer-metadata.js';
+
+const CV_CN_SHIFT = 3;
+const CV_CN_MAX = 512;
+const CV_MAT_CN_MASK = (CV_CN_MAX - 1) << CV_CN_SHIFT;
+const CV_DEPTH_MAX = 1 << CV_CN_SHIFT;
+const CV_MAT_TYPE_MASK = CV_DEPTH_MAX * CV_CN_MAX - 1;
+
+export interface MatFields {
+  flags: number;
+  cols: number;
+  rows: number;
+  step0: number; // step.buf[0]: row stride in bytes
+}
+
+export interface MatMetadata {
+  width: number;
+  height: number;
+  channels: number;
+  bufferType: number; // flags & 7 (OpenCV depth code)
+  stride: number;     // row stride in elements
+  pixelLayout: 'bgra' | 'rgba';
+  byteCount: number;  // rows * step0
+}
+
+/** Port of resources/oidscripts/oidtypes/opencv.py Mat.get_buffer_metadata. */
+export function decodeMat(f: MatFields): MatMetadata {
+  const channels = ((f.flags & CV_MAT_CN_MASK) >> CV_CN_SHIFT) + 1;
+  const bufferType = (f.flags & CV_MAT_TYPE_MASK) & 7;
+  const stride = Math.floor(
+    Math.floor(f.step0 / channels) / bytesPerChannel(bufferType)
+  );
+  return {
+    width: f.cols,
+    height: f.rows,
+    channels,
+    bufferType,
+    stride,
+    pixelLayout: channels >= 3 ? 'bgra' : 'rgba',
+    byteCount: f.rows * f.step0,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run compile && npm test`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/typebridge/opencv-mat.ts test/opencv-mat.test.ts
+git commit -m "feat(typebridge): decode cv::Mat flags into buffer metadata"
+```
+
+---
+
+### Task 3: DAP client
+
+**Files:**
+- Create: `src/debugger/dap-client.ts`
+- Test: `test/dap-client.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `interface DapSession { customRequest(command: string, args?: unknown): Promise<any> }`
+  - `interface EvaluateResult { result: string; memoryReference?: string; variablesReference: number; type?: string }`
+  - `interface IDapClient { evaluate(expression: string, frameId: number): Promise<EvaluateResult>; readMemory(memoryReference: string, count: number): Promise<Uint8Array>; topFrameId(threadId: number): Promise<number> }`
+  - `class DapClient implements IDapClient` (constructor `(session: DapSession)`)
+  - `function parseIntResult(result: string): number`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// test/dap-client.test.ts
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { DapClient, parseIntResult } from '../src/debugger/dap-client.js';
+
+test('parseIntResult parses decimal and hex CodeLLDB results', () => {
+  assert.equal(parseIntResult('640'), 640);
+  assert.equal(parseIntResult(' 0x10 '), 16);
+  assert.equal(parseIntResult('0X42ff0003'), 0x42ff0003);
+});
+
+test('readMemory decodes base64 DAP payloads to bytes', async () => {
+  const session = {
+    async customRequest(command: string, args: any) {
+      assert.equal(command, 'readMemory');
+      assert.equal(args.memoryReference, '0x1000');
+      assert.equal(args.count, 3);
+      return { address: '0x1000', data: Buffer.from([1, 2, 3]).toString('base64') };
+    },
+  };
+  const bytes = await new DapClient(session).readMemory('0x1000', 3);
+  assert.deepEqual([...bytes], [1, 2, 3]);
+});
+
+test('topFrameId returns the first stack frame id', async () => {
+  const session = {
+    async customRequest(command: string, args: any) {
+      assert.equal(command, 'stackTrace');
+      assert.equal(args.threadId, 7);
+      return { stackFrames: [{ id: 42 }, { id: 43 }] };
+    },
+  };
+  assert.equal(await new DapClient(session).topFrameId(7), 42);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run compile`
+Expected: FAIL — `Cannot find module '../src/debugger/dap-client.js'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// src/debugger/dap-client.ts
+
+export interface DapSession {
+  customRequest(command: string, args?: unknown): Promise<any>;
+}
+
+export interface EvaluateResult {
+  result: string;
+  memoryReference?: string;
+  variablesReference: number;
+  type?: string;
+}
+
+export interface IDapClient {
+  evaluate(expression: string, frameId: number): Promise<EvaluateResult>;
+  readMemory(memoryReference: string, count: number): Promise<Uint8Array>;
+  topFrameId(threadId: number): Promise<number>;
+}
+
+/** Parse a CodeLLDB scalar `evaluate` result string (decimal or 0x-hex) to a number. */
+export function parseIntResult(result: string): number {
+  const s = result.trim();
+  return /^0x/i.test(s) ? parseInt(s, 16) : parseInt(s, 10);
+}
+
+export class DapClient implements IDapClient {
+  constructor(private readonly session: DapSession) {}
+
+  evaluate(expression: string, frameId: number): Promise<EvaluateResult> {
+    return this.session.customRequest('evaluate', {
+      expression,
+      frameId,
+      context: 'watch',
+    });
+  }
+
+  async readMemory(memoryReference: string, count: number): Promise<Uint8Array> {
+    if (count <= 0) return new Uint8Array(0);
+    const res = await this.session.customRequest('readMemory', {
+      memoryReference,
+      count,
+    });
+    if (!res?.data) return new Uint8Array(0);
+    return new Uint8Array(Buffer.from(res.data, 'base64'));
+  }
+
+  async topFrameId(threadId: number): Promise<number> {
+    const res = await this.session.customRequest('stackTrace', {
+      threadId,
+      startFrame: 0,
+      levels: 1,
+    });
+    return res.stackFrames[0].id;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run compile && npm test`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/debugger/dap-client.ts test/dap-client.test.ts
+git commit -m "feat(debugger): add CodeLLDB DAP client wrappers"
+```
+
+---
+
+### Task 4: CodeLLDB bridge
+
+**Files:**
+- Create: `src/debugger/codelldb-bridge.ts`
+- Test: `test/codelldb-bridge.test.ts`
+- Test fixture: `test/fixtures/cv-mat-variables.json`
+
+**Interfaces:**
+- Consumes: `IDapClient`, `EvaluateResult`, `parseIntResult` from `dap-client.js`; `decodeMat` from `opencv-mat.js`; `PlotBufferParams` from `ipc/message-exchange.js`
+- Produces: `class CodeLldbBridge` (constructor `(dap: IDapClient)`) with `getBufferMetadata(variable: string, frameId: number): Promise<PlotBufferParams>`
+
+- [ ] **Step 1: Create the fixture** — `0x42FF0010 = 1124007952` is a CV_8UC3 Mat (magic high bits + type bits `16` → channels 3, depth 0).
+
+```json
+// test/fixtures/cv-mat-variables.json
+{
+  "TestField.flags": "1124007952",
+  "TestField.cols": "4",
+  "TestField.rows": "2",
+  "TestField.step.buf[0]": "12",
+  "TestField.data": "0x1000",
+  "memory": {
+    "0x1000": [
+      255, 0, 0, 0, 255, 0, 0, 0, 255, 10, 20, 30,
+      40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150
+    ]
+  }
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```typescript
+// test/codelldb-bridge.test.ts
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { CodeLldbBridge } from '../src/debugger/codelldb-bridge.js';
+import type { IDapClient, EvaluateResult } from '../src/debugger/dap-client.js';
+
+const fixture = JSON.parse(
+  readFileSync(fileURLToPath(new URL('./fixtures/cv-mat-variables.json', import.meta.url)), 'utf8')
+);
+
+function fakeDap(): IDapClient {
+  return {
+    async evaluate(expression: string): Promise<EvaluateResult> {
+      const value = fixture[expression];
+      if (value === undefined) throw new Error(`no fixture for ${expression}`);
+      const result: EvaluateResult = { result: value, variablesReference: 0 };
+      if (expression.endsWith('.data')) result.memoryReference = value;
+      return result;
+    },
+    async readMemory(memoryReference: string, count: number): Promise<Uint8Array> {
+      return new Uint8Array((fixture.memory[memoryReference] as number[]).slice(0, count));
+    },
+    async topFrameId(): Promise<number> {
+      return 0;
+    },
+  };
+}
+
+test('getBufferMetadata assembles PlotBufferParams from a cv::Mat', async () => {
+  const bridge = new CodeLldbBridge(fakeDap());
+  const params = await bridge.getBufferMetadata('TestField', 0);
+  assert.equal(params.variableName, 'TestField');
+  assert.equal(params.width, 4);
+  assert.equal(params.height, 2);
+  assert.equal(params.channels, 3);
+  assert.equal(params.bufferType, 0);
+  assert.equal(params.stride, 4);
+  assert.equal(params.pixelLayout, 'bgra');
+  assert.equal(params.transpose, false);
+  assert.equal(params.pixels.length, 24); // rows(2) * step0(12)
+  assert.equal(params.pixels[0], 255);
+});
+
+test('getBufferMetadata throws when the data pointer is unresolved', async () => {
+  const dap = fakeDap();
+  dap.evaluate = async (expr: string): Promise<EvaluateResult> =>
+    expr.endsWith('.data')
+      ? { result: '0x0', variablesReference: 0 } // no memoryReference
+      : { result: fixture[expr], variablesReference: 0 };
+  const bridge = new CodeLldbBridge(dap);
+  await assert.rejects(bridge.getBufferMetadata('TestField', 0), /data pointer/);
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npm run compile`
+Expected: FAIL — `Cannot find module '../src/debugger/codelldb-bridge.js'`
+
+- [ ] **Step 4: Write minimal implementation**
+
+```typescript
+// src/debugger/codelldb-bridge.ts
+import { decodeMat } from '../typebridge/opencv-mat.js';
+import { parseIntResult, type IDapClient } from './dap-client.js';
+import type { PlotBufferParams } from '../ipc/message-exchange.js';
+
+export class CodeLldbBridge {
+  constructor(private readonly dap: IDapClient) {}
+
+  async getBufferMetadata(variable: string, frameId: number): Promise<PlotBufferParams> {
+    const field = async (expr: string): Promise<number> =>
+      parseIntResult((await this.dap.evaluate(`${variable}.${expr}`, frameId)).result);
+
+    const flags = await field('flags');
+    const cols = await field('cols');
+    const rows = await field('rows');
+    const step0 = await field('step.buf[0]');
+
+    const dataEval = await this.dap.evaluate(`${variable}.data`, frameId);
+    if (!dataEval.memoryReference) {
+      throw new Error(`Cannot resolve data pointer for '${variable}'`);
+    }
+
+    const meta = decodeMat({ flags, cols, rows, step0 });
+    const pixels = await this.dap.readMemory(dataEval.memoryReference, meta.byteCount);
+
+    return {
+      variableName: variable,
+      displayName: variable,
+      pixelLayout: meta.pixelLayout,
+      transpose: false,
+      width: meta.width,
+      height: meta.height,
+      channels: meta.channels,
+      stride: meta.stride,
+      bufferType: meta.bufferType,
+      pixels,
+    };
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm run compile && npm test`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/debugger/codelldb-bridge.ts test/codelldb-bridge.test.ts test/fixtures/cv-mat-variables.json
+git commit -m "feat(debugger): assemble PlotBufferParams from a cv::Mat over DAP"
+```
+
+---
+
+### Task 5: Session manager (watch loop)
+
+**Files:**
+- Create: `src/session/session-manager.ts`
+- Test: `test/session-manager.test.ts`
+
+**Interfaces:**
+- Consumes: `PlotBufferParams` from `ipc/message-exchange.js`
+- Produces:
+  - `interface MetadataSource { getBufferMetadata(variable: string, frameId: number): Promise<PlotBufferParams> }`
+  - `interface PlotSink { ensureReady(): Promise<void>; sendPlotBuffer(bytes: Uint8Array): void | Promise<void> }`
+  - `interface SessionDeps { source: MetadataSource; sink: PlotSink; encode: (p: PlotBufferParams) => Uint8Array; resolveFrame: (threadId: number) => Promise<number>; getWatchList: () => string[]; warn: (message: string) => void }`
+  - `class SessionManager` with `plotVariable(name: string, threadId: number): Promise<void>` and `onStopped(threadId: number): Promise<void>`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// test/session-manager.test.ts
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { SessionManager, type SessionDeps } from '../src/session/session-manager.js';
+import type { PlotBufferParams } from '../src/ipc/message-exchange.js';
+
+function params(name: string): PlotBufferParams {
+  return {
+    variableName: name, displayName: name, pixelLayout: 'rgba', transpose: false,
+    width: 1, height: 1, channels: 1, stride: 1, bufferType: 0, pixels: new Uint8Array([1]),
+  };
+}
+
+function harness(overrides: Partial<SessionDeps> = {}) {
+  const sent: string[] = [];
+  const warnings: string[] = [];
+  const deps: SessionDeps = {
+    source: { async getBufferMetadata(name) {
+      if (name === 'bad') throw new Error('not a Mat');
+      return params(name);
+    } },
+    sink: { async ensureReady() {}, sendPlotBuffer(bytes) { sent.push(`#${bytes.length}`); } },
+    encode: (p) => new Uint8Array([p.variableName.length]),
+    resolveFrame: async () => 0,
+    getWatchList: () => ['img', 'bad', 'img2'],
+    warn: (m) => warnings.push(m),
+    ...overrides,
+  };
+  return { mgr: new SessionManager(deps), sent, warnings };
+}
+
+test('onStopped plots every watch entry and isolates failures', async () => {
+  const { mgr, sent, warnings } = harness();
+  await mgr.onStopped(1);
+  assert.equal(sent.length, 2);          // img + img2 sent; bad skipped
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /bad/);
+});
+
+test('plotVariable sends a single buffer', async () => {
+  const { mgr, sent } = harness({ getWatchList: () => [] });
+  await mgr.plotVariable('img', 1);
+  assert.equal(sent.length, 1);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run compile`
+Expected: FAIL — `Cannot find module '../src/session/session-manager.js'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// src/session/session-manager.ts
+import type { PlotBufferParams } from '../ipc/message-exchange.js';
+
+export interface MetadataSource {
+  getBufferMetadata(variable: string, frameId: number): Promise<PlotBufferParams>;
+}
+
+export interface PlotSink {
+  ensureReady(): Promise<void>;
+  sendPlotBuffer(bytes: Uint8Array): void | Promise<void>;
+}
+
+export interface SessionDeps {
+  source: MetadataSource;
+  sink: PlotSink;
+  encode: (p: PlotBufferParams) => Uint8Array;
+  resolveFrame: (threadId: number) => Promise<number>;
+  getWatchList: () => string[];
+  warn: (message: string) => void;
+}
+
+export class SessionManager {
+  constructor(private readonly deps: SessionDeps) {}
+
+  async plotVariable(name: string, threadId: number): Promise<void> {
+    const frameId = await this.deps.resolveFrame(threadId);
+    await this.plotAtFrame(name, frameId);
+  }
+
+  async onStopped(threadId: number): Promise<void> {
+    const watch = this.deps.getWatchList();
+    if (watch.length === 0) return;
+    const frameId = await this.deps.resolveFrame(threadId);
+    for (const name of watch) {
+      await this.plotAtFrame(name, frameId);
+    }
+  }
+
+  private async plotAtFrame(name: string, frameId: number): Promise<void> {
+    try {
+      const p = await this.deps.source.getBufferMetadata(name, frameId);
+      await this.deps.sink.ensureReady();
+      await this.deps.sink.sendPlotBuffer(this.deps.encode(p));
+    } catch (err) {
+      this.deps.warn(
+        `OID: could not plot '${name}': ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run compile && npm test`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/session/session-manager.ts test/session-manager.test.ts
+git commit -m "feat(session): watch-loop session manager with isolated failures"
+```
+
+---
+
+### Task 6: ViewerController (panel refactor)
+
+**Files:**
+- Modify: `src/webview/panel.ts`
+
+**Interfaces:**
+- Produces:
+  - `class ViewerController` with `open(): void`, `ensureReady(): Promise<void>`, `sendPlotBuffer(bytes: Uint8Array): void`
+  - `function openViewerPanel(context: vscode.ExtensionContext): ViewerController` (back-compat for `oid.openPanel`)
+- Satisfies the `PlotSink` shape from `session/session-manager.js` (`ensureReady` + `sendPlotBuffer`).
+
+Rewrites `panel.ts` into a singleton controller. The webview HTML keeps the existing IPC glue (`toUint8Array`, the `oid-ipc-forward` handler, the `oid-viewer-ready` relay). The embedded smoke-test buffer is removed — buffers now arrive from the extension via `oid-ipc-forward`. `ensureReady()` resolves on the `viewer-ready` control message; sends queue until ready.
+
+- [ ] **Step 1: Replace `src/webview/panel.ts` with the controller**
+
+```typescript
+// src/webview/panel.ts
+import * as vscode from 'vscode';
+
+function htmlFor(webview: vscode.Webview, media: vscode.Uri): string {
+  const uri = (file: string) => webview.asWebviewUri(vscode.Uri.joinPath(media, file));
+  const oidwindowJs = uri('oidwindow.js');
+  const qtloaderJs = uri('qtloader.js');
+  const oidwindowWasm = uri('oidwindow.wasm');
+
+  return `<!DOCTYPE html>
+<html lang="en-us">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, height=device-height, user-scalable=0">
+  <title>Open Image Debugger</title>
+  <style>
+    html, body { padding: 0; margin: 0; overflow: hidden; width: 100%; height: 100%; }
+    #screen { position: absolute; inset: 0; width: 100%; height: 100%; }
+    #qtspinner { margin: 0; }
+  </style>
+</head>
+<body onload="init()">
+  <figure style="overflow:visible;" id="qtspinner">
+    <center style="margin-top:1.5em; line-height:150%">
+      <strong>Open Image Debugger</strong>
+      <div id="qtstatus">Loading...</div>
+    </center>
+  </figure>
+  <div id="screen"></div>
+
+  <script>
+    const vscode = acquireVsCodeApi();
+
+    function toUint8Array(payload) {
+      if (payload instanceof Uint8Array) return payload;
+      if (Array.isArray(payload)) return new Uint8Array(payload);
+      if (payload instanceof ArrayBuffer) return new Uint8Array(payload);
+      if (payload && typeof payload === 'object') return new Uint8Array(Object.values(payload));
+      throw new Error('invalid oid-ipc payload');
+    }
+
+    window.oidSend = function(u8) {
+      const arr = u8 instanceof Uint8Array ? u8 : new Uint8Array(u8);
+      vscode.postMessage({ type: 'oid-ipc-out', payload: Array.from(arr) });
+    };
+
+    function handleViewerReady(msg) { vscode.postMessage(msg); }
+    window.oidOnViewerReady = handleViewerReady;
+    window.addEventListener('oid-viewer-ready', (ev) => handleViewerReady(ev.detail));
+
+    window.addEventListener('message', (ev) => {
+      if (ev.data?.type !== 'oid-ipc-forward' || !ev.data.payload) return;
+      const arr = toUint8Array(ev.data.payload);
+      if (window.oidOnMessage) window.oidOnMessage(arr);
+    });
+  </script>
+
+  <script type="text/javascript">
+    async function init() {
+      const spinner = document.querySelector('#qtspinner');
+      const screen = document.querySelector('#screen');
+      const status = document.querySelector('#qtstatus');
+      const showUi = (ui) => {
+        [spinner, screen].forEach((el) => el.style.display = 'none');
+        if (screen === ui) screen.style.position = 'default';
+        ui.style.display = 'block';
+      };
+      try {
+        showUi(spinner);
+        status.innerHTML = 'Loading...';
+        const wasmResponse = await fetch('${oidwindowWasm}');
+        if (!wasmResponse.ok) throw new Error('Failed to fetch oidwindow.wasm: ' + wasmResponse.status);
+        const wasmModule = await WebAssembly.compile(await wasmResponse.arrayBuffer());
+        await qtLoad({
+          locateFile: (path) => (path === 'oidwindow.wasm' ? '${oidwindowWasm}' : path),
+          qt: {
+            module: wasmModule,
+            onLoaded: () => showUi(screen),
+            onExit: (exitData) => {
+              status.innerHTML = 'Application exit';
+              if (exitData.code !== undefined) status.innerHTML += ' with code ' + exitData.code;
+              if (exitData.text !== undefined) status.innerHTML += ' (' + exitData.text + ')';
+              showUi(spinner);
+            },
+            entryFunction: window.oidwindow_entry,
+            containerElements: [screen],
+          },
+        });
+      } catch (e) {
+        console.error(e);
+        status.innerHTML = String(e);
+        showUi(spinner);
+      }
+    }
+  </script>
+  <script src="${oidwindowJs}"></script>
+  <script src="${qtloaderJs}"></script>
+</body>
+</html>`;
+}
+
+/** Owns the single viewer webview and forwards encoded PlotBufferContents frames. */
+export class ViewerController {
+  private panel: vscode.WebviewPanel | undefined;
+  private ready = false;
+  private readyWaiters: Array<() => void> = [];
+  private readonly media: vscode.Uri;
+
+  constructor(private readonly context: vscode.ExtensionContext) {
+    this.media = vscode.Uri.joinPath(context.extensionUri, 'media');
+  }
+
+  open(): void {
+    if (this.panel) {
+      this.panel.reveal(vscode.ViewColumn.One);
+      return;
+    }
+    const panel = vscode.window.createWebviewPanel(
+      'oidViewer',
+      'Open Image Debugger',
+      vscode.ViewColumn.One,
+      { enableScripts: true, retainContextWhenHidden: true, localResourceRoots: [this.media] }
+    );
+    panel.webview.html = htmlFor(panel.webview, this.media);
+    panel.webview.onDidReceiveMessage((msg) => {
+      if (msg?.type === 'oid-control' && msg.event === 'viewer-ready') {
+        this.ready = true;
+        for (const w of this.readyWaiters.splice(0)) w();
+      }
+    });
+    panel.onDidDispose(() => {
+      this.panel = undefined;
+      this.ready = false;
+      this.readyWaiters = [];
+    });
+    this.panel = panel;
+  }
+
+  ensureReady(): Promise<void> {
+    this.open();
+    if (this.ready) return Promise.resolve();
+    return new Promise<void>((resolve) => this.readyWaiters.push(resolve));
+  }
+
+  sendPlotBuffer(bytes: Uint8Array): void {
+    this.panel?.webview.postMessage({ type: 'oid-ipc-forward', payload: Array.from(bytes) });
+  }
+}
+
+/** Back-compat entry point for the `oid.openPanel` command. */
+export function openViewerPanel(context: vscode.ExtensionContext): ViewerController {
+  const controller = new ViewerController(context);
+  controller.open();
+  return controller;
+}
+```
+
+- [ ] **Step 2: Compile to verify it type-checks**
+
+Run: `npm run compile && npm test`
+Expected: PASS (no type errors; existing unit tests still green)
+
+- [ ] **Step 3: Manual smoke check** — `F5` → Extension Dev Host → run **OID: Open Viewer Panel**. The Qt canvas loads and shows the empty viewer (no auto image now — the smoke-test buffer was removed). Confirm no console errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/webview/panel.ts
+git commit -m "refactor(webview): ViewerController singleton, drop embedded smoke-test"
+```
+
+---
+
+### Task 7: Extension wiring + manifest
+
+**Files:**
+- Modify: `src/extension.ts`
+- Modify: `package.json`
+
+**Interfaces:**
+- Consumes: `ViewerController` from `webview/panel.js`; `DapClient` from `debugger/dap-client.js`; `CodeLldbBridge` from `debugger/codelldb-bridge.js`; `SessionManager` from `session/session-manager.js`; `buildPlotBufferContents` from `ipc/message-exchange.js`
+
+- [ ] **Step 1: Update `package.json` (commands, activation, config)**
+
+```json
+{
+  "name": "openimagedebugger-vscode",
+  "displayName": "Open Image Debugger",
+  "version": "0.0.1",
+  "engines": { "vscode": "^1.85.0" },
+  "activationEvents": ["onDebug"],
+  "main": "./out/src/extension.js",
+  "contributes": {
+    "commands": [
+      { "command": "oid.openPanel", "title": "OID: Open Viewer Panel" },
+      { "command": "oid.plot", "title": "OID: Plot Variable" }
+    ],
+    "configuration": {
+      "title": "Open Image Debugger",
+      "properties": {
+        "oid.watchOnStop": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Variable names to plot automatically on every debugger stop."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p .",
+    "test": "node --test out/test/*.js"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.85.0",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.4.0"
+  }
+}
+```
+
+- [ ] **Step 2: Rewrite `src/extension.ts`**
+
+```typescript
+// src/extension.ts
+import * as vscode from 'vscode';
+import { ViewerController } from './webview/panel.js';
+import { DapClient } from './debugger/dap-client.js';
+import { CodeLldbBridge } from './debugger/codelldb-bridge.js';
+import { SessionManager } from './session/session-manager.js';
+import { buildPlotBufferContents } from './ipc/message-exchange.js';
+
+function watchList(): string[] {
+  return vscode.workspace.getConfiguration('oid').get<string[]>('watchOnStop', []);
+}
+
+function activeSession(): vscode.DebugSession | undefined {
+  return vscode.debug.activeDebugSession;
+}
+
+export function activate(context: vscode.ExtensionContext): void {
+  const viewer = new ViewerController(context);
+  let stoppedThreadId: number | undefined;
+
+  const manager = new SessionManager({
+    source: {
+      async getBufferMetadata(name, frameId) {
+        const session = activeSession();
+        if (!session) throw new Error('no active debug session');
+        return new CodeLldbBridge(new DapClient(session)).getBufferMetadata(name, frameId);
+      },
+    },
+    sink: viewer,
+    encode: (p) => buildPlotBufferContents(p, 'wasm32'),
+    resolveFrame: async (threadId) => {
+      const session = activeSession();
+      if (!session) throw new Error('no active debug session');
+      return new DapClient(session).topFrameId(threadId);
+    },
+    getWatchList: watchList,
+    warn: (m) => vscode.window.showWarningMessage(m),
+  });
+
+  // Track CodeLLDB stop events: capture the stopped thread and auto-plot the watch list.
+  context.subscriptions.push(
+    vscode.debug.registerDebugAdapterTrackerFactory('lldb', {
+      createDebugAdapterTracker() {
+        return {
+          onDidSendMessage(message: any) {
+            if (message.type === 'event' && message.event === 'stopped') {
+              stoppedThreadId = message.body?.threadId;
+              if (stoppedThreadId !== undefined) void manager.onStopped(stoppedThreadId);
+            }
+          },
+        };
+      },
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('oid.openPanel', () => viewer.open()),
+    vscode.commands.registerCommand('oid.plot', async () => {
+      if (!activeSession() || stoppedThreadId === undefined) {
+        vscode.window.showWarningMessage('OID: pause in a debug session first.');
+        return;
+      }
+      const editor = vscode.window.activeTextEditor;
+      const selected = editor?.document.getText(editor.selection).trim();
+      const name = selected || (await vscode.window.showInputBox({ prompt: 'Variable to plot' }))?.trim();
+      if (name) await manager.plotVariable(name, stoppedThreadId);
+    })
+  );
+}
+
+export function deactivate(): void {}
+```
+
+- [ ] **Step 3: Compile + test**
+
+Run: `npm run compile && npm test`
+Expected: PASS (all unit tests; extension wiring is type-checked)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/extension.ts package.json
+git commit -m "feat(extension): wire CodeLLDB stop -> plot + oid.plot command"
+```
+
+---
+
+### Task 8: Manual verification (testbench)
+
+**Files:** none (verification only)
+
+The OID testbench `testbench/main.cpp` declares `Mat TestField;` and fills it via `ones<uint8_t>(W, H, C, TestField)` inside `nest()`. Use it as the live target.
+
+- [ ] **Step 1: Build the testbench (OID repo)**
+
+```bash
+cmake -S testbench -B testbench/build && cmake --build testbench/build -j
+```
+
+- [ ] **Step 2: Configure a CodeLLDB launch** — in `openimagedebugger-vscode/.vscode/launch.json`, add a `lldb` launch for the built testbench binary (under `../OpenImageDebugger/testbench/build/`), with a breakpoint inside `nest()` after `ones<uint8_t>(W, H, C, TestField)`.
+
+- [ ] **Step 3: Run** — `F5` (Extension Dev Host) → start the CodeLLDB launch → hit the breakpoint in `nest()`.
+
+- [ ] **Step 4: Plot on demand** — run **OID: Open Viewer Panel**, then **OID: Plot Variable** with `TestField` (select the identifier or type it). Confirm the image renders in the viewer.
+
+- [ ] **Step 5: Auto-plot on stop** — set `"oid.watchOnStop": ["TestField"]`, continue/step to the next stop, confirm `TestField` re-plots automatically.
+
+- [ ] **Step 6: Float check** — repeat against a float32 Mat (e.g. a `doSimpleCalculation<float>` path) and confirm it renders.
+
+- [ ] **Step 7: Commit any launch.json fixture used**
+
+```bash
+git add .vscode/launch.json
+git commit -m "test: CodeLLDB launch config for testbench verification"
+```
+
+---
+
+## Plan self-review
+
+- **Spec coverage:** §3 components → Tasks 1 (`buffer-metadata`), 2 (`opencv-mat`), 3 (`dap-client`), 4 (`codelldb-bridge`), 5 (`session-manager`), 6 (`ViewerController`/panel), 7 (`extension.ts`/manifest). §4 extraction → Tasks 2 + 4. §5 flow → Tasks 5 + 7. §6 error handling → Task 4 (null pointer/evaluate), Task 5 (isolated watch failures/warn), Task 7 (no stopped frame). §7 testing → unit Tasks 1–5, manual Task 8.
+- **Placeholder scan:** No TBD / "add error handling" / "similar to" steps; every code step shows full code. The fixture flags literal is concrete (`1124007952`).
+- **Type consistency:** `PlotBufferParams` (existing), `MatFields`/`MatMetadata`, `IDapClient`/`EvaluateResult`/`DapSession`, `MetadataSource`/`PlotSink`/`SessionDeps`, `ViewerController` are referenced with identical names/signatures across producing and consuming tasks. `getBufferMetadata`, `ensureReady`, `sendPlotBuffer`, `onStopped`, `plotVariable`, `topFrameId`, `parseIntResult` are spelled consistently.
+- **Scope:** Extension-only; eight tasks each ending in a testable deliverable.

--- a/docs/superpowers/plans/2026-06-24-oid-vscode-p3-session.md
+++ b/docs/superpowers/plans/2026-06-24-oid-vscode-p3-session.md
@@ -1,0 +1,868 @@
+# OID VS Code P3: Session management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn P2's one-shot plot into a live session loop — populate the viewer's symbol autocomplete, let the viewer own the watched-buffer set, and re-plot it with fresh data on every debugger stop.
+
+**Architecture:** Extension-only, on top of P2. Pure codecs and the session loop live in VS-Code-free modules (`ipc/message-exchange.ts`, `session/session-manager.ts`, `debugger/symbol-enumerator.ts`) so they unit-test under `node:test`. The VS-Code-coupled glue (`webview/panel.ts`'s `ViewerController`, `extension.ts`) is thin wiring verified by compile + manual run. The watched set is owned by the WASM viewer and polled via the existing `GetObservedSymbols` request/response protocol; `oid.watchOnStop` seeds it once per debug session.
+
+**Tech Stack:** TypeScript (ES modules, `.js` import specifiers), `node:test` + `node:assert`, VS Code Debug API (DAP custom requests), Emscripten `wasm32` wire format.
+
+## Global Constraints
+
+- **Repo:** all changes are in the sibling extension repo `/Users/bruno/ws/openimagedebugger-vscode`. No OpenImageDebugger C++/WASM changes.
+- **Wire format:** `wasm32` mode — message-type header, `size_t` counts, and string length prefixes are all little-endian `u32`. Strings are UTF-8, length-prefixed (no NUL terminator).
+- **Message types** (`MessageType` enum, must match OID `src/ipc/message_exchange.h`): `GetObservedSymbols = 0`, `GetObservedSymbolsResponse = 1`, `SetAvailableSymbols = 2`, `PlotBufferContents = 3`, `PlotBufferRequest = 4`.
+- **Module imports:** use `.js` specifiers (e.g. `'../src/ipc/message-exchange.js'`) — the project compiles to `out/` and runs the compiled JS.
+- **Test layout:** specs live in `test/*.test.ts`; `npm test` runs `node --test out/test/*.js`. Modules that `import * as vscode` cannot load under `node:test`, so keep `session-manager.ts`, `message-exchange.ts`, and `symbol-enumerator.ts` free of any `vscode` import.
+- **Build/test commands:** `npm run compile` (tsc), then `npm test`. Always compile before testing.
+- **Persistence is out of scope** (deferred to P5). The observed set is in-memory only.
+
+---
+
+### Task 1: Symbol-list codecs in `message-exchange.ts`
+
+Add the encoders for `SetAvailableSymbols` (host→viewer) and `GetObservedSymbols` (host→viewer, header-only), and a decoder for inbound viewer→extension frames (`GetObservedSymbolsResponse`, `PlotBufferRequest`).
+
+**Files:**
+- Modify: `openimagedebugger-vscode/src/ipc/message-exchange.ts`
+- Test: `openimagedebugger-vscode/test/message-exchange.test.ts`
+
+**Interfaces:**
+- Consumes: existing module-private `pushU32`, `pushString`; existing `WasmLengthMode`.
+- Produces:
+  - `buildSetAvailableSymbols(names: string[], mode: WasmLengthMode): Uint8Array`
+  - `buildGetObservedSymbols(): Uint8Array`
+  - `decodeInbound(bytes: Uint8Array): InboundMessage`
+  - `type InboundMessage = { kind: 'observedSymbols'; names: string[] } | { kind: 'plotRequest'; name: string } | { kind: 'unknown'; type: number }`
+  - extended `MessageType` enum with all five members.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `openimagedebugger-vscode/test/message-exchange.test.ts`:
+
+```ts
+import {
+  buildSetAvailableSymbols,
+  buildGetObservedSymbols,
+  decodeInbound,
+} from '../src/ipc/message-exchange.js';
+
+// Local helper: encode an inbound frame the way the wasm32 viewer would.
+function encodeFrame(type: number, strings: string[], withCount: boolean): Uint8Array {
+  const parts: number[] = [];
+  const u32 = (v: number) => parts.push(v & 0xff, (v >> 8) & 0xff, (v >> 16) & 0xff, (v >> 24) & 0xff);
+  const str = (s: string) => {
+    const b = new TextEncoder().encode(s);
+    u32(b.length);
+    for (const x of b) parts.push(x);
+  };
+  u32(type);
+  if (withCount) u32(strings.length);
+  for (const s of strings) str(s);
+  return new Uint8Array(parts);
+}
+
+test('buildSetAvailableSymbols frames type 2, count, then names', () => {
+  const bytes = buildSetAvailableSymbols(['img', 'mask'], 'wasm32');
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  assert.equal(view.getUint32(0, true), MessageType.SetAvailableSymbols);
+  assert.equal(view.getUint32(4, true), 2); // count
+  assert.equal(view.getUint32(8, true), 3); // length of 'img'
+});
+
+test('buildGetObservedSymbols is a 4-byte type-0 header', () => {
+  const bytes = buildGetObservedSymbols();
+  assert.equal(bytes.length, 4);
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  assert.equal(view.getUint32(0, true), MessageType.GetObservedSymbols);
+});
+
+test('decodeInbound parses GetObservedSymbolsResponse names', () => {
+  const frame = encodeFrame(MessageType.GetObservedSymbolsResponse, ['img', 'mask'], true);
+  const msg = decodeInbound(frame);
+  assert.deepEqual(msg, { kind: 'observedSymbols', names: ['img', 'mask'] });
+});
+
+test('decodeInbound parses an empty observed list', () => {
+  const frame = encodeFrame(MessageType.GetObservedSymbolsResponse, [], true);
+  assert.deepEqual(decodeInbound(frame), { kind: 'observedSymbols', names: [] });
+});
+
+test('decodeInbound parses a PlotBufferRequest name', () => {
+  const frame = encodeFrame(MessageType.PlotBufferRequest, ['TestField'], false);
+  assert.deepEqual(decodeInbound(frame), { kind: 'plotRequest', name: 'TestField' });
+});
+
+test('decodeInbound returns unknown for unhandled types', () => {
+  const frame = encodeFrame(MessageType.PlotBufferContents, [], false);
+  assert.deepEqual(decodeInbound(frame), { kind: 'unknown', type: MessageType.PlotBufferContents });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd /Users/bruno/ws/openimagedebugger-vscode && npm run compile`
+Expected: FAIL — `tsc` errors that `buildSetAvailableSymbols`, `buildGetObservedSymbols`, `decodeInbound` are not exported.
+
+- [ ] **Step 3: Extend the `MessageType` enum**
+
+In `openimagedebugger-vscode/src/ipc/message-exchange.ts`, replace:
+
+```ts
+export enum MessageType {
+  PlotBufferContents = 3,
+}
+```
+
+with:
+
+```ts
+export enum MessageType {
+  GetObservedSymbols = 0,
+  GetObservedSymbolsResponse = 1,
+  SetAvailableSymbols = 2,
+  PlotBufferContents = 3,
+  PlotBufferRequest = 4,
+}
+```
+
+- [ ] **Step 4: Add the encoders and decoder**
+
+Append to the end of `openimagedebugger-vscode/src/ipc/message-exchange.ts`:
+
+```ts
+export function buildSetAvailableSymbols(
+  names: string[],
+  mode: WasmLengthMode
+): Uint8Array {
+  const parts: number[] = [];
+  pushU32(parts, MessageType.SetAvailableSymbols);
+  pushU32(parts, names.length);
+  for (const name of names) {
+    pushString(parts, name, mode);
+  }
+  return new Uint8Array(parts);
+}
+
+export function buildGetObservedSymbols(): Uint8Array {
+  const parts: number[] = [];
+  pushU32(parts, MessageType.GetObservedSymbols);
+  return new Uint8Array(parts);
+}
+
+export type InboundMessage =
+  | { kind: 'observedSymbols'; names: string[] }
+  | { kind: 'plotRequest'; name: string }
+  | { kind: 'unknown'; type: number };
+
+export function decodeInbound(bytes: Uint8Array): InboundMessage {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let offset = 0;
+  const readU32 = (): number => {
+    const v = view.getUint32(offset, true);
+    offset += 4;
+    return v;
+  };
+  const readString = (): string => {
+    const len = readU32();
+    const slice = bytes.subarray(offset, offset + len);
+    offset += len;
+    return new TextDecoder().decode(slice);
+  };
+
+  const type = readU32();
+  switch (type) {
+    case MessageType.GetObservedSymbolsResponse: {
+      const count = readU32();
+      const names: string[] = [];
+      for (let i = 0; i < count; i++) names.push(readString());
+      return { kind: 'observedSymbols', names };
+    }
+    case MessageType.PlotBufferRequest:
+      return { kind: 'plotRequest', name: readString() };
+    default:
+      return { kind: 'unknown', type };
+  }
+}
+```
+
+- [ ] **Step 5: Compile and run the tests to verify they pass**
+
+Run: `cd /Users/bruno/ws/openimagedebugger-vscode && npm run compile && npm test`
+Expected: PASS — all `message-exchange` tests green, existing `PlotBufferContents` test still green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/bruno/ws/openimagedebugger-vscode
+git add src/ipc/message-exchange.ts test/message-exchange.test.ts
+git commit -m "feat(ipc): symbol-list and observed-symbols codecs"
+```
+
+---
+
+### Task 2: Scope symbol enumerator
+
+Enumerate the current frame's local + argument variables (name + type) via DAP `scopes`/`variables`, for the viewer's autocomplete.
+
+**Files:**
+- Modify: `openimagedebugger-vscode/src/debugger/dap-client.ts`
+- Create: `openimagedebugger-vscode/src/debugger/symbol-enumerator.ts`
+- Test: `openimagedebugger-vscode/test/dap-client.test.ts` (extend)
+- Test: `openimagedebugger-vscode/test/symbol-enumerator.test.ts` (new)
+
+**Interfaces:**
+- Consumes: existing `DapClient` / `DapSession.customRequest`.
+- Produces:
+  - In `dap-client.ts`: `interface DapScope { name: string; variablesReference: number; presentationHint?: string }`, `interface DapVariable { name: string; value: string; type?: string; variablesReference: number }`, and on `IDapClient`/`DapClient`: `scopes(frameId: number): Promise<DapScope[]>`, `variables(variablesReference: number): Promise<DapVariable[]>`.
+  - In `symbol-enumerator.ts`: `interface ScopeReader { scopes(frameId): Promise<DapScope[]>; variables(ref): Promise<DapVariable[]> }`, `interface ScopeSymbol { name: string; type: string }`, `listScopeSymbols(reader: ScopeReader, frameId: number): Promise<ScopeSymbol[]>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `openimagedebugger-vscode/test/symbol-enumerator.test.ts`:
+
+```ts
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { listScopeSymbols, type ScopeReader } from '../src/debugger/symbol-enumerator.js';
+import type { DapScope, DapVariable } from '../src/debugger/dap-client.js';
+
+function reader(
+  scopes: DapScope[],
+  vars: Record<number, DapVariable[]>
+): ScopeReader {
+  return {
+    async scopes() { return scopes; },
+    async variables(ref) { return vars[ref] ?? []; },
+  };
+}
+
+test('lists locals and arguments, skips registers/statics', async () => {
+  const syms = await listScopeSymbols(
+    reader(
+      [
+        { name: 'Local', variablesReference: 1, presentationHint: 'locals' },
+        { name: 'Arguments', variablesReference: 2, presentationHint: 'arguments' },
+        { name: 'Registers', variablesReference: 3, presentationHint: 'registers' },
+      ],
+      {
+        1: [{ name: 'img', value: '...', type: 'cv::Mat', variablesReference: 0 }],
+        2: [{ name: 'rows', value: '4', type: 'int', variablesReference: 0 }],
+        3: [{ name: 'rax', value: '0x0', variablesReference: 0 }],
+      }
+    ),
+    7
+  );
+  assert.deepEqual(syms, [
+    { name: 'img', type: 'cv::Mat' },
+    { name: 'rows', type: 'int' },
+  ]);
+});
+
+test('falls back to scope name when no presentationHint, and dedupes', async () => {
+  const syms = await listScopeSymbols(
+    reader(
+      [
+        { name: 'Local', variablesReference: 1 },
+        { name: 'Local', variablesReference: 2 },
+      ],
+      {
+        1: [{ name: 'img', value: '', type: 'cv::Mat', variablesReference: 0 }],
+        2: [
+          { name: 'img', value: '', type: 'cv::Mat', variablesReference: 0 },
+          { name: '', value: '', variablesReference: 0 },
+        ],
+      }
+    ),
+    1
+  );
+  assert.deepEqual(syms, [{ name: 'img', type: 'cv::Mat' }]);
+});
+```
+
+Append to `openimagedebugger-vscode/test/dap-client.test.ts`:
+
+```ts
+import { DapClient } from '../src/debugger/dap-client.js';
+
+test('scopes/variables unwrap the DAP response and default to []', async () => {
+  const calls: Array<[string, any]> = [];
+  const session = {
+    async customRequest(command: string, args?: unknown) {
+      calls.push([command, args]);
+      if (command === 'scopes') return { scopes: [{ name: 'Local', variablesReference: 9 }] };
+      if (command === 'variables') return {}; // missing variables array
+      return {};
+    },
+  };
+  const client = new DapClient(session);
+  assert.deepEqual(await client.scopes(7), [{ name: 'Local', variablesReference: 9 }]);
+  assert.deepEqual(await client.variables(9), []);
+  assert.deepEqual(await client.variables(0), []); // ref <= 0 short-circuits
+  assert.deepEqual(calls, [['scopes', { frameId: 7 }], ['variables', { variablesReference: 9 }]]);
+});
+```
+
+(If `dap-client.test.ts` does not already import `test`/`assert`, add `import { strict as assert } from 'node:assert';` and `import { test } from 'node:test';` at the top.)
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd /Users/bruno/ws/openimagedebugger-vscode && npm run compile`
+Expected: FAIL — `symbol-enumerator.js` not found; `scopes`/`variables` not on `DapClient`.
+
+- [ ] **Step 3: Add `scopes`/`variables` to the DAP client**
+
+In `openimagedebugger-vscode/src/debugger/dap-client.ts`, after the `EvaluateResult` interface (line 10), add:
+
+```ts
+export interface DapScope {
+  name: string;
+  variablesReference: number;
+  presentationHint?: string;
+}
+
+export interface DapVariable {
+  name: string;
+  value: string;
+  type?: string;
+  variablesReference: number;
+}
+```
+
+Add these two methods to the `IDapClient` interface:
+
+```ts
+  scopes(frameId: number): Promise<DapScope[]>;
+  variables(variablesReference: number): Promise<DapVariable[]>;
+```
+
+Add these two methods to the `DapClient` class (after `topFrameId`):
+
+```ts
+  async scopes(frameId: number): Promise<DapScope[]> {
+    const res = await this.session.customRequest('scopes', { frameId });
+    return res?.scopes ?? [];
+  }
+
+  async variables(variablesReference: number): Promise<DapVariable[]> {
+    if (variablesReference <= 0) return [];
+    const res = await this.session.customRequest('variables', { variablesReference });
+    return res?.variables ?? [];
+  }
+```
+
+- [ ] **Step 4: Create the enumerator**
+
+Create `openimagedebugger-vscode/src/debugger/symbol-enumerator.ts`:
+
+```ts
+import type { DapScope, DapVariable } from './dap-client.js';
+
+export interface ScopeReader {
+  scopes(frameId: number): Promise<DapScope[]>;
+  variables(variablesReference: number): Promise<DapVariable[]>;
+}
+
+export interface ScopeSymbol {
+  name: string;
+  type: string;
+}
+
+function isLocalOrArgument(scope: DapScope): boolean {
+  const hint = scope.presentationHint?.toLowerCase();
+  if (hint === 'locals' || hint === 'arguments') return true;
+  if (hint === 'registers') return false;
+  return /local|argument/i.test(scope.name);
+}
+
+/** Flat list of the current frame's local + argument variables (top level only). */
+export async function listScopeSymbols(
+  reader: ScopeReader,
+  frameId: number
+): Promise<ScopeSymbol[]> {
+  const scopes = await reader.scopes(frameId);
+  const seen = new Set<string>();
+  const out: ScopeSymbol[] = [];
+  for (const scope of scopes) {
+    if (!isLocalOrArgument(scope)) continue;
+    const vars = await reader.variables(scope.variablesReference);
+    for (const v of vars) {
+      if (!v.name || seen.has(v.name)) continue;
+      seen.add(v.name);
+      out.push({ name: v.name, type: v.type ?? '' });
+    }
+  }
+  return out;
+}
+```
+
+- [ ] **Step 5: Compile and run the tests to verify they pass**
+
+Run: `cd /Users/bruno/ws/openimagedebugger-vscode && npm run compile && npm test`
+Expected: PASS — `symbol-enumerator` and new `dap-client` tests green; all prior tests still green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/bruno/ws/openimagedebugger-vscode
+git add src/debugger/dap-client.ts src/debugger/symbol-enumerator.ts test/symbol-enumerator.test.ts test/dap-client.test.ts
+git commit -m "feat(debugger): enumerate local+argument scope symbols"
+```
+
+---
+
+### Task 3: Session loop in `SessionManager`
+
+Replace the static watch-list `onStopped` with the full loop: push available symbols, poll the viewer's observed set, seed once from `oid.watchOnStop`, re-plot each observed buffer. Add `onPlotBufferRequest` and `resetSeed`.
+
+**Files:**
+- Modify: `openimagedebugger-vscode/src/session/session-manager.ts`
+- Test: `openimagedebugger-vscode/test/session-manager.test.ts`
+
+**Interfaces:**
+- Consumes: existing `PlotBufferParams`.
+- Produces:
+  - `interface ViewerChannel { setAvailableSymbols(names: string[]): void | Promise<void>; getObservedSymbols(): Promise<string[]> }`
+  - extended `SessionDeps` adding `channel: ViewerChannel` and `listScopeSymbols: (frameId: number) => Promise<string[]>`.
+  - on `SessionManager`: `resetSeed(): void`, `onPlotBufferRequest(name: string, threadId: number): Promise<void>`, and the rewritten `onStopped(threadId: number): Promise<void>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the entire contents of `openimagedebugger-vscode/test/session-manager.test.ts` with:
+
+```ts
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { SessionManager, type SessionDeps } from '../src/session/session-manager.js';
+import type { PlotBufferParams } from '../src/ipc/message-exchange.js';
+
+function params(name: string): PlotBufferParams {
+  return {
+    variableName: name,
+    displayName: name,
+    pixelLayout: 'rgba',
+    transpose: false,
+    width: 1,
+    height: 1,
+    channels: 1,
+    stride: 1,
+    bufferType: 0,
+    pixels: new Uint8Array([1]),
+  };
+}
+
+function harness(overrides: Partial<SessionDeps> = {}) {
+  const sent: string[] = [];
+  const warnings: string[] = [];
+  const available: string[][] = [];
+  let observed: string[] = [];
+  const deps: SessionDeps = {
+    source: {
+      async getBufferMetadata(name) {
+        if (name === 'bad') throw new Error('not Mat');
+        return params(name);
+      },
+    },
+    sink: {
+      async ensureReady() {},
+      sendPlotBuffer(bytes) { sent.push(String(bytes.length)); },
+    },
+    channel: {
+      setAvailableSymbols(names) { available.push(names); },
+      async getObservedSymbols() { return observed; },
+    },
+    encode: (p) => new Uint8Array([p.bufferType]),
+    resolveFrame: async () => 42,
+    listScopeSymbols: async () => ['a', 'b'],
+    getWatchList: () => [],
+    warn: (msg) => warnings.push(msg),
+    ...overrides,
+  };
+  return {
+    deps, sent, warnings, available,
+    setObserved: (o: string[]) => { observed = o; },
+    mgr: new SessionManager(deps),
+  };
+}
+
+test('onStopped pushes enumerated symbols to the viewer autocomplete', async () => {
+  const { available, mgr } = harness();
+  await mgr.onStopped(1);
+  assert.deepEqual(available[0], ['a', 'b']);
+});
+
+test('onStopped replots the viewer-observed set', async () => {
+  const h = harness();
+  h.setObserved(['img', 'mask']);
+  await h.mgr.onStopped(1);
+  assert.equal(h.sent.length, 2);
+});
+
+test('watchOnStop seeds the observed set only on the first stop', async () => {
+  const { sent, mgr } = harness({ getWatchList: () => ['img'] });
+  await mgr.onStopped(1); // seeds: plots img
+  await mgr.onStopped(1); // already seeded, channel still []: no new plots
+  assert.equal(sent.length, 1);
+});
+
+test('resetSeed re-arms the watchOnStop seed', async () => {
+  const { sent, mgr } = harness({ getWatchList: () => ['img'] });
+  await mgr.onStopped(1);
+  mgr.resetSeed();
+  await mgr.onStopped(1);
+  assert.equal(sent.length, 2);
+});
+
+test('seed is unioned with observed without duplicating', async () => {
+  const h = harness({ getWatchList: () => ['img', 'mask'] });
+  h.setObserved(['img']);
+  await h.mgr.onStopped(1);
+  assert.equal(h.sent.length, 2); // img (observed) + mask (seed); img not doubled
+});
+
+test('a failing buffer is isolated and warned', async () => {
+  const h = harness({ getWatchList: () => ['img', 'bad', 'mask'] });
+  await h.mgr.onStopped(1);
+  assert.equal(h.sent.length, 2);
+  assert.equal(h.warnings.length, 1);
+  assert(h.warnings[0].includes('bad'));
+});
+
+test('onPlotBufferRequest plots a single buffer', async () => {
+  const { sent, mgr } = harness();
+  await mgr.onPlotBufferRequest('img', 1);
+  assert.equal(sent.length, 1);
+});
+
+test('plotVariable sends a single buffer', async () => {
+  const { sent, mgr } = harness();
+  await mgr.plotVariable('img', 1);
+  assert.equal(sent.length, 1);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd /Users/bruno/ws/openimagedebugger-vscode && npm run compile`
+Expected: FAIL — `SessionDeps` has no `channel`/`listScopeSymbols`; `resetSeed`/`onPlotBufferRequest` missing.
+
+- [ ] **Step 3: Rewrite `session-manager.ts`**
+
+Replace the entire contents of `openimagedebugger-vscode/src/session/session-manager.ts` with:
+
+```ts
+import type { PlotBufferParams } from '../ipc/message-exchange.js';
+
+export interface MetadataSource {
+  getBufferMetadata(variable: string, frameId: number): Promise<PlotBufferParams>;
+}
+
+export interface PlotSink {
+  ensureReady(): Promise<void>;
+  sendPlotBuffer(bytes: Uint8Array): void | Promise<void>;
+}
+
+export interface ViewerChannel {
+  setAvailableSymbols(names: string[]): void | Promise<void>;
+  getObservedSymbols(): Promise<string[]>;
+}
+
+export interface SessionDeps {
+  source: MetadataSource;
+  sink: PlotSink;
+  channel: ViewerChannel;
+  encode: (p: PlotBufferParams) => Uint8Array;
+  resolveFrame: (threadId: number) => Promise<number>;
+  listScopeSymbols: (frameId: number) => Promise<string[]>;
+  getWatchList: () => string[];
+  warn: (message: string) => void;
+}
+
+function describe(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function union(a: string[], b: string[]): string[] {
+  const seen = new Set(a);
+  const out = [...a];
+  for (const x of b) {
+    if (!seen.has(x)) {
+      seen.add(x);
+      out.push(x);
+    }
+  }
+  return out;
+}
+
+export class SessionManager {
+  private seeded = false;
+
+  constructor(private readonly deps: SessionDeps) {}
+
+  /** Re-arm the one-time watchOnStop seed (call when a new debug session starts). */
+  resetSeed(): void {
+    this.seeded = false;
+  }
+
+  async plotVariable(name: string, threadId: number): Promise<void> {
+    const frameId = await this.deps.resolveFrame(threadId);
+    await this.plotAtFrame(name, frameId);
+  }
+
+  /** Handle a viewer-initiated PlotBufferRequest (user added a symbol in the viewer). */
+  async onPlotBufferRequest(name: string, threadId: number): Promise<void> {
+    await this.plotVariable(name, threadId);
+  }
+
+  async onStopped(threadId: number): Promise<void> {
+    const frameId = await this.deps.resolveFrame(threadId);
+
+    // 1. Populate the viewer's autocomplete with in-scope names.
+    try {
+      const names = await this.deps.listScopeSymbols(frameId);
+      await this.deps.channel.setAvailableSymbols(names);
+    } catch (err) {
+      this.deps.warn(`OID: could not list symbols: ${describe(err)}`);
+    }
+
+    // 2. Ask the viewer which buffers it is watching (it owns the list).
+    let observed: string[];
+    try {
+      observed = await this.deps.channel.getObservedSymbols();
+    } catch {
+      observed = [];
+    }
+
+    // 3. First stop of the session: seed from oid.watchOnStop config.
+    if (!this.seeded) {
+      observed = union(observed, this.deps.getWatchList());
+      this.seeded = true;
+    }
+
+    // 4. Re-plot every observed buffer with fresh data.
+    for (const name of observed) {
+      await this.plotAtFrame(name, frameId);
+    }
+  }
+
+  private async plotAtFrame(name: string, frameId: number): Promise<void> {
+    try {
+      const p = await this.deps.source.getBufferMetadata(name, frameId);
+      await this.deps.sink.ensureReady();
+      await this.deps.sink.sendPlotBuffer(this.deps.encode(p));
+    } catch (err) {
+      this.deps.warn(`OID: could not plot '${name}': ${describe(err)}`);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Compile and run the tests to verify they pass**
+
+Run: `cd /Users/bruno/ws/openimagedebugger-vscode && npm run compile && npm test`
+Expected: PASS — all 8 `session-manager` tests green. (`extension.ts` will not yet compile against the new deps — that is fixed in Task 4; if `npm run compile` fails only on `src/extension.ts`, that is expected here. Run `npm test` regardless to confirm the session-manager unit tests pass against the freshly built `out/`.)
+
+> Note: because Task 3 changes `SessionDeps`, `src/extension.ts` (Task 4) is now out of sync. If `tsc` blocks `out/` from updating, temporarily it is acceptable to proceed directly to Task 4 in the same sitting; do not commit Task 3 until `npm test` shows the session-manager suite green. The committed tree need not compile mid-task, but SHOULD compile by the end of Task 4.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/bruno/ws/openimagedebugger-vscode
+git add src/session/session-manager.ts test/session-manager.test.ts
+git commit -m "feat(session): viewer-owned watch loop with available-symbols push"
+```
+
+---
+
+### Task 4: Viewer channel + extension wiring
+
+Make `ViewerController` implement `ViewerChannel` (send `SetAvailableSymbols`, poll `GetObservedSymbols` with a timeout, dispatch inbound `oid-ipc-out` frames) and wire it all in `extension.ts`. This is the integration task; verified by compile + the existing unit suite + the manual matrix.
+
+**Files:**
+- Modify: `openimagedebugger-vscode/src/webview/panel.ts`
+- Modify: `openimagedebugger-vscode/src/extension.ts`
+
+**Interfaces:**
+- Consumes: `buildSetAvailableSymbols`, `buildGetObservedSymbols`, `decodeInbound` (Task 1); `SessionManager`, `ViewerChannel` (Task 3); `listScopeSymbols` (Task 2).
+- Produces: `ViewerController` gains `setAvailableSymbols(names: string[]): Promise<void>`, `getObservedSymbols(): Promise<string[]>`, `onPlotBufferRequest(handler: (name: string) => void): void` — satisfying `ViewerChannel` and supplying the inbound callback.
+
+- [ ] **Step 1: Add the channel + inbound dispatch to `ViewerController`**
+
+In `openimagedebugger-vscode/src/webview/panel.ts`, update the import line near the top (after the `vscode` import) to add the codecs:
+
+```ts
+import {
+  buildSetAvailableSymbols,
+  buildGetObservedSymbols,
+  decodeInbound,
+} from '../ipc/message-exchange.js';
+```
+
+Add these fields to the `ViewerController` class (next to the existing `private ready = false;`):
+
+```ts
+  private observedResolver: ((names: string[]) => void) | undefined;
+  private observedTimer: ReturnType<typeof setTimeout> | undefined;
+  private plotRequestHandler: ((name: string) => void) | undefined;
+```
+
+Replace the `panel.webview.onDidReceiveMessage(...)` call inside `open()` with:
+
+```ts
+    panel.webview.onDidReceiveMessage((msg) => {
+      if (msg?.type === 'oid-control' && msg.event === 'viewer-ready') {
+        this.ready = true;
+        for (const w of this.readyWaiters.splice(0)) w();
+        return;
+      }
+      if (msg?.type === 'oid-ipc-out' && msg.payload) {
+        this.handleInbound(new Uint8Array(msg.payload));
+      }
+    });
+```
+
+Add `this.resolveObserved([]);` inside the existing `panel.onDidDispose(() => { ... })` callback (so a pending poll never hangs after the panel closes), e.g.:
+
+```ts
+    panel.onDidDispose(() => {
+      this.panel = undefined;
+      this.ready = false;
+      this.resolveObserved([]);
+      for (const w of this.readyWaiters.splice(0)) w();
+    });
+```
+
+Add these methods to the `ViewerController` class (after `sendPlotBuffer`):
+
+```ts
+  onPlotBufferRequest(handler: (name: string) => void): void {
+    this.plotRequestHandler = handler;
+  }
+
+  async setAvailableSymbols(names: string[]): Promise<void> {
+    await this.ensureReady();
+    this.panel?.webview.postMessage({
+      type: 'oid-ipc-forward',
+      payload: Array.from(buildSetAvailableSymbols(names, 'wasm32')),
+    });
+  }
+
+  async getObservedSymbols(): Promise<string[]> {
+    await this.ensureReady();
+    // Settle any prior in-flight poll defensively (only one poll at a time).
+    this.resolveObserved([]);
+    const result = new Promise<string[]>((resolve) => {
+      this.observedResolver = resolve;
+      this.observedTimer = setTimeout(() => {
+        console.warn('OID: GetObservedSymbols timed out; treating as empty.');
+        this.resolveObserved([]);
+      }, 1000);
+    });
+    this.panel?.webview.postMessage({
+      type: 'oid-ipc-forward',
+      payload: Array.from(buildGetObservedSymbols()),
+    });
+    return result;
+  }
+
+  private handleInbound(bytes: Uint8Array): void {
+    const inbound = decodeInbound(bytes);
+    if (inbound.kind === 'observedSymbols') {
+      this.resolveObserved(inbound.names);
+    } else if (inbound.kind === 'plotRequest') {
+      this.plotRequestHandler?.(inbound.name);
+    }
+  }
+
+  private resolveObserved(names: string[]): void {
+    if (this.observedTimer) {
+      clearTimeout(this.observedTimer);
+      this.observedTimer = undefined;
+    }
+    const resolve = this.observedResolver;
+    this.observedResolver = undefined;
+    resolve?.(names);
+  }
+```
+
+- [ ] **Step 2: Wire the new deps + callbacks in `extension.ts`**
+
+In `openimagedebugger-vscode/src/extension.ts`, add the enumerator import after the existing `DapClient` import (line 4):
+
+```ts
+import { listScopeSymbols } from './debugger/symbol-enumerator.js';
+```
+
+Add the `channel` and `listScopeSymbols` deps to the `new SessionManager({ ... })` object (alongside `sink: viewer,`):
+
+```ts
+    sink: viewer,
+    channel: viewer,
+    listScopeSymbols: async (frameId) => {
+      const session = activeSession();
+      if (!session) throw new Error('no active debug session');
+      const syms = await listScopeSymbols(new DapClient(session), frameId);
+      return syms.map((s) => s.name);
+    },
+```
+
+Immediately after the `const manager = new SessionManager({ ... });` block (before the DebugAdapterTracker registration), add the inbound handler and the per-session seed reset:
+
+```ts
+  viewer.onPlotBufferRequest((name) => {
+    if (stoppedThreadId === undefined) {
+      vscode.window.showWarningMessage('OID: pause in a debug session first.');
+      return;
+    }
+    void manager.onPlotBufferRequest(name, stoppedThreadId);
+  });
+
+  context.subscriptions.push(
+    vscode.debug.onDidStartDebugSession(() => manager.resetSeed())
+  );
+```
+
+- [ ] **Step 3: Compile and run the full test suite**
+
+Run: `cd /Users/bruno/ws/openimagedebugger-vscode && npm run compile && npm test`
+Expected: PASS — `tsc` produces no errors (including `src/extension.ts`); all unit suites green.
+
+- [ ] **Step 4: Manual verification (CodeLLDB → WASM viewer)**
+
+Prerequisites: OID testbench built; extension media (`oidwindow.js/.wasm`, `qtloader.js`) present in `media/`; CodeLLDB installed.
+
+1. Launch the Extension Development Host (F5) with a `launch.json` that debugs the OID `testbench` binary via CodeLLDB.
+2. Break in `testbench/main.cpp` inside `nest()`. Open the viewer (`OID: Open Viewer Panel`).
+   - Expect: the viewer's symbol search autocomplete lists `nest()`'s locals + arguments.
+3. In the viewer's symbol box, type `TestField` and pick it.
+   - Expect: `TestField` plots (viewer-initiated `PlotBufferRequest`).
+4. Set `"oid.watchOnStop": ["TestField"]`, restart the debug session, hit the breakpoint.
+   - Expect: `TestField` auto-plots on the first stop.
+5. Step/continue so values change.
+   - Expect: watched buffers re-plot with updated data.
+6. Remove `TestField` from the viewer's list, then step.
+   - Expect: `TestField` is **not** re-plotted (poll returns the smaller observed set).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/bruno/ws/openimagedebugger-vscode
+git add src/webview/panel.ts src/extension.ts
+git commit -m "feat(session): viewer channel + extension wiring for P3 session loop"
+```
+
+---
+
+## Plan self-review
+
+- **Spec coverage:**
+  - §3 `symbol-enumerator.ts` → Task 2. `SetAvailableSymbols` encode → Task 1; sent in loop → Task 3 (`setAvailableSymbols`) + Task 4 (`ViewerController.setAvailableSymbols`).
+  - §3/§4 `GetObservedSymbols` poll + `GetObservedSymbolsResponse` decode → Task 1 (codec) + Task 4 (poll/correlation in `ViewerController`).
+  - §3/§4 `PlotBufferRequest` inbound → Task 1 (decode) + Task 4 (`onPlotBufferRequest` dispatch + extension guard) + Task 3 (`onPlotBufferRequest`).
+  - §4 auto-replot of observed set + §2 first-stop `oid.watchOnStop` seed → Task 3 (`onStopped`, `union`, `seeded`, `resetSeed`).
+  - §5 request/response correlation + 1000 ms timeout → Task 4 (`getObservedSymbols`/`resolveObserved`).
+  - §6 error handling (enumeration failure, observed timeout, per-buffer skip) → Task 3 try/catch + Task 4 timeout; covered by session-manager tests.
+  - §8 persistence deferred → no task (intentional, per Global Constraints).
+- **Placeholder scan:** none — every code step shows full content; every command shows expected result.
+- **Type consistency:** `ViewerChannel` (Task 3) matches `ViewerController`'s `setAvailableSymbols`/`getObservedSymbols` (Task 4). `ScopeReader` (Task 2) is structurally satisfied by `DapClient.scopes`/`variables` (Task 2). `InboundMessage` kinds `'observedSymbols'`/`'plotRequest'`/`'unknown'` are produced in Task 1 and consumed in Task 4. `MessageType` numbers match OID `message_exchange.h`. `listScopeSymbols` returns `ScopeSymbol[]`; the extension dep maps to `string[]` for `SessionDeps.listScopeSymbols`, matching its `Promise<string[]>` signature.

--- a/docs/superpowers/plans/2026-06-24-oid-wasm-vscode-qt611.md
+++ b/docs/superpowers/plans/2026-06-24-oid-wasm-vscode-qt611.md
@@ -1,0 +1,1179 @@
+# OID WASM + VS Code Extension (Qt 6.11) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `oidwindow` for Qt 6.11 WebAssembly, refactor IPC onto `ITransport`, publish `@openimagedebugger/viewer-wasm`, and validate with a minimal VS Code extension smoke test using the **existing `MessageComposer` binary protocol** (no Protobuf).
+
+**Architecture:** Desktop keeps TCP via `TcpTransport`. WASM uses `PostMessageTransport` (JS queue + `window.oidSend`). `MessageComposer`/`MessageDecoder` are transport-agnostic. Extension encodes `PlotBufferContents` in TS with **wasm32 `size_t` (4-byte) length prefixes** and sends `{ type: 'oid-ipc', payload }` over postMessage.
+
+**Tech stack:** C++20, Qt 6.11 (desktop + WASM kit), Emscripten 4.0.7, CMake 3.28+, GTest; extension: TypeScript, VS Code Extension API.
+
+**Design spec:** `docs/superpowers/specs/2026-06-24-oid-wasm-vscode-qt611-design.md`
+
+---
+
+## File map — OID repository
+
+| File | Role |
+|------|------|
+| `common.cmake` | Qt 6.11 minimum |
+| `src/CMakeLists.txt` | Qt 6.11; conditional WASM target; skip OpenGL pkg on Emscripten |
+| `src/ipc/transport.h` | `ITransport` interface |
+| `src/ipc/tcp_transport.h` / `.cpp` | Desktop `QTcpSocket` adapter |
+| `src/ipc/postmessage_transport.h` / `.cpp` | WASM `EM_ASM` adapter + test queue |
+| `src/ipc/message_exchange.h` | `MessageComposer::send(ITransport&)`, `MessageDecoder(ITransport&)` |
+| `src/ipc/CMakeLists.txt` | Add transport sources |
+| `src/ui/messaging/message_handler.h` / `.cpp` | `ITransport&` in `Dependencies` |
+| `src/ui/main_window/main_window.h` / `.cpp` | Own `TcpTransport`; wire handler |
+| `src/ui/main_window/main_window_initializer.cpp` | TCP connect guarded by `#ifndef __EMSCRIPTEN__` |
+| `src/oid_window.cpp` | Emscripten entry: no TCP, viewer-ready handshake |
+| `src/ui/gl_canvas.cpp` | `GL_FRAMEBUFFER_EXT` → `GL_FRAMEBUFFER` |
+| `cmake/EmscriptenWasm.cmake` | EMSDK / Qt6_DIR validation |
+| `wasm/loader.html` | Qt loader + `oidSend`/`oidOnMessage` glue |
+| `wasm/package.json` | npm metadata |
+| `wasm/scripts/pack-viewer-wasm.sh` | Assemble `dist/` artifact |
+| `tests/test_transport.cpp` | `TcpTransport` + `PostMessageTransport` tests |
+| `tests/test_message_exchange.cpp` | Update to `TcpTransport` |
+| `tests/CMakeLists.txt` | Register `test_transport` |
+| `.github/workflows/build.yml` | Qt 6.11 on Windows |
+| `.github/workflows/wasm.yml` | WASM CI build |
+
+## File map — extension repository (`openimagedebugger-vscode`)
+
+| File | Role |
+|------|------|
+| `package.json` | `oid.openPanel` command |
+| `src/extension.ts` | Activation |
+| `src/ipc/message-exchange.ts` | TS `MessageComposer` (wasm32 lengths) |
+| `src/webview/panel.ts` | Webview + postMessage relay |
+| `test/message-exchange.test.ts` | Byte layout unit test |
+| `test/fixtures/sample_plot_buffer.bin` | Generated fixture |
+| `media/` | Copied WASM artifacts |
+
+---
+
+## Cross-bitness note (read before Task 8)
+
+Desktop `MessageComposer` uses native `sizeof(std::size_t)` (8 bytes on x64). Qt WASM (wasm32) uses **4-byte `size_t`**. The VS Code extension runs on x64 Node and must encode lengths as **uint32** when targeting WASM. Desktop TCP path is unchanged (bridge and viewer share arch). Task 8 implements `lengthBytes: 4` in the TS codec.
+
+---
+
+# Part I — OID repository
+
+### Task 1: Bump Qt minimum to 6.11
+
+**Files:**
+- Modify: `common.cmake`
+- Modify: `src/CMakeLists.txt`
+- Modify: `README.md`
+- Modify: `.github/workflows/build.yml`
+
+- [ ] **Step 1: Update CMake package requirements**
+
+In `common.cmake` line 35:
+
+```cmake
+find_package(Qt6 6.11 REQUIRED COMPONENTS Network)
+```
+
+In `src/CMakeLists.txt` line 35:
+
+```cmake
+find_package(Qt6 6.11 REQUIRED COMPONENTS Core Gui OpenGL OpenGLWidgets Widgets)
+```
+
+- [ ] **Step 2: Update README** — change `Qt **6.4.2+**` to `Qt **6.11+**`.
+
+- [ ] **Step 3: Update Windows CI Qt version** in `.github/workflows/build.yml`:
+
+```yaml
+version: "6.11.*"
+```
+
+- [ ] **Step 4: Build and test locally**
+
+Run: `cmake -S . -B build -DBUILD_TESTS=ON && cmake --build build --config Release && ctest --test-dir build --output-on-failure`
+
+Expected: PASS (requires Qt 6.11 installed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add common.cmake src/CMakeLists.txt README.md .github/workflows/build.yml
+git commit -m "build: require Qt 6.11 minimum"
+```
+
+---
+
+### Task 2: Introduce `ITransport` and `TcpTransport`
+
+**Files:**
+- Create: `src/ipc/transport.h`
+- Create: `src/ipc/tcp_transport.h`
+- Create: `src/ipc/tcp_transport.cpp`
+- Modify: `src/ipc/CMakeLists.txt`
+- Create: `tests/test_transport.cpp`
+- Modify: `tests/CMakeLists.txt`
+
+- [ ] **Step 1: Write failing transport test**
+
+```cpp
+// tests/test_transport.cpp
+#include <gtest/gtest.h>
+#include <QCoreApplication>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <array>
+#include <bit>
+#include <thread>
+#include <vector>
+
+#include "ipc/tcp_transport.h"
+
+namespace {
+QCoreApplication& app() {
+  static int argc = 1;
+  static std::array<char*, 2> argv = {const_cast<char*>("test"), nullptr};
+  static QCoreApplication application(argc, argv.data());
+  return application;
+}
+}  // namespace
+
+TEST(TcpTransport, RoundTripBytes) {
+  (void)app();
+  QTcpServer server;
+  ASSERT_TRUE(server.listen(QHostAddress::LocalHost));
+
+  std::vector<std::byte> server_received;
+  std::thread server_thread([&] {
+    ASSERT_TRUE(server.waitForNewConnection(5000));
+    QTcpSocket* peer = server.nextPendingConnection();
+    ASSERT_TRUE(peer->waitForReadyRead(5000));
+    const QByteArray data = peer->readAll();
+    server_received.assign(
+        reinterpret_cast<const std::byte*>(data.constData()),
+        reinterpret_cast<const std::byte*>(data.constData()) + data.size());
+    peer->write(data);
+    peer->waitForBytesWritten(5000);
+    peer->close();
+    delete peer;
+  });
+
+  QTcpSocket client;
+  client.connectToHost(QHostAddress::LocalHost, server.serverPort());
+  ASSERT_TRUE(client.waitForConnected(5000));
+
+  oid::TcpTransport transport(client);
+  const std::vector<std::byte> sent{std::byte{0x03}, std::byte{0x01}};
+  transport.send(sent);
+
+  std::array<std::byte, 2> buf{};
+  const auto n = transport.receive(buf);
+  EXPECT_EQ(n, 2u);
+  EXPECT_EQ(buf[0], std::byte{0x03});
+  EXPECT_EQ(buf[1], std::byte{0x01});
+  EXPECT_EQ(server_received, sent);
+
+  server_thread.join();
+}
+```
+
+- [ ] **Step 2: Run test — expect failure**
+
+Run: `cmake -S . -B build -DBUILD_TESTS=ON && cmake --build build --target test_transport 2>&1 | tail -3`
+
+Expected: build error (missing `tcp_transport.h`)
+
+- [ ] **Step 3: Implement transport interface**
+
+```cpp
+// src/ipc/transport.h
+#ifndef IPC_TRANSPORT_H_
+#define IPC_TRANSPORT_H_
+
+#include <cstddef>
+#include <span>
+
+namespace oid {
+
+class ITransport {
+ public:
+  virtual ~ITransport() = default;
+  virtual void send(std::span<const std::byte> data) = 0;
+  virtual std::size_t receive(std::span<std::byte> dst) = 0;
+  virtual bool has_data() const = 0;
+};
+
+}  // namespace oid
+
+#endif
+```
+
+```cpp
+// src/ipc/tcp_transport.h
+#ifndef IPC_TCP_TRANSPORT_H_
+#define IPC_TCP_TRANSPORT_H_
+
+#include "ipc/transport.h"
+
+class QTcpSocket;
+
+namespace oid {
+
+class TcpTransport final : public ITransport {
+ public:
+  explicit TcpTransport(QTcpSocket& socket);
+
+  void send(std::span<const std::byte> data) override;
+  std::size_t receive(std::span<std::byte> dst) override;
+  bool has_data() const override;
+
+ private:
+  QTcpSocket& socket_;
+};
+
+}  // namespace oid
+
+#endif
+```
+
+```cpp
+// src/ipc/tcp_transport.cpp
+#include "ipc/tcp_transport.h"
+
+#include <bit>
+
+#include <QAbstractSocket>
+#include <QTcpSocket>
+
+#include "ipc/message_exchange.h"  // SocketTimeoutError
+
+namespace oid {
+
+TcpTransport::TcpTransport(QTcpSocket& socket) : socket_{socket} {}
+
+void TcpTransport::send(std::span<const std::byte> data) {
+  auto offset = qint64{0};
+  const auto total = static_cast<qint64>(data.size());
+  while (offset < total) {
+    offset += socket_.write(std::bit_cast<const char*>(data.data() + offset),
+                            total - offset);
+    if (offset < total && !socket_.waitForBytesWritten(5000)) {
+      throw_socket_timeout_error("write");
+    }
+  }
+  if (!socket_.waitForBytesWritten(5000)) {
+    throw_socket_timeout_error("write");
+  }
+}
+
+std::size_t TcpTransport::receive(std::span<std::byte> dst) {
+  auto offset = std::size_t{0};
+  while (offset < dst.size()) {
+    if (!has_data() && !socket_.waitForReadyRead(5000)) {
+      throw_socket_timeout_error("read");
+    }
+    const auto n = socket_.read(
+        std::bit_cast<char*>(dst.data() + offset),
+        static_cast<qint64>(dst.size() - offset));
+    if (n < 0) {
+      throw_socket_timeout_error("read");
+    }
+    if (n == 0) {
+      break;
+    }
+    offset += static_cast<std::size_t>(n);
+  }
+  return offset;
+}
+
+bool TcpTransport::has_data() const {
+  return socket_.bytesAvailable() > 0;
+}
+
+}  // namespace oid
+```
+
+- [ ] **Step 4: Wire into `src/ipc/CMakeLists.txt`**
+
+```cmake
+add_library(${PROJECT_NAME} SHARED
+            message_exchange.cpp
+            raw_data_decode.cpp
+            tcp_transport.cpp)
+```
+
+- [ ] **Step 5: Register test in `tests/CMakeLists.txt`**
+
+```cmake
+add_executable(test_transport test_transport.cpp)
+target_include_directories(test_transport PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+target_link_libraries(test_transport PRIVATE Qt6::Network Qt6::Core GTest::gtest_main GTest::gtest)
+target_sources(test_transport PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ipc/tcp_transport.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ipc/message_exchange.cpp)
+add_test(NAME TransportTests COMMAND test_transport)
+```
+
+- [ ] **Step 6: Run test**
+
+Run: `cmake --build build --target test_transport && ctest --test-dir build -R TransportTests -V`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ipc/transport.h src/ipc/tcp_transport.h src/ipc/tcp_transport.cpp \
+        src/ipc/CMakeLists.txt tests/test_transport.cpp tests/CMakeLists.txt
+git commit -m "feat(ipc): add ITransport and TcpTransport"
+```
+
+---
+
+### Task 3: Refactor `MessageComposer` / `MessageDecoder` to use `ITransport`
+
+**Files:**
+- Modify: `src/ipc/message_exchange.h`
+- Modify: `tests/test_message_exchange.cpp`
+
+- [ ] **Step 1: Replace `QTcpSocket` with `ITransport` in `message_exchange.h`**
+
+Add include:
+
+```cpp
+#include "ipc/transport.h"
+```
+
+Remove `#include <QTcpSocket>` and `QPointer`.
+
+Change `MessageComposer::send`:
+
+```cpp
+void send(ITransport& transport) const {
+  for (const auto& block : message_blocks_) {
+    transport.send(std::span{block->data(), block->size()});
+  }
+}
+```
+
+Change `MessageDecoder`:
+
+```cpp
+class MessageDecoder {
+ public:
+  explicit MessageDecoder(ITransport& transport) : transport_{transport} {}
+
+  // ... template read methods unchanged ...
+
+ private:
+  ITransport& transport_;
+
+  void read_impl(std::span<std::byte> dst) const {
+    auto offset = std::size_t{0};
+    while (offset < dst.size()) {
+      const auto n = transport_.receive(dst.subspan(offset));
+      if (n == 0) {
+        throw_socket_timeout_error("read");
+      }
+      offset += n;
+    }
+  }
+};
+```
+
+- [ ] **Step 2: Update `tests/test_message_exchange.cpp`**
+
+Add `#include "ipc/tcp_transport.h"`. Replace every:
+
+```cpp
+composer.push(...).send(client_socket_.get());
+```
+
+with:
+
+```cpp
+oid::TcpTransport client_transport(*client_socket_);
+composer.push(...).send(client_transport);
+```
+
+Replace every:
+
+```cpp
+MessageDecoder decoder(server_socket_);
+```
+
+with:
+
+```cpp
+oid::TcpTransport server_transport(server_socket_);
+MessageDecoder decoder(server_transport);
+```
+
+- [ ] **Step 3: Run message exchange tests**
+
+Run: `cmake --build build --target test_message_exchange && ctest --test-dir build -R MessageExchangeTests -V`
+
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ipc/message_exchange.h tests/test_message_exchange.cpp
+git commit -m "refactor(ipc): MessageComposer/Decoder use ITransport"
+```
+
+---
+
+### Task 4: Wire `MessageHandler` and `MainWindow` to `ITransport`
+
+**Files:**
+- Modify: `src/ui/messaging/message_handler.h`
+- Modify: `src/ui/messaging/message_handler.cpp`
+- Modify: `src/ui/main_window/main_window.h`
+- Modify: `src/ui/main_window/main_window.cpp`
+
+- [ ] **Step 1: Update `MessageHandler::Dependencies`**
+
+In `message_handler.h`:
+
+```cpp
+#include "ipc/transport.h"
+// remove: class QTcpSocket;
+
+struct Dependencies {
+  // ...
+  ITransport& transport;  // was: QTcpSocket& socket
+  // ...
+};
+```
+
+- [ ] **Step 2: Update `message_handler.cpp`**
+
+Replace all `deps_.socket` with `deps_.transport`:
+
+- `MessageDecoder{&deps_.socket}` → `MessageDecoder{deps_.transport}`
+- `message_composer.send(&deps_.socket)` → `message_composer.send(deps_.transport)`
+- `decode_incoming_messages`: replace `deps_.socket.bytesAvailable()` with `deps_.transport.has_data()`
+- Header read:
+
+```cpp
+auto header = MessageType{};
+std::array<std::byte, sizeof(header)> header_bytes{};
+if (deps_.transport.receive(header_bytes) != header_bytes.size()) {
+  return;
+}
+header = std::bit_cast<MessageType>(header_bytes);
+```
+
+Remove socket error/close handling in WASM builds (`#ifndef __EMSCRIPTEN__` guard the close path).
+
+- [ ] **Step 3: Update `main_window.h`**
+
+```cpp
+#include "ipc/tcp_transport.h"
+
+// keep QTcpSocket socket_{}; for desktop TCP
+std::unique_ptr<TcpTransport> transport_;
+```
+
+- [ ] **Step 4: Update `main_window.cpp` constructor**
+
+After `socket_` is ready (existing initializer connects it):
+
+```cpp
+transport_ = std::make_unique<TcpTransport>(socket_);
+// MessageHandler deps: *transport_ instead of socket_
+```
+
+- [ ] **Step 5: Build desktop target**
+
+Run: `cmake --build build --target oidwindow && ctest --test-dir build --output-on-failure`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui/messaging/message_handler.h src/ui/messaging/message_handler.cpp \
+        src/ui/main_window/main_window.h src/ui/main_window/main_window.cpp
+git commit -m "refactor(ui): MessageHandler uses ITransport"
+```
+
+---
+
+### Task 5: `PostMessageTransport` with queue-based tests
+
+**Files:**
+- Create: `src/ipc/postmessage_transport.h`
+- Create: `src/ipc/postmessage_transport.cpp`
+- Modify: `src/ipc/CMakeLists.txt`
+- Modify: `tests/test_transport.cpp`
+
+- [ ] **Step 1: Add failing queue transport test**
+
+Append to `tests/test_transport.cpp`:
+
+```cpp
+#include "ipc/postmessage_transport.h"
+
+TEST(PostMessageTransport, QueuesSendAndReceive) {
+  oid::PostMessageTransport transport;
+  const std::vector<std::byte> msg{std::byte{0x03}, std::byte{0xAA}};
+  transport.send(msg);
+
+  std::array<std::byte, 2> out{};
+  EXPECT_EQ(transport.receive(out), 2u);
+  EXPECT_EQ(out[0], std::byte{0x03});
+  EXPECT_EQ(out[1], std::byte{0xAA});
+}
+```
+
+- [ ] **Step 2: Implement queue transport (shared by tests and WASM)**
+
+```cpp
+// src/ipc/postmessage_transport.h
+#ifndef IPC_POSTMESSAGE_TRANSPORT_H_
+#define IPC_POSTMESSAGE_TRANSPORT_H_
+
+#include <deque>
+#include <mutex>
+#include <vector>
+
+#include "ipc/transport.h"
+
+namespace oid {
+
+class PostMessageTransport final : public ITransport {
+ public:
+  void send(std::span<const std::byte> data) override;
+  std::size_t receive(std::span<std::byte> dst) override;
+  bool has_data() const override;
+
+  void enqueue_inbound(std::vector<std::byte> data);
+
+ private:
+  mutable std::mutex mutex_;
+  std::deque<std::byte> inbound_;
+};
+
+}  // namespace oid
+
+#endif
+```
+
+```cpp
+// src/ipc/postmessage_transport.cpp
+#include "ipc/postmessage_transport.h"
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
+namespace oid {
+
+void PostMessageTransport::send(std::span<const std::byte> data) {
+#ifdef __EMSCRIPTEN__
+  // EM_ASM passes Uint8Array to window.oidSend
+  EM_ASM({ window.oidSend(HEAPU8.slice($0, $0 + $1)); }, data.data(), data.size());
+#else
+  (void)data;
+#endif
+}
+
+std::size_t PostMessageTransport::receive(std::span<std::byte> dst) {
+  std::scoped_lock lock(mutex_);
+  std::size_t n = 0;
+  while (n < dst.size() && !inbound_.empty()) {
+    dst[n++] = inbound_.front();
+    inbound_.pop_front();
+  }
+  return n;
+}
+
+bool PostMessageTransport::has_data() const {
+  std::scoped_lock lock(mutex_);
+  return !inbound_.empty();
+}
+
+void PostMessageTransport::enqueue_inbound(std::vector<std::byte> data) {
+  std::scoped_lock lock(mutex_);
+  inbound_.insert(inbound_.end(), data.begin(), data.end());
+}
+
+}  // namespace oid
+```
+
+- [ ] **Step 3: Add to `src/ipc/CMakeLists.txt`**
+
+```cmake
+target_sources(${PROJECT_NAME} PRIVATE postmessage_transport.cpp)
+```
+
+- [ ] **Step 4: Extend test CMake target sources**
+
+Add `postmessage_transport.cpp` to `test_transport` sources.
+
+- [ ] **Step 5: Run tests**
+
+Run: `ctest --test-dir build -R TransportTests -V`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ipc/postmessage_transport.h src/ipc/postmessage_transport.cpp \
+        src/ipc/CMakeLists.txt tests/test_transport.cpp tests/CMakeLists.txt
+git commit -m "feat(ipc): add PostMessageTransport with inbound queue"
+```
+
+---
+
+### Task 6: WebGL / GLES compatibility fixes
+
+**Files:**
+- Modify: `src/ui/gl_canvas.cpp`
+
+- [ ] **Step 1: Replace legacy FBO constants**
+
+In `src/ui/gl_canvas.cpp`, replace all three occurrences:
+
+```cpp
+glBindFramebuffer(GL_FRAMEBUFFER_EXT, 0);
+// →
+glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+glBindFramebuffer(GL_FRAMEBUFFER_EXT, icon_fbo_);
+// →
+glBindFramebuffer(GL_FRAMEBUFFER, icon_fbo_);
+```
+
+- [ ] **Step 2: Build and run desktop tests**
+
+Run: `cmake --build build --target oidwindow && ctest --test-dir build --output-on-failure`
+
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/ui/gl_canvas.cpp
+git commit -m "fix(gl): use GL_FRAMEBUFFER for WebGL compatibility"
+```
+
+---
+
+### Task 7: WASM build scaffolding
+
+**Files:**
+- Create: `cmake/EmscriptenWasm.cmake`
+- Modify: `src/CMakeLists.txt`
+- Modify: `src/ui/main_window/main_window_initializer.cpp`
+- Modify: `src/oid_window.cpp`
+
+- [ ] **Step 1: Create `cmake/EmscriptenWasm.cmake`**
+
+```cmake
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  return()
+endif()
+
+if(NOT DEFINED ENV{EMSDK})
+  message(FATAL_ERROR "EMSDK not set. Run: source emsdk_env.sh")
+endif()
+
+if(NOT Qt6_DIR)
+  message(FATAL_ERROR "Set -DQt6_DIR=/path/to/qt6-wasm/lib/cmake/Qt6")
+endif()
+
+add_compile_definitions(OID_TRANSPORT_POSTMESSAGE)
+```
+
+- [ ] **Step 2: Guard TCP connect in `main_window_initializer.cpp`**
+
+Wrap `deps_.socket.connectToHost(...)` and `waitForConnected()` in:
+
+```cpp
+#ifndef __EMSCRIPTEN__
+  deps_.socket.connectToHost(...);
+  deps_.socket.waitForConnected();
+#endif
+```
+
+- [ ] **Step 3: Emscripten `main_window` uses `PostMessageTransport`**
+
+In `main_window.cpp`:
+
+```cpp
+#ifdef __EMSCRIPTEN__
+  postmessage_transport_ = std::make_unique<PostMessageTransport>();
+  transport_ = std::unique_ptr<ITransport>(postmessage_transport_.get());
+#else
+  transport_ = std::make_unique<TcpTransport>(socket_);
+#endif
+```
+
+Add member `std::unique_ptr<PostMessageTransport> postmessage_transport_;` (WASM only via `#ifdef` or always present).
+
+- [ ] **Step 4: Emscripten entry in `oid_window.cpp`**
+
+```cpp
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#include "ipc/postmessage_transport.h"
+#endif
+
+int main(int argc, char* argv[]) {
+  auto app = QApplication{argc, argv};
+
+#ifndef __EMSCRIPTEN__
+  // existing parser + ConnectionSettings
+  auto window = oid::MainWindow{host_settings};
+#else
+  oid::ConnectionSettings host_settings{};  // unused
+  auto window = oid::MainWindow{host_settings};
+  EM_ASM({
+    window.oidOnMessage = function(buf) {
+      Module.oidEnqueueInbound(buf);
+    };
+    window.parent.postMessage({type:'oid-control', event:'viewer-ready', version:'dev'}, '*');
+  });
+#endif
+
+  window.showWindow();
+  return QApplication::exec();
+}
+```
+
+- [ ] **Step 5: Export `oidEnqueueInbound` from WASM** — add to `postmessage_transport.cpp`:
+
+```cpp
+#ifdef __EMSCRIPTEN__
+namespace {
+PostMessageTransport* g_transport = nullptr;
+}
+
+extern "C" void oid_set_postmessage_transport(PostMessageTransport* t) {
+  g_transport = t;
+}
+
+extern "C" void oidEnqueueInbound(uintptr_t ptr, int len) {
+  if (!g_transport) return;
+  const auto* data = reinterpret_cast<const std::byte*>(ptr);
+  g_transport->enqueue_inbound({data, data + len});
+}
+#endif
+```
+
+Call `oid_set_postmessage_transport(postmessage_transport_.get())` from `MainWindow` constructor on Emscripten.
+
+- [ ] **Step 6: Skip desktop OpenGL package on Emscripten** in `src/CMakeLists.txt`:
+
+```cmake
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  set(OpenGL_GL_PREFERENCE LEGACY)
+  find_package(OpenGL 2.1 REQUIRED)
+endif()
+```
+
+Wrap `${OPENGL_gl_LIBRARY}` link similarly.
+
+- [ ] **Step 7: Document local WASM build command** (verify manually when Qt 6.11 WASM + emsdk 4.0.7 installed):
+
+```bash
+source /path/to/emsdk/emsdk_env.sh   # Emscripten 4.0.7
+/path/to/qt6-wasm/bin/qt-cmake -S . -B build-wasm -DCMAKE_BUILD_TYPE=Release
+cmake --build build-wasm --target oidwindow
+```
+
+Expected: produces `build-wasm/oidwindow.js` and `oidwindow.wasm`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cmake/EmscriptenWasm.cmake src/CMakeLists.txt src/oid_window.cpp \
+        src/ui/main_window/main_window.cpp src/ui/main_window/main_window_initializer.cpp \
+        src/ipc/postmessage_transport.cpp src/ipc/postmessage_transport.h
+git commit -m "feat(wasm): add Emscripten build scaffolding and postMessage entry"
+```
+
+---
+
+### Task 8: WASM loader, npm package, CI
+
+**Files:**
+- Create: `wasm/loader.html`
+- Create: `wasm/package.json`
+- Create: `wasm/scripts/pack-viewer-wasm.sh`
+- Create: `.github/workflows/wasm.yml`
+
+- [ ] **Step 1: Create `wasm/loader.html`**
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Open Image Debugger</title>
+  <script src="qtloader.js"></script>
+</head>
+<body>
+  <div id="qtspinner"></div>
+  <canvas id="qtcanvas"></canvas>
+  <script>
+    window.oidSend = function(u8) {
+      window.parent.postMessage({ type: 'oid-ipc', payload: u8 }, '*');
+    };
+    window.addEventListener('message', (ev) => {
+      if (ev.data?.type === 'oid-ipc' && ev.data.payload) {
+        if (window.oidOnMessage) window.oidOnMessage(ev.data.payload);
+      }
+    });
+    const loader = new QtLoader({
+      path: '.',
+      entryFunction: 'oidwindow',
+      canvas: document.getElementById('qtcanvas'),
+    });
+    loader.loadEmscriptenModule('oidwindow');
+  </script>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Create `wasm/package.json`**
+
+```json
+{
+  "name": "@openimagedebugger/viewer-wasm",
+  "version": "0.0.0-dev",
+  "description": "Qt 6.11 WASM build of oidwindow",
+  "files": ["dist"],
+  "license": "MIT"
+}
+```
+
+- [ ] **Step 3: Create `wasm/scripts/pack-viewer-wasm.sh`**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+DIST="$ROOT/wasm/dist"
+rm -rf "$DIST" && mkdir -p "$DIST"
+cp "$ROOT/build-wasm/oidwindow.wasm" "$ROOT/build-wasm/oidwindow.js" "$DIST/"
+cp "$ROOT/wasm/loader.html" "$DIST/"
+# Copy Qt WASM runtime files emitted beside oidwindow.js (qtloader.js, etc.)
+cp "$ROOT/build-wasm"/qt*.js "$ROOT/build-wasm"/qt*.wasm "$DIST/" 2>/dev/null || true
+echo '{"qt":"6.11","emscripten":"4.0.7","oid":"dev"}' > "$DIST/version.json"
+```
+
+- [ ] **Step 4: Create `.github/workflows/wasm.yml`**
+
+```yaml
+name: WASM Build
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  wasm:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install emsdk 4.0.7
+        run: |
+          git clone https://github.com/emscripten-core/emsdk.git /opt/emsdk
+          /opt/emsdk/emsdk install 4.0.7
+          /opt/emsdk/emsdk activate 4.0.7
+          echo "EMSDK=/opt/emsdk" >> "$GITHUB_ENV"
+          echo "/opt/emsdk/upstream/emscripten" >> "$GITHUB_PATH"
+
+      - name: Install Qt 6.11 WASM
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: "6.11.*"
+          arch: "wasm_singlethread"
+          modules: "qtshadertools"
+          cache: true
+
+      - name: Build WASM
+        run: |
+          qt-cmake -S . -B build-wasm -DCMAKE_BUILD_TYPE=Release
+          cmake --build build-wasm --target oidwindow
+
+      - name: Pack artifact
+        run: bash wasm/scripts/pack-viewer-wasm.sh
+
+      - name: Upload dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: viewer-wasm
+          path: wasm/dist
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wasm/ .github/workflows/wasm.yml
+git commit -m "ci(wasm): add loader, pack script, and WASM build workflow"
+```
+
+---
+
+# Part II — Extension smoke stub
+
+### Task 9: Scaffold `openimagedebugger-vscode`
+
+**Files:**
+- Create: `openimagedebugger-vscode/package.json`
+- Create: `openimagedebugger-vscode/tsconfig.json`
+- Create: `openimagedebugger-vscode/src/extension.ts`
+- Create: `openimagedebugger-vscode/src/webview/panel.ts`
+
+> Create this directory **outside** the OID repo (sibling directory) or in a separate git repo per design spec.
+
+- [ ] **Step 1: Create `package.json`**
+
+```json
+{
+  "name": "openimagedebugger-vscode",
+  "displayName": "Open Image Debugger",
+  "version": "0.0.1",
+  "engines": { "vscode": "^1.85.0" },
+  "activationEvents": ["onCommand:oid.openPanel"],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [{
+      "command": "oid.openPanel",
+      "title": "OID: Open Viewer Panel"
+    }]
+  },
+  "scripts": {
+    "compile": "tsc -p .",
+    "test": "node --test out/test/*.js"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.85.0",
+    "typescript": "^5.4.0"
+  }
+}
+```
+
+- [ ] **Step 2: Create `src/extension.ts`**
+
+```typescript
+import * as vscode from 'vscode';
+import { openViewerPanel } from './webview/panel';
+
+export function activate(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('oid.openPanel', () => openViewerPanel(context))
+  );
+}
+
+export function deactivate(): void {}
+```
+
+- [ ] **Step 3: Create `src/webview/panel.ts`**
+
+```typescript
+import * as vscode from 'vscode';
+import { buildPlotBufferContents, type WasmLengthMode } from '../ipc/message-exchange';
+
+export function openViewerPanel(context: vscode.ExtensionContext): void {
+  const panel = vscode.window.createWebviewPanel(
+    'oidViewer', 'Open Image Debugger', vscode.ViewColumn.One,
+    { enableScripts: true, localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, 'media')] }
+  );
+
+  const loaderUri = panel.webview.asWebviewUri(
+    vscode.Uri.joinPath(context.extensionUri, 'media', 'loader.html')
+  );
+  panel.webview.html = `<!DOCTYPE html><html><body style="margin:0">
+    <iframe src="${loaderUri}" style="width:100%;height:100vh;border:none"></iframe>
+  </body></html>`;
+
+  panel.webview.onDidReceiveMessage((msg) => {
+    if (msg?.type === 'oid-control' && msg.event === 'viewer-ready') {
+      const payload = buildPlotBufferContents({
+        variableName: 'test',
+        displayName: 'test',
+        pixelLayout: 'rgba',
+        transpose: false,
+        width: 2,
+        height: 2,
+        channels: 3,
+        stride: 6,
+        bufferType: 0,
+        pixels: new Uint8Array([255, 0, 0, 0, 255, 0, 0, 0, 255, 128, 128, 128]),
+      }, 'wasm32' satisfies WasmLengthMode);
+      panel.webview.postMessage({ type: 'oid-ipc', payload });
+    }
+  });
+}
+```
+
+- [ ] **Step 4: Compile**
+
+Run: `cd openimagedebugger-vscode && npm install && npm run compile`
+
+Expected: no TypeScript errors (after Task 10 adds `message-exchange.ts`)
+
+- [ ] **Step 5: Commit** (in extension repo)
+
+```bash
+git init openimagedebugger-vscode && cd openimagedebugger-vscode
+git add package.json tsconfig.json src/
+git commit -m "feat: scaffold VS Code extension smoke stub"
+```
+
+---
+
+### Task 10: TypeScript `MessageComposer` (wasm32 lengths)
+
+**Files:**
+- Create: `openimagedebugger-vscode/src/ipc/message-exchange.ts`
+- Create: `openimagedebugger-vscode/test/message-exchange.test.ts`
+
+- [ ] **Step 1: Write failing unit test**
+
+```typescript
+// test/message-exchange.test.ts
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { buildPlotBufferContents, MessageType } from '../src/ipc/message-exchange.js';
+
+test('PlotBufferContents starts with message type 3', () => {
+  const bytes = buildPlotBufferContents({
+    variableName: 'img',
+    displayName: 'img',
+    pixelLayout: 'rgba',
+    transpose: false,
+    width: 1,
+    height: 1,
+    channels: 3,
+    stride: 3,
+    bufferType: 0,
+    pixels: new Uint8Array([1, 2, 3]),
+  }, 'wasm32');
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  assert.equal(view.getUint32(0, true), MessageType.PlotBufferContents);
+});
+```
+
+- [ ] **Step 2: Implement codec**
+
+```typescript
+// src/ipc/message-exchange.ts
+export enum MessageType {
+  PlotBufferContents = 3,
+}
+
+export type WasmLengthMode = 'wasm32' | 'native';
+
+export interface PlotBufferParams {
+  variableName: string;
+  displayName: string;
+  pixelLayout: string;
+  transpose: boolean;
+  width: number;
+  height: number;
+  channels: number;
+  stride: number;
+  bufferType: number;
+  pixels: Uint8Array;
+}
+
+function pushU32(buf: number[], v: number): void {
+  buf.push(v & 0xff, (v >> 8) & 0xff, (v >> 16) & 0xff, (v >> 24) & 0xff);
+}
+
+function pushString(buf: number[], s: string, mode: WasmLengthMode): void {
+  const bytes = new TextEncoder().encode(s);
+  if (mode === 'wasm32') pushU32(buf, bytes.length);
+  else throw new Error('native mode not implemented for extension');
+  for (const b of bytes) buf.push(b);
+}
+
+export function buildPlotBufferContents(p: PlotBufferParams, mode: WasmLengthMode): Uint8Array {
+  const parts: number[] = [];
+  pushU32(parts, MessageType.PlotBufferContents);
+  pushString(parts, p.variableName, mode);
+  pushString(parts, p.displayName, mode);
+  pushString(parts, p.pixelLayout, mode);
+  parts.push(p.transpose ? 1 : 0, 0, 0, 0); // bool as 4 bytes (bool PrimitiveBlock)
+  pushU32(parts, p.width);
+  pushU32(parts, p.height);
+  pushU32(parts, p.channels);
+  pushU32(parts, p.stride);
+  pushU32(parts, p.bufferType);
+  pushU32(parts, p.pixels.length);
+  for (const b of p.pixels) parts.push(b);
+  return new Uint8Array(parts);
+}
+```
+
+> **Note:** Verify `bool` wire size matches C++ `PrimitiveBlock<bool>` (1 byte on most platforms). Adjust test after checking `sizeof(bool)` in `message_exchange.h` — if 1 byte, push single `p.transpose ? 1 : 0` instead of 4.
+
+- [ ] **Step 3: Run test**
+
+Run: `npm run compile && npm test`
+
+Expected: PASS (fix bool width if test fails)
+
+- [ ] **Step 4: Copy WASM artifact into `media/`**
+
+```bash
+cp -r ../OpenImageDebugger/wasm/dist/* openimagedebugger-vscode/media/
+```
+
+- [ ] **Step 5: Manual smoke test**
+
+1. Open extension folder in VS Code
+2. Press F5 (Extension Development Host)
+3. Run command **OID: Open Viewer Panel**
+4. Expect: WASM loads, 2×2 test image appears
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ipc/message-exchange.ts test/
+git commit -m "feat(ipc): add wasm32 MessageComposer for PlotBufferContents"
+```
+
+---
+
+## Plan self-review
+
+| Spec requirement | Task |
+|------------------|------|
+| Qt 6.11 + Emscripten 4.0.7 | Tasks 1, 8 |
+| Custom IPC (no Protobuf) | Tasks 3–5, 10 |
+| `ITransport` abstraction | Tasks 2–5 |
+| Desktop regression on Qt 6.11 | Task 1, 4 |
+| WASM build + npm artifact | Tasks 7–8 |
+| WebGL compat | Task 6 |
+| Extension smoke stub | Tasks 9–10 |
+| wasm32 length encoding | Task 10 (cross-bitness note) |
+| Qt 6.12 upgrade path | Documented in spec §5.5 (no task — future) |
+
+**Placeholder scan:** None found.
+
+**Type consistency:** `ITransport::receive` returns `std::size_t` throughout Tasks 2–5. `MessageHandler` uses `ITransport&` consistently.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-24-oid-wasm-vscode-qt611.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks, fast iteration
+2. **Inline Execution** — run tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/superpowers/plans/2026-06-27-oid-editor-split-view.md
+++ b/docs/superpowers/plans/2026-06-27-oid-editor-split-view.md
@@ -1,0 +1,263 @@
+# OID Editor Split Viewer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the OID viewer from the activity-bar `WebviewView` to a `WebviewPanel` that opens beside the active editor on first debugger stop.
+
+**Architecture:** Refactor `ViewerController` to own a singleton `WebviewPanel` with `ViewColumn.Beside` (fallback `ViewColumn.Two`). Remove sidebar contributions from `package.json` and `registerWebviewViewProvider` from `extension.ts`. Session lifecycle disposes the panel when debugging ends.
+
+**Tech Stack:** TypeScript, VS Code Extension API (`WebviewPanel`, `ViewColumn`), existing WASM loader HTML in `panel.ts`.
+
+**Spec:** `docs/superpowers/specs/2026-06-27-oid-editor-split-view-design.md`
+
+**Repo:** `openimagedebugger-vscode` (sibling of `OpenImageDebugger`)
+
+---
+
+## File map
+
+| File | Action |
+|------|--------|
+| `openimagedebugger-vscode/package.json` | Remove sidebar `viewsContainers` / `views` |
+| `openimagedebugger-vscode/src/webview/panel.ts` | `WebviewView` → `WebviewPanel` |
+| `openimagedebugger-vscode/src/extension.ts` | Wire `openBeside` / `dispose`; drop view provider |
+
+---
+
+### Task 1: Remove sidebar manifest entries
+
+**Files:**
+- Modify: `openimagedebugger-vscode/package.json`
+
+- [ ] **Step 1: Edit `package.json`**
+
+Remove the entire `viewsContainers` and `views` blocks under `contributes`. The `contributes` section should look like:
+
+```json
+  "contributes": {
+    "commands": [
+      { "command": "oid.openPanel", "title": "OID: Open Viewer Panel" },
+      { "command": "oid.plot", "title": "OID: Plot Variable" },
+      { "command": "oid.clearWatch", "title": "OID: Clear Live Watches" }
+    ],
+    "configuration": {
+      "title": "Open Image Debugger",
+      "properties": {
+        "oid.watchOnStop": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Variable names to plot automatically on every debugger stop."
+        }
+      }
+    }
+  },
+```
+
+- [ ] **Step 2: Verify JSON**
+
+Run: `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('ok')"`  
+Expected: `ok`
+
+---
+
+### Task 2: Refactor ViewerController to WebviewPanel
+
+**Files:**
+- Modify: `openimagedebugger-vscode/src/webview/panel.ts`
+
+- [ ] **Step 1: Replace the class at the bottom of `panel.ts`**
+
+Delete `export class ViewerController implements vscode.WebviewViewProvider { ... }` and replace with:
+
+```typescript
+function targetColumn(): vscode.ViewColumn {
+  return vscode.window.activeTextEditor
+    ? vscode.ViewColumn.Beside
+    : vscode.ViewColumn.Two;
+}
+
+/**
+ * Owns the single viewer webview (local WASM) in an editor split and forwards
+ * encoded PlotBufferContents frames.
+ */
+export class ViewerController {
+  static readonly panelType = 'oid.viewer';
+
+  private panel: vscode.WebviewPanel | undefined;
+  private ready = false;
+  private readonly readyWaiters: Array<() => void> = [];
+
+  constructor(private readonly context: vscode.ExtensionContext) {}
+
+  /** Open or focus the viewer beside the active editor without stealing focus. */
+  openBeside(): void {
+    const column = targetColumn();
+    if (this.panel) {
+      this.panel.reveal(column, true);
+      return;
+    }
+    const media = vscode.Uri.joinPath(this.context.extensionUri, 'media');
+    const panel = vscode.window.createWebviewPanel(
+      ViewerController.panelType,
+      'Open Image Debugger',
+      column,
+      {
+        retainContextWhenHidden: true,
+        enableScripts: true,
+        localResourceRoots: [media],
+      }
+    );
+    panel.webview.html = htmlFor(panel.webview, media);
+    panel.webview.onDidReceiveMessage((msg) => {
+      if (msg?.type === 'oid-control' && msg.event === 'viewer-ready') {
+        this.ready = true;
+        for (const w of this.readyWaiters.splice(0)) w();
+      }
+    });
+    panel.onDidDispose(() => {
+      this.panel = undefined;
+      this.ready = false;
+      for (const w of this.readyWaiters.splice(0)) w();
+    });
+    this.panel = panel;
+  }
+
+  dispose(): void {
+    this.panel?.dispose();
+    this.panel = undefined;
+    this.ready = false;
+    for (const w of this.readyWaiters.splice(0)) w();
+  }
+
+  ensureReady(): Promise<void> {
+    if (this.ready) return Promise.resolve();
+    this.openBeside();
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(new Error('Viewer did not become ready'));
+      }, READY_TIMEOUT_MS);
+      this.readyWaiters.push(() => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  }
+
+  async sendPlotBuffer(bytes: Uint8Array): Promise<void> {
+    await this.ensureReady();
+    this.panel?.webview.postMessage({ type: 'oid-ipc-forward', payload: Array.from(bytes) });
+  }
+}
+```
+
+- [ ] **Step 2: Update the file header comment**
+
+Replace the old `WebviewView` / secondary sidebar comment block (lines 116–123) — it is removed by the replacement above.
+
+- [ ] **Step 3: Compile**
+
+Run: `cd openimagedebugger-vscode && npm run compile`  
+Expected: errors in `extension.ts` until Task 3 (expected temporarily)
+
+---
+
+### Task 3: Wire extension.ts
+
+**Files:**
+- Modify: `openimagedebugger-vscode/src/extension.ts`
+
+- [ ] **Step 1: Remove WebviewViewProvider registration**
+
+Delete this block entirely:
+
+```typescript
+  context.subscriptions.push(
+    vscode.window.registerWebviewViewProvider(ViewerController.viewId, viewer, {
+      webviewOptions: { retainContextWhenHidden: true },
+    })
+  );
+```
+
+- [ ] **Step 2: Rename session flag and call `openBeside`**
+
+Change `revealedThisSession` → `openedThisSession` and `viewer.reveal()` → `viewer.openBeside()`:
+
+```typescript
+  let openedThisSession = false;
+```
+
+Inside the `stopped` handler:
+
+```typescript
+              if (!openedThisSession) {
+                openedThisSession = true;
+                viewer.openBeside();
+              }
+```
+
+- [ ] **Step 3: Dispose panel on session end**
+
+In `onDidTerminateDebugSession`:
+
+```typescript
+    vscode.debug.onDidTerminateDebugSession(() => {
+      stoppedThreadId = undefined;
+      openedThisSession = false;
+      viewer.dispose();
+      manager.reset();
+    })
+```
+
+- [ ] **Step 4: Update openPanel command**
+
+```typescript
+    vscode.commands.registerCommand('oid.openPanel', () => viewer.openBeside()),
+```
+
+- [ ] **Step 5: Compile and test**
+
+Run: `cd openimagedebugger-vscode && npm run compile && npm test`  
+Expected: compile OK, 26 tests pass
+
+- [ ] **Step 6: Commit in `openimagedebugger-vscode`**
+
+```bash
+cd openimagedebugger-vscode
+git add package.json src/webview/panel.ts src/extension.ts
+git commit -m "feat(webview): open viewer in editor split beside source on stop"
+```
+
+---
+
+### Task 4: Manual verification
+
+- [ ] **Step 1: Launch Extension Development Host**
+
+Run the extension (F5) from `openimagedebugger-vscode`.
+
+- [ ] **Step 2: Debug smoke test**
+
+1. Configure `oid.watchOnStop` with a known image variable.
+2. Start a CodeLLDB debug session and hit a breakpoint.
+3. Confirm viewer tab opens **to the right of source**; Run and Debug sidebar can stay open on the left.
+4. Continue → stop again; image updates without reloading WASM.
+5. End debug session; viewer tab closes.
+6. Run command **OID: Open Viewer Panel** without debugging; split opens.
+
+---
+
+## Plan self-review
+
+| Spec requirement | Task |
+|------------------|------|
+| Remove sidebar view | Task 1 |
+| WebviewPanel + Beside | Task 2 |
+| First stop opens split | Task 3 |
+| Session end dispose | Task 3 |
+| preserveFocus | Task 2 `reveal(column, true)` |
+| No active editor fallback | Task 2 `targetColumn()` |
+| retainContextWhenHidden | Task 2 panel options |
+| No new settings | (none added) |
+
+No placeholders. Type names consistent: `openBeside`, `dispose`, `panelType`.

--- a/docs/superpowers/plans/2026-06-27-oid-vscode-live-watch.md
+++ b/docs/superpowers/plans/2026-06-27-oid-vscode-live-watch.md
@@ -1,0 +1,345 @@
+# OID VS Code Live Watch Set Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make plotted image buffers auto-refresh on every debugger stop by having the extension remember what it plotted in the current session and re-plot that set.
+
+**Architecture:** `SessionManager` (in the `openimagedebugger-vscode` repo) gains a per-session live set of variable names. `plotVariable` enrolls a name on successful plot; `onStopped` re-plots the union of the live set and the `oid.watchOnStop` config, silently. A new `oid.clearWatch` command and a session-terminate hook clear the set. No C++/WASM/hosted-viewer changes.
+
+**Tech Stack:** TypeScript (CommonJS, Node16 module resolution — **all relative imports use `.js` extensions**), VS Code Extension API, `node:test` + `node:assert` run against compiled JS in `out/`.
+
+## Global Constraints
+
+- Repo: `openimagedebugger-vscode`, branch `feat/p2-codelldb-bridge`. (Plan/spec docs live in the `OpenImageDebugger` repo.)
+- Relative imports MUST use `.js` extensions (Node16 resolution).
+- Tests run against compiled output: `npm run compile` then `npm test` (`node --test out/test/*.js`). Stale `out/` causes phantom passes — start each verification with `rm -rf out`.
+- Commit messages: plain, no `Co-Authored-By` / AI-attribution trailer.
+- VS Code engine floor stays `^1.85.0`. No new dependencies.
+
+---
+
+### Task 1: Live set — enroll on plot, re-plot union on stop, silent failures, reset
+
+**Files:**
+- Modify: `src/session/session-manager.ts` (replace the `SessionManager` class body)
+- Test: `test/session-manager.test.ts` (update one existing test, add new tests)
+
+**Interfaces:**
+- Consumes: existing `SessionDeps` (`source.getBufferMetadata`, `sink.ensureReady`, `sink.sendPlotBuffer`, `encode`, `resolveFrame`, `getWatchList`, `warn`) — unchanged.
+- Produces:
+  - `SessionManager.plotVariable(name: string, threadId: number): Promise<void>` — plots once; enrolls `name` into the live set only on success.
+  - `SessionManager.onStopped(threadId: number): Promise<void>` — re-plots the deduped union of the live set and `getWatchList()`; failures are silent and names are retained; no-op when the union is empty.
+  - `SessionManager.reset(): void` — clears the live set.
+
+- [ ] **Step 1: Update the existing watch test for silent auto-replot and add new tests**
+
+In `test/session-manager.test.ts`, REPLACE the existing test `onStopped plots every watch entry and isolates failures` with the silent version below, then APPEND the new tests after it.
+
+```ts
+test('onStopped plots every watch entry and is silent on failure', async () => {
+  const { sent, warnings, mgr } = harness({
+    getWatchList: () => ['img', 'bad', 'mask'],
+  });
+  await mgr.onStopped(1);
+  assert.equal(sent.length, 2);
+  assert.equal(warnings.length, 0); // auto re-plot never toasts
+});
+
+test('plotVariable enrolls the variable so a later stop re-plots it', async () => {
+  const { sent, mgr } = harness();
+  await mgr.plotVariable('img', 1);
+  assert.equal(sent.length, 1);
+  await mgr.onStopped(1);
+  assert.equal(sent.length, 2);
+});
+
+test('plotVariable failure warns and does not enroll', async () => {
+  const { sent, warnings, mgr } = harness();
+  await mgr.plotVariable('bad', 1);
+  assert.equal(sent.length, 0);
+  assert.equal(warnings.length, 1);
+  await mgr.onStopped(1);
+  assert.equal(sent.length, 0);
+});
+
+test('onStopped re-plots the union of live set and watch list, deduped', async () => {
+  const { sent, mgr } = harness({ getWatchList: () => ['mask', 'img'] });
+  await mgr.plotVariable('img', 1);
+  sent.length = 0;
+  await mgr.onStopped(1);
+  assert.equal(sent.length, 2); // {img, mask}, img not duplicated
+});
+
+test('a live variable that fails one stop re-plots when it returns to scope', async () => {
+  let inScope = true;
+  const { sent, mgr } = harness({
+    source: {
+      async getBufferMetadata(name) {
+        if (!inScope) throw new Error('out of scope');
+        return params(name);
+      },
+    },
+  });
+  await mgr.plotVariable('img', 1); // enrolled
+  inScope = false;
+  await mgr.onStopped(1); // silent failure, retained
+  inScope = true;
+  sent.length = 0;
+  await mgr.onStopped(1);
+  assert.equal(sent.length, 1); // resumed
+});
+
+test('reset clears the live set', async () => {
+  const { sent, mgr } = harness();
+  await mgr.plotVariable('img', 1);
+  mgr.reset();
+  sent.length = 0;
+  await mgr.onStopped(1);
+  assert.equal(sent.length, 0);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/bruno/ws/openimagedebugger-vscode && rm -rf out && npm run compile && npm test`
+Expected: compile succeeds; the new tests FAIL (e.g. `reset is not a function`, enrolled re-plot counts wrong) and the updated silent test FAILS on `warnings.length` until the implementation changes.
+
+- [ ] **Step 3: Rewrite the SessionManager class**
+
+Replace the `SessionManager` class in `src/session/session-manager.ts` (keep the interfaces above it unchanged) with:
+
+```ts
+export class SessionManager {
+  private readonly liveNames = new Set<string>();
+
+  constructor(private readonly deps: SessionDeps) {}
+
+  async plotVariable(name: string, threadId: number): Promise<void> {
+    const frameId = await this.deps.resolveFrame(threadId);
+    const ok = await this.plotAtFrame(name, frameId, { warnOnError: true });
+    if (ok) this.liveNames.add(name);
+  }
+
+  async onStopped(threadId: number): Promise<void> {
+    const names = this.effectiveNames();
+    if (names.length === 0) return;
+    const frameId = await this.deps.resolveFrame(threadId);
+    for (const name of names) {
+      await this.plotAtFrame(name, frameId, { warnOnError: false });
+    }
+  }
+
+  reset(): void {
+    this.liveNames.clear();
+  }
+
+  private effectiveNames(): string[] {
+    const set = new Set<string>(this.liveNames);
+    for (const name of this.deps.getWatchList()) set.add(name);
+    return [...set];
+  }
+
+  private async plotAtFrame(
+    name: string,
+    frameId: number,
+    opts: { warnOnError: boolean }
+  ): Promise<boolean> {
+    try {
+      const p = await this.deps.source.getBufferMetadata(name, frameId);
+      await this.deps.sink.ensureReady();
+      await this.deps.sink.sendPlotBuffer(this.deps.encode(p));
+      return true;
+    } catch (err) {
+      if (opts.warnOnError) {
+        this.deps.warn(
+          `OID: could not plot '${name}': ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+      return false;
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/bruno/ws/openimagedebugger-vscode && npm run compile && npm test`
+Expected: all `session-manager.test.ts` tests PASS; no other test regresses. (If compile prints errors, fix them — do not trust a stale green from a prior `out/`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/bruno/ws/openimagedebugger-vscode
+git add src/session/session-manager.ts test/session-manager.test.ts
+git commit -m "feat(session): remember plotted vars and re-plot them on each stop"
+```
+
+---
+
+### Task 2: Overlap guard — skip a re-plot while one is in flight
+
+**Files:**
+- Modify: `src/session/session-manager.ts` (`SessionManager`)
+- Test: `test/session-manager.test.ts` (append one test)
+
+**Interfaces:**
+- Consumes: `SessionManager.onStopped` from Task 1.
+- Produces: `onStopped` becomes re-entrancy-safe — a call made while a previous `onStopped` is still awaiting is skipped (no second `resolveFrame`).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/session-manager.test.ts`:
+
+```ts
+test('onStopped skips a re-plot while one is already in flight', async () => {
+  let release!: () => void;
+  const gate = new Promise<void>((r) => { release = r; });
+  let frameCalls = 0;
+  const { mgr } = harness({
+    getWatchList: () => ['img'],
+    resolveFrame: async () => { frameCalls++; await gate; return 42; },
+  });
+  const first = mgr.onStopped(1);
+  const second = mgr.onStopped(2); // in-flight -> skipped
+  release();
+  await Promise.all([first, second]);
+  assert.equal(frameCalls, 1);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/bruno/ws/openimagedebugger-vscode && rm -rf out && npm run compile && npm test`
+Expected: this test FAILS with `frameCalls` equal to `2` (both calls resolve a frame).
+
+- [ ] **Step 3: Add the in-flight guard**
+
+In `src/session/session-manager.ts`, add the field and wrap `onStopped`:
+
+Add the field next to `liveNames`:
+```ts
+  private replotting = false;
+```
+
+Replace `onStopped` with:
+```ts
+  async onStopped(threadId: number): Promise<void> {
+    if (this.replotting) return;
+    const names = this.effectiveNames();
+    if (names.length === 0) return;
+    this.replotting = true;
+    try {
+      const frameId = await this.deps.resolveFrame(threadId);
+      for (const name of names) {
+        await this.plotAtFrame(name, frameId, { warnOnError: false });
+      }
+    } finally {
+      this.replotting = false;
+    }
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/bruno/ws/openimagedebugger-vscode && npm run compile && npm test`
+Expected: the new test PASSES (`frameCalls === 1`); all Task 1 tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/bruno/ws/openimagedebugger-vscode
+git add src/session/session-manager.ts test/session-manager.test.ts
+git commit -m "feat(session): skip overlapping re-plots on rapid stepping"
+```
+
+---
+
+### Task 3: Extension wiring — `oid.clearWatch` command and reset on session end
+
+**Files:**
+- Modify: `src/extension.ts`
+- Modify: `package.json` (contributes.commands)
+
+**Interfaces:**
+- Consumes: `SessionManager.reset()` from Task 1.
+- Produces: command `oid.clearWatch` titled "OID: Clear Live Watches"; the live set is cleared on `oid.clearWatch` and on debug-session terminate.
+
+This task is VS Code glue (not unit-testable under `node:test`); its gate is a clean compile plus the existing suite staying green.
+
+- [ ] **Step 1: Reset the live set on session terminate**
+
+In `src/extension.ts`, the existing terminate subscription is:
+```ts
+  context.subscriptions.push(
+    vscode.debug.onDidTerminateDebugSession(() => { stoppedThreadId = undefined; })
+  );
+```
+Replace it with:
+```ts
+  context.subscriptions.push(
+    vscode.debug.onDidTerminateDebugSession(() => {
+      stoppedThreadId = undefined;
+      manager.reset();
+    })
+  );
+```
+
+- [ ] **Step 2: Register the `oid.clearWatch` command**
+
+In `src/extension.ts`, the existing command registration block is:
+```ts
+  context.subscriptions.push(
+    vscode.commands.registerCommand('oid.openPanel', () => viewer.open()),
+    vscode.commands.registerCommand('oid.plot', async () => {
+```
+Insert a new command registration immediately after the `oid.openPanel` line, so the block begins:
+```ts
+  context.subscriptions.push(
+    vscode.commands.registerCommand('oid.openPanel', () => viewer.open()),
+    vscode.commands.registerCommand('oid.clearWatch', () => {
+      manager.reset();
+      vscode.window.showInformationMessage('OID: live watches cleared.');
+    }),
+    vscode.commands.registerCommand('oid.plot', async () => {
+```
+
+- [ ] **Step 3: Contribute the command in package.json**
+
+In `package.json`, the `contributes.commands` array is:
+```json
+    "commands": [
+      { "command": "oid.openPanel", "title": "OID: Open Viewer Panel" },
+      { "command": "oid.plot", "title": "OID: Plot Variable" }
+    ],
+```
+Replace it with:
+```json
+    "commands": [
+      { "command": "oid.openPanel", "title": "OID: Open Viewer Panel" },
+      { "command": "oid.plot", "title": "OID: Plot Variable" },
+      { "command": "oid.clearWatch", "title": "OID: Clear Live Watches" }
+    ],
+```
+
+- [ ] **Step 4: Verify it compiles and the suite is green**
+
+Run: `cd /Users/bruno/ws/openimagedebugger-vscode && rm -rf out && npm run compile && npm test`
+Expected: compile succeeds with no errors; all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/bruno/ws/openimagedebugger-vscode
+git add src/extension.ts package.json
+git commit -m "feat(extension): clear-watch command and reset live set on session end"
+```
+
+---
+
+## Manual verification (after Task 3)
+
+Run the extension (F5), start a CodeLLDB session, hit a breakpoint, run **OID: Plot Variable** on an image. Continue to the next stop: the image should refresh automatically. Run **OID: Clear Live Watches**; subsequent stops should no longer refresh it. Stopping the debug session and starting a new one should begin with an empty live set.
+
+## Self-review notes
+- Spec coverage: live set state + union (Task 1), enroll-on-success / silent-retained failures / reset (Task 1), overlap guard (Task 2), `oid.clearWatch` + terminate reset + config union (Tasks 1 & 3). All spec sections mapped.
+- Deferred Option B (viewer-authoritative via `GetObservedSymbols`, needing the C++ `MessageComposer::send` coalescing fix) is intentionally **not** in this plan.

--- a/docs/superpowers/plans/2026-06-27-oid-vscode-p3-refine.md
+++ b/docs/superpowers/plans/2026-06-27-oid-vscode-p3-refine.md
@@ -1,0 +1,479 @@
+# OID VS Code P3 Refine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete viewer-owned P3 — WASM autocomplete, viewer-initiated plot requests, and `GetObservedSymbols` poll on stop — replacing the interim extension-owned `liveNames` model.
+
+**Architecture:** Fix `MessageComposer` coalescing in OID so viewer→host IPC is one postMessage frame; rebuild WASM into extension `media/`. Extend the extension with symbol enumeration, `ViewerChannel` inbound handling, and the P3 stop loop. Remove `oid.clearWatch`.
+
+**Tech Stack:** C++ (MessageComposer), Emscripten/Qt WASM, TypeScript VS Code extension, DAP scopes/variables, `node:test`.
+
+**Spec:** `docs/superpowers/specs/2026-06-27-oid-vscode-p3-refine-design.md`
+
+**Repos:** `OpenImageDebugger` + `openimagedebugger-vscode`
+
+---
+
+## Already done (skip)
+
+- `message-exchange.ts` encoders/decoders for types 0,1,2,4 + unit tests
+- `buildPlotBufferContents`, CodeLLDB bridge, editor-split `ViewerController`
+- Live-watch `liveNames` (to be **removed** in Task 6)
+
+---
+
+## Task 1: Coalesce `MessageComposer::send(ITransport&)`
+
+**Files:**
+- Modify: `OpenImageDebugger/src/ipc/message_exchange.h`
+- Test: `OpenImageDebugger/tests/test_message_exchange.cpp`
+
+- [ ] **Step 1: Add recording mock transport in test file**
+
+At top of test cpp (inside `oid` namespace or test fixture), add:
+
+```cpp
+struct RecordingTransport final : oid::ITransport {
+  std::vector<std::vector<std::byte>> sends;
+  void send(std::span<const std::byte> data) override {
+    sends.emplace_back(data.begin(), data.end());
+  }
+  std::size_t receive(std::span<std::byte>) override { return 0; }
+  bool has_data() const override { return false; }
+};
+```
+
+- [ ] **Step 2: Write failing test**
+
+```cpp
+TEST_F(MessageExchangeTest, MessageComposerSendCoalescesBlocks) {
+  RecordingTransport transport;
+  MessageComposer composer;
+  composer.push(MessageType::PlotBufferRequest).push(std::string("TestField"));
+  composer.send(transport);
+  ASSERT_EQ(transport.sends.size(), 1u);
+  ASSERT_GE(transport.sends[0].size(), 12u); // type + len + at least some string bytes
+  const auto type = std::bit_cast<MessageType>(transport.sends[0].data());
+  EXPECT_EQ(type, MessageType::PlotBufferRequest);
+}
+```
+
+- [ ] **Step 3: Implement coalescing in `message_exchange.h`**
+
+Replace `send(ITransport&)` body:
+
+```cpp
+void send(ITransport& transport) const {
+    std::size_t total = 0;
+    for (const auto& block : message_blocks_) {
+        total += block->size();
+    }
+    std::vector<std::byte> frame;
+    frame.reserve(total);
+    for (const auto& block : message_blocks_) {
+        const auto* data = block->data();
+        frame.insert(frame.end(), data, data + block->size());
+    }
+    if (!frame.empty()) {
+        transport.send(frame);
+    }
+}
+```
+
+Add `#include <vector>` if not already present via other headers.
+
+- [ ] **Step 4: Run C++ tests**
+
+Run: `cd OpenImageDebugger && cmake --build cmake-build-debug --target test_message_exchange && ctest -R MessageExchangeTest --test-dir cmake-build-debug`  
+(Adjust build dir to your local preset if different.)
+
+Expected: all `MessageExchangeTest` pass including new test.
+
+- [ ] **Step 5: Commit (OpenImageDebugger)**
+
+```bash
+git add src/ipc/message_exchange.h tests/test_message_exchange.cpp
+git commit -m "fix(ipc): coalesce MessageComposer blocks into one transport send"
+```
+
+---
+
+## Task 2: Rebuild WASM and refresh extension media
+
+**Files:**
+- Copy: `build-wasm/oidwindow.wasm`, `oidwindow.js` → `openimagedebugger-vscode/media/`
+
+- [ ] **Step 1: Rebuild oidwindow**
+
+```bash
+cd OpenImageDebugger
+source /path/to/emsdk/emsdk_env.sh
+/path/to/qt6-wasm/bin/qt-cmake -S . -B build-wasm -DCMAKE_BUILD_TYPE=Release
+cmake --build build-wasm --target oidwindow
+```
+
+- [ ] **Step 2: Copy artifacts**
+
+```bash
+cp build-wasm/oidwindow.wasm build-wasm/oidwindow.js ../openimagedebugger-vscode/media/
+```
+
+- [ ] **Step 3: Commit both repos**
+
+OpenImageDebugger: only if source changed beyond Task 1 (usually Task 1 commit suffices).
+
+```bash
+cd openimagedebugger-vscode
+git add media/oidwindow.wasm media/oidwindow.js
+git commit -m "chore(media): refresh WASM after MessageComposer coalescing fix"
+```
+
+---
+
+## Task 3: DAP symbol enumerator
+
+**Files:**
+- Modify: `openimagedebugger-vscode/src/debugger/dap-client.ts`
+- Create: `openimagedebugger-vscode/src/debugger/symbol-enumerator.ts`
+- Create: `openimagedebugger-vscode/test/symbol-enumerator.test.ts`
+
+- [ ] **Step 1: Extend `IDapClient` and `DapClient`**
+
+Add to `dap-client.ts`:
+
+```typescript
+export interface ScopeInfo {
+  name: string;
+  variablesReference: number;
+}
+
+export interface VariableInfo {
+  name: string;
+  type?: string;
+}
+
+// In IDapClient:
+scopes(frameId: number): Promise<ScopeInfo[]>;
+variables(variablesReference: number): Promise<VariableInfo[]>;
+
+// In DapClient:
+async scopes(frameId: number): Promise<ScopeInfo[]> {
+  const res = await this.session.customRequest('scopes', { frameId });
+  return (res.scopes ?? []).map((s: any) => ({
+    name: s.name,
+    variablesReference: s.variablesReference,
+  }));
+}
+
+async variables(variablesReference: number): Promise<VariableInfo[]> {
+  const res = await this.session.customRequest('variables', { variablesReference });
+  return (res.variables ?? []).map((v: any) => ({ name: v.name, type: v.type }));
+}
+```
+
+- [ ] **Step 2: Create `symbol-enumerator.ts`**
+
+```typescript
+import type { IDapClient, VariableInfo } from './dap-client.js';
+
+const ALLOWED_SCOPES = new Set(['Local', 'Arguments']);
+
+export async function listScopeSymbols(
+  client: IDapClient,
+  frameId: number
+): Promise<VariableInfo[]> {
+  const scopes = await client.scopes(frameId);
+  const out: VariableInfo[] = [];
+  for (const scope of scopes) {
+    if (!ALLOWED_SCOPES.has(scope.name)) continue;
+    if (scope.variablesReference <= 0) continue;
+    const vars = await client.variables(scope.variablesReference);
+    out.push(...vars);
+  }
+  return out;
+}
+```
+
+- [ ] **Step 3: Write tests with mock client**
+
+Test keeps Local+Arguments, drops Registers; merges variables from both scopes.
+
+- [ ] **Step 4: `npm run compile && npm test`**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/debugger/dap-client.ts src/debugger/symbol-enumerator.ts test/symbol-enumerator.test.ts
+git commit -m "feat(debugger): enumerate Local and Arguments scope symbols"
+```
+
+---
+
+## Task 4: ViewerChannel in `panel.ts`
+
+**Files:**
+- Modify: `openimagedebugger-vscode/src/webview/panel.ts`
+
+- [ ] **Step 1: Add imports and constants**
+
+```typescript
+import {
+  buildSetAvailableSymbols,
+  buildGetObservedSymbols,
+  decodeInbound,
+} from '../ipc/message-exchange.js';
+
+const OBSERVED_TIMEOUT_MS = 1_000;
+```
+
+- [ ] **Step 2: Add channel state to `ViewerController`**
+
+Fields:
+
+```typescript
+private pendingObserved: ((names: string[]) => void) | undefined;
+private onPlotBufferRequest: ((name: string) => void) | undefined;
+
+setPlotBufferRequestHandler(handler: (name: string) => void): void {
+  this.onPlotBufferRequest = handler;
+}
+```
+
+- [ ] **Step 3: Handle `oid-ipc-out` in `onDidReceiveMessage`**
+
+```typescript
+if (msg?.type === 'oid-ipc-out' && msg.payload) {
+  const bytes = new Uint8Array(msg.payload);
+  const decoded = decodeInbound(bytes);
+  if (decoded.kind === 'observedSymbols') {
+    this.pendingObserved?.(decoded.names);
+    this.pendingObserved = undefined;
+  } else if (decoded.kind === 'plotRequest') {
+    this.onPlotBufferRequest?.(decoded.name);
+  }
+  return;
+}
+```
+
+- [ ] **Step 4: Add `sendFrame`, `setAvailableSymbols`, `getObservedSymbols`**
+
+```typescript
+private async sendFrame(bytes: Uint8Array): Promise<void> {
+  await this.ensureReady();
+  this.panel?.webview.postMessage({ type: 'oid-ipc-forward', payload: Array.from(bytes) });
+}
+
+async setAvailableSymbols(names: string[]): Promise<void> {
+  await this.sendFrame(buildSetAvailableSymbols(names, 'wasm32'));
+}
+
+async getObservedSymbols(): Promise<string[]> {
+  await this.sendFrame(buildGetObservedSymbols());
+  return new Promise<string[]>((resolve) => {
+    if (this.pendingObserved) this.pendingObserved([]);
+    const timer = setTimeout(() => {
+      this.pendingObserved = undefined;
+      console.warn('OID: GetObservedSymbols timed out');
+      resolve([]);
+    }, OBSERVED_TIMEOUT_MS);
+    this.pendingObserved = (names) => {
+      clearTimeout(timer);
+      resolve(names);
+    };
+  });
+}
+```
+
+Wire `pendingObserved` resolver in the `oid-ipc-out` handler as shown.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/webview/panel.ts
+git commit -m "feat(webview): ViewerChannel for symbols and inbound plot requests"
+```
+
+---
+
+## Task 5: P3 session loop (replace liveNames)
+
+**Files:**
+- Modify: `openimagedebugger-vscode/src/session/session-manager.ts`
+- Modify: `openimagedebugger-vscode/test/session-manager.test.ts`
+
+- [ ] **Step 1: Extend `SessionDeps`**
+
+```typescript
+export interface ViewerChannel {
+  setAvailableSymbols(names: string[]): Promise<void>;
+  getObservedSymbols(): Promise<string[]>;
+}
+
+export interface SessionDeps {
+  source: MetadataSource;
+  sink: PlotSink;
+  channel: ViewerChannel;
+  listScopeSymbols: (frameId: number) => Promise<{ name: string }[]>;
+  encode: (p: PlotBufferParams) => Uint8Array;
+  resolveFrame: (threadId: number) => Promise<number>;
+  getWatchList: () => string[];
+  warn: (message: string) => void;
+}
+```
+
+Remove `liveNames` field. Add `private seeded = false`.
+
+- [ ] **Step 2: Replace `onStopped` with P3 loop**
+
+```typescript
+async onStopped(threadId: number): Promise<void> {
+  if (this.replotting) return;
+  this.replotting = true;
+  try {
+    const frameId = await this.deps.resolveFrame(threadId);
+    try {
+      const syms = await this.deps.listScopeSymbols(frameId);
+      await this.deps.channel.setAvailableSymbols(syms.map((s) => s.name));
+    } catch (err) {
+      this.deps.warn(`OID: could not list symbols: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    let observed = await this.deps.channel.getObservedSymbols();
+    if (!this.seeded) {
+      observed = [...new Set([...observed, ...this.deps.getWatchList()])];
+      this.seeded = true;
+    }
+    for (const name of observed) {
+      await this.plotAtFrame(name, frameId, { warnOnError: true });
+    }
+  } catch {
+    // frame resolution failure — silent
+  } finally {
+    this.replotting = false;
+  }
+}
+```
+
+- [ ] **Step 3: Add `onPlotBufferRequest`**
+
+```typescript
+async onPlotBufferRequest(name: string, threadId: number): Promise<void> {
+  const frameId = await this.deps.resolveFrame(threadId);
+  await this.plotAtFrame(name, frameId, { warnOnError: true });
+}
+```
+
+- [ ] **Step 4: Change `plotVariable` to delegate**
+
+```typescript
+async plotVariable(name: string, threadId: number): Promise<void> {
+  await this.onPlotBufferRequest(name, threadId);
+}
+```
+
+- [ ] **Step 5: `reset()` clears `seeded` only**
+
+```typescript
+reset(): void {
+  this.seeded = false;
+}
+```
+
+- [ ] **Step 6: Rewrite session-manager tests**
+
+Replace live-watch tests with mocks for `channel` + `listScopeSymbols`:
+
+- `setAvailableSymbols` called with enumerated names on stop
+- `getObservedSymbols` result plotted (one `sendPlotBuffer` per name)
+- first stop unions watch list into observed set
+- `onPlotBufferRequest` plots with warn on failure
+- overlap guard retained
+- `reset` clears seeded so next session re-seeds watch list
+
+- [ ] **Step 7: `npm run compile && npm test`**
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/session/session-manager.ts test/session-manager.test.ts
+git commit -m "feat(session): viewer-owned stop loop with symbol list and poll"
+```
+
+---
+
+## Task 6: Wire `extension.ts` and remove `oid.clearWatch`
+
+**Files:**
+- Modify: `openimagedebugger-vscode/src/extension.ts`
+- Modify: `openimagedebugger-vscode/package.json`
+
+- [ ] **Step 1: Remove `oid.clearWatch` from `package.json` commands**
+
+- [ ] **Step 2: Wire deps in `extension.ts`**
+
+```typescript
+import { listScopeSymbols } from './debugger/symbol-enumerator.js';
+
+// In activate, after creating viewer:
+viewer.setPlotBufferRequestHandler((name) => {
+  if (stoppedThreadId === undefined) {
+    vscode.window.showWarningMessage('OID: pause in a debug session first.');
+    return;
+  }
+  void manager.onPlotBufferRequest(name, stoppedThreadId);
+});
+
+const manager = new SessionManager({
+  source: { /* unchanged */ },
+  sink: viewer,
+  channel: viewer,
+  listScopeSymbols: async (frameId) => {
+    const session = activeSession();
+    if (!session) throw new Error('no active debug session');
+    return listScopeSymbols(new DapClient(session), frameId);
+  },
+  encode: (p) => buildPlotBufferContents(p, 'wasm32'),
+  resolveFrame: async (threadId) => { /* unchanged */ },
+  getWatchList: watchList,
+  warn: (m) => vscode.window.showWarningMessage(m),
+});
+```
+
+Remove `oid.clearWatch` command registration.
+
+Make `ViewerController` implement `ViewerChannel` interface (TypeScript structural typing — methods already on class).
+
+- [ ] **Step 3: `npm run compile && npm test`**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/extension.ts package.json
+git commit -m "feat(extension): wire P3 viewer channel and drop clearWatch command"
+```
+
+---
+
+## Task 7: Manual verification
+
+- [ ] Break in testbench — WASM autocomplete shows locals/arguments
+- [ ] Add variable via viewer symbol box — plots immediately
+- [ ] `oid.watchOnStop` seeds on first stop
+- [ ] Step/continue refreshes observed buffers
+- [ ] Remove buffer in viewer — not replotted on next stop
+- [ ] Debug session end disposes panel; new session re-seeds watch list
+
+---
+
+## Plan self-review
+
+| Spec § | Task |
+|--------|------|
+| MessageComposer coalescing | Task 1 |
+| WASM refresh | Task 2 |
+| Symbol enumeration | Task 3 |
+| ViewerChannel inbound/outbound | Task 4 |
+| P3 stop loop, remove liveNames | Task 5 |
+| Wire extension, remove clearWatch | Task 6 |
+| Manual P3 checklist | Task 7 |
+
+No placeholders. `ViewerController` satisfies `ViewerChannel` structurally.

--- a/docs/superpowers/plans/2026-06-27-oid-vscode-p5-full-parity.md
+++ b/docs/superpowers/plans/2026-06-27-oid-vscode-p5-full-parity.md
@@ -1,0 +1,342 @@
+# OID VS Code P5: Full parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship export (PNG/Octave), cross-restart session persistence, and full TypeBridge parity (Eigen, legacy OpenCV types, custom types) in the VS Code extension + WASM viewer via extended legacy IPC.
+
+**Architecture:** Extension owns persistence and export file I/O; WASM owns UI state and sends debounced JSON deltas plus export requests with contrast parameters. TypeBridge in the extension ports all `oidtypes/*.py` inspectors. Legacy message types 5–8 extend the proven P3 wire format — no OBP migration.
+
+**Tech Stack:** C++20/Qt6 WASM (OID), TypeScript/VS Code extension API, CodeLLDB DAP, `pngjs`, `node:test`.
+
+## Global Constraints
+
+- **Repos:** OID `/Users/bruno/ws/OpenImageDebugger` (branch `feat/wasm-vscode`); extension `/Users/bruno/ws/openimagedebugger-vscode` (branch `feat/live-update-local-wasm`).
+- **Wire format:** `wasm32` — little-endian u32 headers/counts/lengths; UTF-8 length-prefixed strings.
+- **Message types** (must match `src/ipc/message_exchange.h` and `src/ipc/message-exchange.ts`): 0–4 existing; **5** `ExportBufferRequest`; **6** `ApplySessionState`; **7** `SessionStateChanged`; **8** `ExportSelectedBuffer`.
+- **Type 5 stub:** already ships variable name only; P5 extends with `int32 format` + `float32[8]` contrast — update OID media and extension atomically.
+- **WASM nested event loops:** never call `QMenu::exec()` or `QFileDialog::exec()` under `__EMSCRIPTEN__`; use `popup()` and IPC.
+- **Module imports (extension):** `.js` specifiers; compile before test (`npm run compile && npm test`).
+- **Media sync:** after OID WASM rebuild, run `wasm/scripts/pack.sh` to copy artifacts into extension `media/`.
+- **Persistence delay:** 100 ms debounce (matches desktop `SETTINGS_PERSIST_DELAY_MS`).
+- **Buffer expiry:** 1 day (`BUFFER_EXPIRATION_DAYS` in `settings_manager.h`).
+
+---
+
+### Task 1: Extend ExportBufferRequest IPC (format + contrast)
+
+**Files:**
+- Modify: `OpenImageDebugger/src/ipc/message_exchange.h`
+- Modify: `OpenImageDebugger/src/ui/messaging/message_handler.h`
+- Modify: `OpenImageDebugger/src/ui/messaging/message_handler.cpp`
+- Modify: `OpenImageDebugger/src/ui/events/event_handler.cpp`
+- Modify: `openimagedebugger-vscode/src/ipc/message-exchange.ts`
+- Test: `openimagedebugger-vscode/test/message-exchange.test.ts`
+
+**Interfaces:**
+- Consumes: existing `MessageComposer` / `decodeInbound`.
+- Produces:
+  - C++ `MessageHandler::request_export_buffer(const QString& name, int format, std::array<float,8> contrast)`
+  - TS `decodeInbound` → `{ kind: 'exportRequest', name: string, format: number, contrast: Float32Array }`
+  - TS `buildExportBufferRequest(...)` for tests only (viewer sends from C++)
+
+- [ ] **Step 1: Add `float` to C++ `PrimitiveType` concept**
+
+In `message_exchange.h`, extend the concept:
+
+```cpp
+concept PrimitiveType =
+    std::is_same_v<T, MessageType> || std::is_same_v<T, int> ||
+    std::is_same_v<T, float> ||
+    /* ... existing ... */;
+```
+
+- [ ] **Step 2: Extend WASM export to send format + 8 floats**
+
+In `event_handler.cpp` `#ifdef __EMSCRIPTEN__` block inside `export_buffer`, after resolving `Buffer` component:
+
+```cpp
+const auto* bc = component.auto_buffer_contrast_brightness();
+std::array<float, 8> contrast{};
+for (int i = 0; i < 8; ++i) contrast[i] = bc[i];
+emit exportBufferRequested(buffer_name, 0, contrast); // 0 = PNG default from menu
+```
+
+Update signal to carry `(QString, int format, std::array<float,8>)` and `MessageHandler::request_export_buffer` to push all fields.
+
+- [ ] **Step 3: Write failing TS decode test**
+
+```ts
+test('decodeInbound parses ExportBufferRequest with format and contrast', () => {
+  const parts: number[] = [];
+  const u32 = (v: number) => parts.push(v & 0xff, (v >> 8) & 0xff, (v >> 16) & 0xff, (v >> 24) & 0xff);
+  const f32 = (v: number) => { const buf = new ArrayBuffer(4); new DataView(buf).setFloat32(0, v, true); parts.push(...new Uint8Array(buf)); };
+  u32(MessageType.ExportBufferRequest);
+  u32(3); parts.push('i'.charCodeAt(0), 'm'.charCodeAt(0), 'g'.charCodeAt(0)); // use TextEncoder in real test
+  u32(1); // format Octave
+  for (let i = 0; i < 8; i++) f32(i * 0.1);
+  const msg = decodeInbound(new Uint8Array(parts));
+  assert.equal(msg.kind, 'exportRequest');
+  // assert name, format, contrast length
+});
+```
+
+- [ ] **Step 4: Implement TS decoder + run tests**
+
+Run: `cd openimagedebugger-vscode && npm run compile && npm test`  
+Expected: PASS
+
+- [ ] **Step 5: Rebuild WASM + commit both repos**
+
+```bash
+cd OpenImageDebugger && wasm/scripts/pack.sh --build
+cd ../openimagedebugger-vscode && npm run compile && npm test
+# commit OID + extension separately
+git commit -m "feat(ipc): extend ExportBufferRequest with format and contrast"
+```
+
+---
+
+### Task 2: Extension buffer exporter (PNG + Octave)
+
+**Files:**
+- Create: `openimagedebugger-vscode/src/export/buffer-exporter.ts`
+- Create: `openimagedebugger-vscode/src/export/contrast.ts` (port `get_multiplier`, contrast math from `buffer_exporter.cpp`)
+- Create: `openimagedebugger-vscode/test/buffer-exporter.test.ts`
+- Modify: `openimagedebugger-vscode/package.json` (add `pngjs` dependency)
+
+**Interfaces:**
+- Consumes: `PlotBufferParams`, `Float32Array` contrast (8), save path, format enum.
+- Produces: `exportBuffer(params: ExportParams): Promise<void>`
+
+- [ ] **Step 1: Add `pngjs` and write failing Octave header test**
+
+```ts
+test('octaveHeader writes type descriptor and dimensions', () => {
+  const header = buildOctaveHeader('uint8', 10, 20, 1);
+  assert.match(header, /^uint81020/);
+});
+```
+
+- [ ] **Step 2: Implement Octave binary writer + PNG path using pngjs**
+
+Port row iteration from `export_binary` / `export_bitmap` in `src/io/buffer_exporter.cpp`.
+
+- [ ] **Step 3: Wire `ViewerController.setExportBufferRequestHandler` → `exportBuffer`**
+
+Replace info toast in `extension.ts` with:
+
+```ts
+viewer.setExportBufferRequestHandler((req) => {
+  void handleExportRequest(req, stoppedThreadId, bridge, context);
+});
+```
+
+`handleExportRequest`: `showSaveDialog` → `getBufferMetadata` → `exportBuffer`.
+
+- [ ] **Step 4: Run tests and commit**
+
+```bash
+git commit -m "feat(export): add PNG and Octave buffer exporter in extension"
+```
+
+---
+
+### Task 3: ExportSelectedBuffer + `oid.export` command
+
+**Files:**
+- Modify: `OpenImageDebugger/src/ipc/message_exchange.h` (type 8)
+- Modify: `OpenImageDebugger/src/ui/messaging/message_handler.cpp` (decode 8)
+- Modify: `openimagedebugger-vscode/src/ipc/message-exchange.ts` (`buildExportSelectedBuffer`)
+- Modify: `openimagedebugger-vscode/src/webview/panel.ts`
+- Modify: `openimagedebugger-vscode/package.json`
+- Modify: `openimagedebugger-vscode/src/extension.ts`
+
+**Interfaces:**
+- Produces: command `oid.export`; `panel.requestExportSelected(): Promise<void>` sends type 8.
+
+- [ ] **Step 1: OID decode type 8 → call `UIEventHandler::export_buffer(selectedName)`**
+
+Track `selectedBuffer` from list selection (already in `buffer_data.currently_selected_stage` / list row).
+
+- [ ] **Step 2: Register command in extension**
+
+```json
+{ "command": "oid.export", "title": "OID: Export Selected Buffer" }
+```
+
+- [ ] **Step 3: Manual test** — plot buffer, run command, save dialog appears, file written.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(export): add oid.export command via ExportSelectedBuffer IPC"
+```
+
+---
+
+### Task 4: Session persistence — extension module
+
+**Files:**
+- Create: `openimagedebugger-vscode/src/session/persistence.ts`
+- Create: `openimagedebugger-vscode/test/persistence.test.ts`
+- Modify: `openimagedebugger-vscode/src/extension.ts`
+
+**Interfaces:**
+- Produces:
+  - `loadSession(context): OidSessionState`
+  - `saveSession(context, state): void` (debounced)
+  - `mergeSessionDelta(state, partial): OidSessionState`
+  - `migrateWatchOnStop(state, names: string[]): OidSessionState`
+  - `encodeSessionState(state): string` / `decodeSessionState(json): OidSessionState`
+
+- [ ] **Step 1: Write failing tests for expiry + merge + migration**
+
+- [ ] **Step 2: Implement persistence module matching spec §3 JSON schema**
+
+Defaults: framerate 60, defaultSuffix `"Image File (*.png)"`, empty watched list.
+
+- [ ] **Step 3: On viewer ready, load + migrate + send ApplySessionState (Task 5 codec)**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(session): add extension-owned session persistence module"
+```
+
+---
+
+### Task 5: Session persistence — IPC + WASM apply/persist
+
+**Files:**
+- Modify: `OpenImageDebugger/src/ipc/message_exchange.h` (types 6, 7)
+- Modify: `OpenImageDebugger/src/ui/messaging/message_handler.cpp`
+- Modify: `OpenImageDebugger/src/ui/main_window/main_window.cpp`
+- Create: `OpenImageDebugger/src/ui/messaging/session_state_codec.cpp` (JSON parse → SettingsApplier calls; use Qt `QJsonDocument` or minimal parser)
+- Modify: `openimagedebugger-vscode/src/ipc/message-exchange.ts`
+- Modify: `openimagedebugger-vscode/src/webview/panel.ts`
+
+**Interfaces:**
+- Produces: `buildApplySessionState(json: string): Uint8Array`; decode type 7 in panel → `onSessionStateChanged(partial)`.
+
+- [ ] **Step 1: Implement C++ decode ApplySessionState** — populate `buffer_data.previous_session_buffers`, emit same signals as `SettingsManager::load_*`.
+
+- [ ] **Step 2: Replace EMSCRIPTEN `SettingsManager::persist_settings` path** — serialize `MainWindow::persist_settings` callbacks to JSON, send type 7.
+
+- [ ] **Step 3: Skip QSettings load on WASM startup**
+
+- [ ] **Step 4: Extension sends ApplySessionState on viewer-ready; handles SessionStateChanged**
+
+- [ ] **Step 5: Rebuild WASM, pack media, manual test restart persistence**
+
+- [ ] **Step 6: Commit both repos**
+
+```bash
+git commit -m "feat(session): sync session state over ApplySessionState IPC"
+```
+
+---
+
+### Task 6: TypeBridge router + OpenCV legacy types
+
+**Files:**
+- Create: `openimagedebugger-vscode/src/typebridge/index.ts`
+- Create: `openimagedebugger-vscode/src/typebridge/opencv-cvmat.ts`
+- Create: `openimagedebugger-vscode/src/typebridge/opencv-iplimage.ts`
+- Modify: `openimagedebugger-vscode/src/debugger/codelldb-bridge.ts`
+- Test: `openimagedebugger-vscode/test/opencv-cvmat.test.ts`, `opencv-iplimage.test.ts`
+
+**Interfaces:**
+- Produces: `resolveInspector(type: string): TypeInspector | undefined`
+- Produces: `TypeInspector.getBufferMetadata(name, frameId, dap): Promise<PlotBufferParams>`
+
+- [ ] **Step 1: Port `CvMat` and `IplImage` decode from `resources/oidscripts/oidtypes/opencv.py`**
+
+- [ ] **Step 2: Refactor `CodeLldbBridge` to evaluate type string first, dispatch via router**
+
+- [ ] **Step 3: Tests + commit**
+
+```bash
+git commit -m "feat(typebridge): add CvMat and IplImage inspectors"
+```
+
+---
+
+### Task 7: Eigen matrix inspector
+
+**Files:**
+- Create: `openimagedebugger-vscode/src/typebridge/eigen-matrix.ts`
+- Create: `openimagedebugger-vscode/test/fixtures/eigen-*.json` (recorded LLDB evaluate outputs)
+- Test: `openimagedebugger-vscode/test/eigen-matrix.test.ts`
+
+- [ ] **Step 1: Port `eigen3.py` using DAP evaluate for Map/Matrix, dynamic dims, transpose**
+
+- [ ] **Step 2: Register in router after OpenCV, before custom types**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat(typebridge): add Eigen Matrix/Map inspector"
+```
+
+---
+
+### Task 8: Custom types (`oid.customTypes`)
+
+**Files:**
+- Create: `openimagedebugger-vscode/src/typebridge/custom-type.ts`
+- Modify: `openimagedebugger-vscode/package.json` (configuration schema)
+- Modify: `openimagedebugger-vscode/src/typebridge/symbol-observable.ts`
+- Test: `openimagedebugger-vscode/test/custom-type.test.ts`
+
+- [ ] **Step 1: Define `CustomTypeConfig` interface matching spec §6**
+
+- [ ] **Step 2: Load workspace configs at activation; prepend custom inspectors in router**
+
+- [ ] **Step 3: Extend `isSymbolObservable` with custom patterns**
+
+- [ ] **Step 4: Document example in extension README (optional one-liner in package.json description)**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(typebridge): add pluggable custom type inspectors"
+```
+
+---
+
+### Task 9: Integration verification + media refresh
+
+**Files:**
+- Modify: `OpenImageDebugger/tests/test_message_exchange.cpp` (fix `bit_cast` on enum if needed, add type 5–8 round-trips)
+
+- [ ] **Step 1: Full rebuild**
+
+```bash
+cd OpenImageDebugger && wasm/scripts/pack.sh --build
+cd ../openimagedebugger-vscode && npm run compile && npm test
+```
+
+- [ ] **Step 2: Manual matrix (spec §9)**
+
+- [ ] **Step 3: Final commits if any fixups**
+
+```bash
+git commit -m "chore(media): refresh WASM for P5 full parity"
+```
+
+---
+
+## Plan self-review
+
+| Spec requirement | Task |
+|------------------|------|
+| Export PNG/Octave hybrid | 1–3 |
+| Re-fetch + contrast from WASM | 1–2 |
+| Extension persistence | 4–5 |
+| Full desktop UI prefs + buffers | 4–5 |
+| Eigen + CvMat + IplImage | 6–7 |
+| Custom types | 8 |
+| Legacy IPC 5–8 | 1, 3, 5 |
+| Testing | All tasks |
+
+No TBD placeholders. Type/function names consistent across tasks (`exportBuffer`, `OidSessionState`, `buildApplySessionState`).

--- a/docs/superpowers/plans/2026-06-27-oid-wasm-session-persistence.md
+++ b/docs/superpowers/plans/2026-06-27-oid-wasm-session-persistence.md
@@ -1,0 +1,650 @@
+# OID WASM Session Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist OID viewer session state across VS Code restarts with behavioral parity to desktop C++ `SettingsManager`, using extension-owned storage and IPC types 6–7.
+
+**Architecture:** Extension owns canonical state in `globalState`/`workspaceState`. On `viewer-ready`, extension sends `ApplySessionState` (type 6) with a full JSON snapshot. WASM applies via `session_state_codec` → existing `SettingsApplier` slots. On UI/buffer changes, WASM sends debounced `SessionStateChanged` (type 7) partial JSON; extension deep-merges and runs the C++ buffer-merge algorithm before saving.
+
+**Tech Stack:** TypeScript (`node:test`), VS Code Extension API, Qt 6 / C++17, `QJsonDocument`, Emscripten WASM, legacy IPC wire format (`wasm32` little-endian u32 length-prefixed strings).
+
+**Spec:** `docs/superpowers/specs/2026-06-27-oid-wasm-session-persistence-design.md`
+
+## Global Constraints
+
+- **Repos:** OID C++/WASM in `/Users/bruno/ws/OpenImageDebugger`; extension in `/Users/bruno/ws/openimagedebugger-vscode`.
+- **Wire format:** `wasm32` — message-type header + u32 length-prefixed UTF-8 strings (no NUL).
+- **Message types:** `ApplySessionState = 6`, `SessionStateChanged = 7` (already in both `message_exchange.h` and `message-exchange.ts`).
+- **Already exists (extension):** `src/session/persistence.ts` with `loadSession`, `saveSession`, `mergeSessionDelta`, `migrateWatchOnStop`, `pruneExpiredBuffers`, debounced save; basic tests in `test/persistence.test.ts`. **Not yet wired** to panel/extension; **missing** C++ buffer-merge port and IPC codecs.
+- **Not in scope:** export, TypeBridge, shared desktop INI, `selectedBuffer` persistence, window geometry.
+- **Extension tests:** `npm run compile && npm test` in `openimagedebugger-vscode`.
+- **OID tests:** `cmake --build build --target test_session_state_codec && ctest -R SessionStateCodec`.
+
+---
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `openimagedebugger-vscode/src/session/persistence.ts` | Load/save/merge; buffer merge algorithm |
+| `openimagedebugger-vscode/src/ipc/message-exchange.ts` | Encode type 6; decode type 7 |
+| `openimagedebugger-vscode/src/webview/panel.ts` | Send restore on ready; route type 7 to persistence |
+| `openimagedebugger-vscode/src/extension.ts` | Lifecycle wiring |
+| `OpenImageDebugger/src/ui/messaging/session_state_codec.{h,cpp}` | JSON ↔ `SettingsApplier` |
+| `OpenImageDebugger/src/ui/messaging/message_handler.cpp` | Decode type 6 |
+| `OpenImageDebugger/src/ui/main_window/main_window.cpp` | WASM persist → type 7; skip QSettings load |
+| `OpenImageDebugger/tests/test_session_state_codec.cpp` | Codec unit tests |
+
+---
+
+### Task 1: Extension buffer merge + schema cleanup
+
+**Files:**
+- Modify: `openimagedebugger-vscode/src/session/persistence.ts`
+- Modify: `openimagedebugger-vscode/test/persistence.test.ts`
+
+**Interfaces produced:**
+- `mergeBuffersFromWasmDelta(state, delta, now?): OidSessionState`
+- `sessionStateForRestore(state, now?): OidSessionState` — prune expired before sending to WASM
+- Remove `selectedBuffer` from `OidSessionState` and `SessionDelta`
+
+- [ ] **Step 1: Write failing buffer-merge tests**
+
+Add to `test/persistence.test.ts`:
+
+```typescript
+import { mergeBuffersFromWasmDelta, sessionStateForRestore } from '../src/session/persistence.js';
+
+test('mergeBuffersFromWasmDelta keeps unheld unexpired buffers', () => {
+  const now = 1_000_000;
+  const state = mergeSessionDelta(defaultSessionState(), {
+    buffers: {
+      watched: [
+        { name: 'idle', expiresAt: now + 5000 },
+        { name: 'stale', expiresAt: now - 1 },
+      ],
+      removed: [],
+    },
+  });
+  const merged = mergeBuffersFromWasmDelta(
+    state,
+    { held: ['active'], removed: [] },
+    now
+  );
+  assert.deepEqual(
+    merged.buffers.watched.map((w) => w.name).sort(),
+    ['active', 'idle']
+  );
+  assert.equal(merged.buffers.watched.find((w) => w.name === 'active')!.expiresAt, now + BUFFER_EXPIRY_MS);
+});
+
+test('mergeBuffersFromWasmDelta drops removed and clears removed list', () => {
+  const now = 2_000_000;
+  const state = mergeSessionDelta(defaultSessionState(), {
+    buffers: {
+      watched: [{ name: 'gone', expiresAt: now + 5000 }],
+      removed: [],
+    },
+  });
+  const merged = mergeBuffersFromWasmDelta(state, { held: [], removed: ['gone'] }, now);
+  assert.deepEqual(merged.buffers.watched, []);
+  assert.deepEqual(merged.buffers.removed, []);
+});
+
+test('sessionStateForRestore filters expired watched entries', () => {
+  const now = 3_000_000;
+  const state = mergeSessionDelta(defaultSessionState(), {
+    buffers: {
+      watched: [
+        { name: 'ok', expiresAt: now + 1 },
+        { name: 'dead', expiresAt: now - 1 },
+      ],
+      removed: [],
+    },
+  });
+  const restored = sessionStateForRestore(state, now);
+  assert.deepEqual(
+    restored.buffers.watched.map((w) => w.name),
+    ['ok']
+  );
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/bruno/ws/openimagedebugger-vscode && npm run compile && npm test`
+Expected: FAIL — `mergeBuffersFromWasmDelta is not exported`
+
+- [ ] **Step 3: Implement merge helpers and remove selectedBuffer**
+
+Add to `persistence.ts`:
+
+```typescript
+export interface BufferPersistDelta {
+  held: readonly string[];
+  removed: readonly string[];
+}
+
+export function mergeBuffersFromWasmDelta(
+  state: OidSessionState,
+  delta: BufferPersistDelta,
+  now = Date.now()
+): OidSessionState {
+  const nextExpiry = now + BUFFER_EXPIRY_MS;
+  const heldSet = new Set(delta.held);
+  const removedSet = new Set(delta.removed);
+  const watched: WatchedBuffer[] = [];
+
+  for (const entry of state.buffers.watched) {
+    if (removedSet.has(entry.name)) continue;
+    if (heldSet.has(entry.name)) continue;
+    if (entry.expiresAt < now) continue;
+    watched.push(entry);
+  }
+  for (const name of delta.held) {
+    watched.push({ name, expiresAt: nextExpiry });
+  }
+
+  return mergeSessionDelta(state, { buffers: { watched, removed: [] } });
+}
+
+export function sessionStateForRestore(state: OidSessionState, now = Date.now()): OidSessionState {
+  return pruneExpiredBuffers(state, now);
+}
+
+export function applySessionDelta(
+  state: OidSessionState,
+  partial: SessionDelta,
+  now = Date.now()
+): OidSessionState {
+  const merged = mergeSessionDelta(state, partial);
+  if (partial.buffers?.held || partial.buffers?.removed) {
+    return mergeBuffersFromWasmDelta(merged, {
+      held: partial.buffers.held ?? [],
+      removed: partial.buffers.removed ?? merged.buffers.removed,
+    }, now);
+  }
+  return merged;
+}
+```
+
+Extend `SessionDelta` / WASM delta shape:
+
+```typescript
+export type SessionDelta = {
+  rendering?: Partial<OidSessionState['rendering']>;
+  export?: Partial<OidSessionState['export']>;
+  ui?: Partial<OidSessionState['ui']>;
+  buffers?: Partial<OidSessionState['buffers']> & {
+    held?: readonly string[];
+  };
+};
+```
+
+Remove `selectedBuffer` from `OidSessionState`, `SessionDelta`, and `mergeSessionDelta`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm run compile && npm test`
+Expected: PASS
+
+- [ ] **Step 5: Commit (extension repo)**
+
+```bash
+cd /Users/bruno/ws/openimagedebugger-vscode
+git add src/session/persistence.ts test/persistence.test.ts
+git commit -m "feat(session): add buffer merge algorithm for WASM deltas"
+```
+
+---
+
+### Task 2: Extension IPC codecs for types 6–7
+
+**Files:**
+- Modify: `openimagedebugger-vscode/src/ipc/message-exchange.ts`
+- Create: `openimagedebugger-vscode/test/message-exchange-session.test.ts`
+
+- [ ] **Step 1: Write failing IPC tests**
+
+```typescript
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import {
+  MessageType,
+  buildApplySessionState,
+  decodeInbound,
+} from '../src/ipc/message-exchange.js';
+
+test('buildApplySessionState encodes type 6 + JSON string', () => {
+  const json = '{"version":1}';
+  const bytes = buildApplySessionState(json);
+  assert.equal(bytes[0], MessageType.ApplySessionState);
+  const len = bytes[4] | (bytes[5] << 8) | (bytes[6] << 16) | (bytes[7] << 24);
+  assert.equal(len, json.length);
+  assert.equal(new TextDecoder().decode(bytes.subarray(8)), json);
+});
+
+test('decodeInbound parses SessionStateChanged JSON', () => {
+  const json = '{"ui":{"contrastEnabled":true}}';
+  const enc = new TextEncoder().encode(json);
+  const parts = new Uint8Array(4 + 4 + enc.length);
+  new DataView(parts.buffer).setUint32(0, MessageType.SessionStateChanged, true);
+  new DataView(parts.buffer).setUint32(4, enc.length, true);
+  parts.set(enc, 8);
+  const decoded = decodeInbound(parts);
+  assert.equal(decoded.kind, 'sessionStateChanged');
+  if (decoded.kind === 'sessionStateChanged') {
+    assert.equal(JSON.parse(decoded.json).ui.contrastEnabled, true);
+  }
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run compile && npm test`
+Expected: FAIL — `buildApplySessionState is not exported`
+
+- [ ] **Step 3: Implement codecs**
+
+In `message-exchange.ts`:
+
+```typescript
+export function buildApplySessionState(json: string, mode: WasmLengthMode = 'wasm32'): Uint8Array {
+  const parts: number[] = [];
+  pushU32(parts, MessageType.ApplySessionState);
+  pushString(parts, json, mode);
+  return new Uint8Array(parts);
+}
+
+export type InboundMessage =
+  | { kind: 'observedSymbols'; names: string[] }
+  | { kind: 'plotRequest'; name: string }
+  | { kind: 'exportRequest'; name: string; format: ExportFormat; contrast: Float32Array }
+  | { kind: 'sessionStateChanged'; json: string }
+  | { kind: 'unknown'; type: number };
+```
+
+Add to `decodeInbound` switch:
+
+```typescript
+case MessageType.SessionStateChanged:
+  return { kind: 'sessionStateChanged', json: readString() };
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm run compile && npm test`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ipc/message-exchange.ts test/message-exchange-session.test.ts
+git commit -m "feat(ipc): add ApplySessionState and SessionStateChanged codecs"
+```
+
+---
+
+### Task 3: Extension lifecycle wiring
+
+**Files:**
+- Modify: `openimagedebugger-vscode/src/webview/panel.ts`
+- Modify: `openimagedebugger-vscode/src/extension.ts`
+
+- [ ] **Step 1: Extend ViewerController with session hooks**
+
+In `panel.ts`, add imports and fields:
+
+```typescript
+import { buildApplySessionState } from '../ipc/message-exchange.js';
+import type { SessionDelta } from '../session/persistence.js';
+
+// in ViewerController:
+private onSessionStateChanged: ((json: string) => void) | undefined;
+private sessionRestoreJson: string | undefined;
+private restoreSent = false;
+
+setSessionStateChangedHandler(handler: (json: string) => void): void {
+  this.onSessionStateChanged = handler;
+}
+
+queueSessionRestore(json: string): void {
+  this.sessionRestoreJson = json;
+  this.restoreSent = false;
+  void this.maybeSendSessionRestore();
+}
+
+private async maybeSendSessionRestore(): Promise<void> {
+  if (!this.ready || this.restoreSent || !this.sessionRestoreJson) return;
+  await this.sendFrame(buildApplySessionState(this.sessionRestoreJson));
+  this.restoreSent = true;
+}
+```
+
+In `onDidReceiveMessage`, after setting `ready = true`:
+
+```typescript
+void this.maybeSendSessionRestore();
+```
+
+And in IPC decode branch:
+
+```typescript
+} else if (decoded.kind === 'sessionStateChanged') {
+  this.onSessionStateChanged?.(decoded.json);
+}
+```
+
+- [ ] **Step 2: Wire extension.ts**
+
+```typescript
+import {
+  loadSession,
+  migrateWatchOnStop,
+  sessionStateForRestore,
+  encodeSessionState,
+  applySessionDelta,
+  saveSessionDebounced,
+  type OidSessionState,
+} from './session/persistence.js';
+
+let sessionState: OidSessionState = loadSession(context);
+let watchSeededThisDebugSession = false;
+
+viewer.setSessionStateChangedHandler((json) => {
+  try {
+    const partial = JSON.parse(json) as SessionDelta;
+    sessionState = applySessionDelta(sessionState, partial);
+    saveSessionDebounced(context, sessionState);
+  } catch (err) {
+    console.warn('OID: invalid SessionStateChanged JSON', err);
+  }
+});
+
+// inside viewer-ready path — add helper called when panel opens first time per stop:
+function prepareSessionRestore(): void {
+  if (!watchSeededThisDebugSession) {
+    sessionState = migrateWatchOnStop(sessionState, watchList());
+    watchSeededThisDebugSession = true;
+  }
+  const restore = sessionStateForRestore(sessionState);
+  viewer.queueSessionRestore(encodeSessionState(restore));
+}
+
+// Call prepareSessionRestore() when viewer.openBeside() first runs per debug session
+// (e.g. in onStopped before manager.onStopped, after ensureReady is unnecessary — queue handles ready gate)
+```
+
+Reset `watchSeededThisDebugSession = false` in `onDidTerminateDebugSession`.
+
+Reload `sessionState = loadSession(context)` on extension activate only (already at init); do not reload on every stop.
+
+- [ ] **Step 3: Compile**
+
+Run: `npm run compile`
+Expected: no errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/webview/panel.ts src/extension.ts
+git commit -m "feat(session): restore and persist session state over IPC"
+```
+
+---
+
+### Task 4: C++ session_state_codec
+
+**Files:**
+- Create: `OpenImageDebugger/src/ui/messaging/session_state_codec.h`
+- Create: `OpenImageDebugger/src/ui/messaging/session_state_codec.cpp`
+- Create: `OpenImageDebugger/tests/test_session_state_codec.cpp`
+- Modify: `OpenImageDebugger/src/CMakeLists.txt`
+- Modify: `OpenImageDebugger/tests/CMakeLists.txt`
+
+- [ ] **Step 1: Write failing codec test**
+
+Create `tests/test_session_state_codec.cpp` with a mock/minimal applier recording calls, or test against real `SettingsApplier` with stub deps. Minimal approach — test JSON parsing helpers:
+
+```cpp
+#include <gtest/gtest.h>
+#include <QJsonDocument>
+#include "ui/messaging/session_state_codec.h"
+
+TEST(SessionStateCodec, ParsesFramerateAndContrast) {
+  const auto json = R"({"rendering":{"framerate":30},"ui":{"contrastEnabled":true}})";
+  SessionStateFields fields;
+  ASSERT_TRUE(parse_session_state_json(json, fields));
+  EXPECT_DOUBLE_EQ(fields.framerate.value(), 30.0);
+  EXPECT_TRUE(fields.contrast_enabled.value());
+}
+
+TEST(SessionStateCodec, ParsesWatchedBufferNames) {
+  const auto json = R"({"buffers":{"watched":[{"name":"img","expiresAt":9999999999000}]}})";
+  SessionStateFields fields;
+  ASSERT_TRUE(parse_session_state_json(json, fields));
+  ASSERT_EQ(fields.previous_session_buffers.size(), 1);
+  EXPECT_EQ(fields.previous_session_buffers.front(), QStringLiteral("img"));
+}
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+Run: `cmake --build build --target test_session_state_codec && ctest -R SessionStateCodec -V`
+Expected: build failure — target missing
+
+- [ ] **Step 3: Implement codec**
+
+`session_state_codec.h`:
+
+```cpp
+struct SessionStateFields {
+  std::optional<double> framerate;
+  std::optional<QString> default_export_suffix;
+  std::optional<QList<int>> splitter_sizes;
+  std::optional<QString> list_position;
+  std::optional<bool> minmax_visible;
+  std::optional<bool> minmax_compact;
+  std::optional<bool> contrast_enabled;
+  std::optional<bool> link_views_enabled;
+  std::optional<QString> colorspace;
+  QStringList previous_session_buffers;
+};
+
+bool parse_session_state_json(QByteArray json, SessionStateFields& out);
+void apply_session_state_fields(const SessionStateFields& fields, SettingsApplier& applier);
+QByteArray serialize_session_state_delta(/* callback sources matching MainWindow::persist_settings */);
+```
+
+Implement `apply_session_state_fields` by calling existing `SettingsApplier` slots (mirror `SettingsManager::load_*` mapping). Colorspace: parse 4-char string using same `b/g/r/a` → channel name logic as `settings_manager.cpp`.
+
+- [ ] **Step 4: Add to CMake**
+
+Add `session_state_codec.cpp` to `src/CMakeLists.txt` SOURCES.
+
+Add `test_session_state_codec` executable in `tests/CMakeLists.txt` (link Qt6::Core, gtest, oid sources or codec-only).
+
+- [ ] **Step 5: Run tests**
+
+Expected: PASS
+
+- [ ] **Step 6: Commit (OID repo)**
+
+```bash
+cd /Users/bruno/ws/OpenImageDebugger
+git add src/ui/messaging/session_state_codec.* tests/test_session_state_codec.cpp src/CMakeLists.txt tests/CMakeLists.txt
+git commit -m "feat(session): add session_state_codec for ApplySessionState JSON"
+```
+
+---
+
+### Task 5: C++ MessageHandler decode ApplySessionState
+
+**Files:**
+- Modify: `OpenImageDebugger/src/ui/messaging/message_handler.h`
+- Modify: `OpenImageDebugger/src/ui/messaging/message_handler.cpp`
+- Modify: `OpenImageDebugger/src/ui/main_window/main_window.cpp`
+
+- [ ] **Step 1: Add SettingsApplier to MessageHandler deps (EMSCRIPTEN only or always)**
+
+```cpp
+// message_handler.h Dependencies struct:
+SettingsApplier* settings_applier = nullptr; // non-owning; set on WASM path
+```
+
+- [ ] **Step 2: Implement decode_apply_session_state**
+
+```cpp
+void MessageHandler::decode_apply_session_state() {
+  auto message_decoder = MessageDecoder{deps_.transport};
+  auto json = std::string{};
+  message_decoder.read(json);
+  if (deps_.settings_applier == nullptr) return;
+  SessionStateFields fields;
+  if (!parse_session_state_json(QByteArray::fromStdString(json), fields)) {
+    std::cerr << "[OID] Invalid ApplySessionState JSON\n";
+    return;
+  }
+  apply_session_state_fields(fields, *deps_.settings_applier);
+}
+```
+
+Add `case MessageType::ApplySessionState:` to `decode_incoming_messages()`.
+
+Pass `settings_applier_.get()` when constructing `MessageHandler` in `main_window.cpp`.
+
+- [ ] **Step 3: Guard QSettings load on WASM**
+
+```cpp
+#ifndef __EMSCRIPTEN__
+    settings_manager_->load_settings();
+#endif
+```
+
+- [ ] **Step 4: Build WASM target**
+
+Run: `cmake --build build-wasm` (or project's emscripten build command)
+Expected: compiles
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(session): decode ApplySessionState in MessageHandler"
+```
+
+---
+
+### Task 6: C++ WASM persist → SessionStateChanged
+
+**Files:**
+- Modify: `OpenImageDebugger/src/ui/main_window/main_window.cpp`
+- Modify: `OpenImageDebugger/src/ui/messaging/session_state_codec.cpp`
+
+- [ ] **Step 1: Implement serialize_session_state_delta**
+
+Build JSON object from the same `DataCallbacks` already populated in `MainWindow::persist_settings()`:
+
+```cpp
+#ifdef __EMSCRIPTEN__
+void MainWindow::persist_settings() {
+  SettingsManager::DataCallbacks callbacks;
+  // ... existing callback lambdas unchanged ...
+
+  const auto json = serialize_session_state_delta(callbacks);
+  auto composer = MessageComposer{};
+  composer.push(MessageType::SessionStateChanged).push(std::string(json.constData(), json.size()))
+      .send(*postmessage_transport_);
+  return;
+}
+#endif
+SettingsManager::persist_settings(callbacks); // desktop path
+```
+
+JSON shape must match extension `SessionDelta`:
+
+```json
+{
+  "rendering": { "framerate": 60 },
+  "export": { "defaultSuffix": "Image File (*.png)" },
+  "ui": {
+    "splitterSizes": [200, 400],
+    "minmaxVisible": true,
+    "contrastEnabled": false,
+    "linkViewsEnabled": false,
+    "listPosition": "left",
+    "minmaxCompact": false,
+    "colorspace": "rgba"
+  },
+  "buffers": {
+    "held": ["img"],
+    "removed": ["old"]
+  }
+}
+```
+
+Collect `held` from `getCurrentBufferNames()`, `removed` from `getRemovedBufferNames()`, then call `clearRemovedBufferNames()` after serialize (same order as desktop persist).
+
+Also wire persist triggers for fields desktop doesn't write today but spec requires: list position, minmax compact, colorspace — read from UI state in callbacks.
+
+- [ ] **Step 2: Add codec round-trip test for serialize**
+
+Extend `test_session_state_codec.cpp` verifying serialize output contains `"held"` array keys.
+
+- [ ] **Step 3: Rebuild WASM and copy to extension media**
+
+Run project's wasm pack script (e.g. copy `oidwindow.wasm` / `oidwindow.js` to `openimagedebugger-vscode/media/`).
+
+- [ ] **Step 4: Commit both repos**
+
+```bash
+# OID
+git commit -m "feat(session): emit SessionStateChanged JSON from WASM persist"
+
+# Extension (media update)
+git add media/oidwindow.wasm media/oidwindow.js
+git commit -m "chore(media): rebuild WASM with session persistence IPC"
+```
+
+---
+
+### Task 7: Manual verification
+
+- [ ] **Step 1: Toggle contrast + move splitter → reload VS Code window → verify restored**
+
+- [ ] **Step 2: Add buffer to watch list → reload VS Code → break on next debug stop → verify auto-plot when symbol in scope**
+
+- [ ] **Step 3: Remove buffer → reload → verify it does not return**
+
+- [ ] **Step 4: Confirm desktop OID QSettings file unchanged after WASM session**
+
+---
+
+## Self-review
+
+| Spec requirement | Task |
+|------------------|------|
+| Extension-owned storage | 1, 3 |
+| IPC types 6–7 | 2, 5, 6 |
+| C++ SettingsApplier apply path | 4, 5 |
+| C++ persist callbacks + 100 ms debounce | 6 (WASM emit; extension debounce in Task 1) |
+| Buffer merge algorithm | 1 |
+| watchOnStop migration | 3 |
+| Skip QSettings on WASM | 5 |
+| No window geometry / selectedBuffer | 1, 4 |
+| Persist listPosition/minmaxCompact/colorspace | 6 |
+| Error handling invalid JSON | 3, 5 |
+| Unit tests | 1, 2, 4 |
+
+**Placeholder scan:** No TBD steps. All function names consistent (`mergeBuffersFromWasmDelta`, `buildApplySessionState`, `parse_session_state_json`, `apply_session_state_fields`).
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-27-oid-wasm-session-persistence.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** — execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/superpowers/plans/2026-06-28-oid-persistence-redesign.md
+++ b/docs/superpowers/plans/2026-06-28-oid-persistence-redesign.md
@@ -1,0 +1,1495 @@
+# OID Persistence Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist OID viewer state across VS Code restarts with behavioral parity to desktop C++ — global UI prefs plus an auto-captured, 1-day-expiring per-workspace set of plotted buffers that auto-replot in scope — without regressing autocompletion or plotting.
+
+**Architecture:** The extension is the single source of truth, split into two independent subsystems. **Buffers** (per-workspace) are owned entirely by the extension and synced via *existing* IPC (`GetObservedSymbols` 0/1 + `PlotBufferContents` 3) — no C++ change, replot decision never depends on IPC ordering. **UI prefs** (global) sync via new IPC `ApplySessionState` (6) and `SessionStateChanged` (7), applied/serialized in the viewer through the existing `SettingsApplier`.
+
+**Tech Stack:** TypeScript (`node:test`), VS Code Extension API, Qt 6 / C++20, `QJsonDocument`, Emscripten WASM, legacy IPC wire format (`wasm32` little-endian u32 length-prefixed strings).
+
+**Spec:** `docs/superpowers/specs/2026-06-28-oid-persistence-redesign-design.md`
+
+## Global Constraints
+
+- **Repos:** OID C++/WASM in `/Users/bruno/ws/OpenImageDebugger` (branch `feat/wasm-vscode`); extension in `/Users/bruno/ws/openimagedebugger-vscode` (branch `feat/live-update-local-wasm`).
+- **Wire format:** `wasm32` — message-type header (u32) + u32 length-prefixed UTF-8 strings (no NUL).
+- **Message types:** `ApplySessionState = 6`, `SessionStateChanged = 7` already declared in both `message_exchange.h` and `message-exchange.ts`. `float` is already in the C++ `PrimitiveType` concept.
+- **Storage scope:** UI prefs → `context.globalState`; buffer set → `context.workspaceState` (already per-workspace).
+- **Buffer expiry:** 1 day (`BUFFER_EXPIRATION_DAYS = 1`); persist debounce 100 ms (`SETTINGS_PERSIST_DELAY_MS`).
+- **Wire JSON shape** (types 6/7 payload, prefs only — no buffer keys):
+  ```json
+  {
+    "rendering": { "framerate": 60 },
+    "export": { "defaultSuffix": "Image File (*.png)" },
+    "ui": {
+      "splitterSizes": [200, 400],
+      "minmaxVisible": true,
+      "contrastEnabled": false,
+      "linkViewsEnabled": false,
+      "listPosition": "left",
+      "colorspace": "rgba"
+    }
+  }
+  ```
+- **Extension build/test:** `cd /Users/bruno/ws/openimagedebugger-vscode && npm run compile && npm test`.
+- **OID native test:** `cd /Users/bruno/ws/OpenImageDebugger && cmake build && cmake --build build --target test_session_state_codec && ctest --test-dir build -R SessionStateCodec`.
+- **OID WASM build + media sync:** `cd /Users/bruno/ws/OpenImageDebugger && bash wasm/scripts/build-wasm.sh --reconfigure && bash wasm/scripts/pack.sh`.
+- **Pre-existing untracked WIP:** OID may contain untracked `src/ui/messaging/session_state_{codec.h,codec.cpp,apply.cpp}` and `tests/test_session_state_codec.cpp`; the extension may contain untracked `test/message-exchange-session.test.ts`. The C++/test tasks below define the **authoritative** content — overwrite any WIP.
+- **No `Co-Authored-By` trailer in commits.**
+
+---
+
+## File map
+
+| File | Repo | Responsibility |
+|------|------|----------------|
+| `src/session/buffer-store.ts` | ext | **new** — per-workspace `wanted` set: seed, prune, refresh, removal-diff, persist |
+| `test/buffer-store.test.ts` | ext | **new** — buffer-store unit tests |
+| `src/session/pref-store.ts` | ext | **new** — global prefs: defaults, deep-merge, encode, applyDelta, debounce |
+| `test/pref-store.test.ts` | ext | **new** — pref-store unit tests |
+| `src/session/session-manager.ts` | ext | wire to buffer-store (replot `wanted ∪ held`, capture held) |
+| `test/session-manager.test.ts` | ext | updated for new deps |
+| `src/ipc/message-exchange.ts` | ext | codecs: build type 6, decode type 7 |
+| `test/message-exchange-session.test.ts` | ext | **new** — IPC 6/7 tests |
+| `src/webview/panel.ts` | ext | send type 6 on ready; route type 7 → handler |
+| `src/extension.ts` | ext | construct stores; lifecycle wiring |
+| `src/session/persistence.ts` + `test/persistence.test.ts` | ext | **removed** |
+| `src/ui/messaging/session_state_codec.{h,cpp}` | OID | prefs JSON parse + serialize (prefs only) |
+| `src/ui/messaging/session_state_apply.cpp` | OID | apply prefs via `SettingsApplier` |
+| `tests/test_session_state_codec.cpp` | OID | native codec unit tests |
+| `src/ui/messaging/message_handler.{h,cpp}` | OID | decode type 6 → applier |
+| `src/ui/main_window/main_window.cpp` | OID | EMSCRIPTEN persist→type 7; skip QSettings load |
+| `src/CMakeLists.txt`, `tests/CMakeLists.txt` | OID | register codec sources + test |
+
+---
+
+### Task 1: Remove dead persistence module (extension)
+
+`src/session/persistence.ts` is committed but unreferenced (verified: no imports in `src/`). It is replaced by `buffer-store.ts` + `pref-store.ts`.
+
+**Files:**
+- Delete: `openimagedebugger-vscode/src/session/persistence.ts`
+- Delete: `openimagedebugger-vscode/test/persistence.test.ts`
+
+- [ ] **Step 1: Confirm it is unreferenced**
+
+Run: `cd /Users/bruno/ws/openimagedebugger-vscode && grep -rn "persistence" src/`
+Expected: no matches.
+
+- [ ] **Step 2: Delete the files**
+
+```bash
+git rm src/session/persistence.ts test/persistence.test.ts
+```
+
+- [ ] **Step 3: Compile and test**
+
+Run: `npm run compile && npm test`
+Expected: compiles; remaining tests pass (the persistence tests are gone).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "refactor(session): remove unused persistence module"
+```
+
+---
+
+### Task 2: Buffer-store (extension, per-workspace)
+
+**Files:**
+- Create: `openimagedebugger-vscode/src/session/buffer-store.ts`
+- Create: `openimagedebugger-vscode/test/buffer-store.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `BUFFER_EXPIRY_MS: number`
+  - `interface WantedBuffer { name: string; expiresAt: number }`
+  - `pruneExpired(set, now): WantedBuffer[]`
+  - `seedWatchList(set, names, now): WantedBuffer[]`
+  - `applyStop(set, held, prevHeld, now): WantedBuffer[]`
+  - `class BufferStore { startSession(watchList, now?): void; names(now?): string[]; recordHeld(held, now?): void; reset(): void }`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/buffer-store.test.ts`:
+
+```typescript
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import {
+  BUFFER_EXPIRY_MS,
+  applyStop,
+  pruneExpired,
+  seedWatchList,
+  BufferStore,
+  type WantedBuffer,
+} from '../src/session/buffer-store.js';
+
+test('pruneExpired drops entries past their expiry', () => {
+  const now = 1_000;
+  const out = pruneExpired(
+    [
+      { name: 'keep', expiresAt: now + 1 },
+      { name: 'gone', expiresAt: now - 1 },
+    ],
+    now
+  );
+  assert.deepEqual(out.map((b) => b.name), ['keep']);
+});
+
+test('seedWatchList adds new names with fresh expiry, skips known/empty', () => {
+  const now = 5_000;
+  const out = seedWatchList([{ name: 'a', expiresAt: now + 10 }], ['a', '', 'b'], now);
+  assert.deepEqual(out.map((b) => b.name).sort(), ['a', 'b']);
+  assert.equal(out.find((b) => b.name === 'b')?.expiresAt, now + BUFFER_EXPIRY_MS);
+  assert.equal(out.find((b) => b.name === 'a')?.expiresAt, now + 10); // unchanged
+});
+
+test('applyStop refreshes held, keeps unexpired out-of-scope, drops expired', () => {
+  const now = 2_000;
+  const set: WantedBuffer[] = [
+    { name: 'held', expiresAt: now + 1 },
+    { name: 'offscreen', expiresAt: now + 999 },
+    { name: 'stale', expiresAt: now - 1 },
+  ];
+  const out = applyStop(set, ['held'], [], now);
+  const byName = new Map(out.map((b) => [b.name, b.expiresAt]));
+  assert.deepEqual([...byName.keys()].sort(), ['held', 'offscreen']);
+  assert.equal(byName.get('held'), now + BUFFER_EXPIRY_MS);
+  assert.equal(byName.get('offscreen'), now + 999);
+});
+
+test('applyStop drops a buffer that left the held set (removal)', () => {
+  const now = 3_000;
+  const set: WantedBuffer[] = [{ name: 'x', expiresAt: now + 999 }];
+  const out = applyStop(set, [], ['x'], now); // x was held last stop, now absent → removed
+  assert.deepEqual(out, []);
+});
+
+test('BufferStore round-trips through a memento and seeds once', () => {
+  const store = new Map<string, unknown>();
+  const memento = {
+    get: <T>(k: string, d: T): T => (store.has(k) ? (store.get(k) as T) : d),
+    update: (k: string, v: unknown) => {
+      store.set(k, v);
+      return Promise.resolve();
+    },
+    keys: () => [...store.keys()],
+  };
+  const now = 10_000;
+  const bs = new BufferStore(memento as never);
+  bs.startSession(['seed'], now);
+  assert.deepEqual(bs.names(now), ['seed']);
+  bs.recordHeld(['seed', 'live'], now);
+  assert.deepEqual(bs.names(now).sort(), ['live', 'seed']);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run compile && npm test`
+Expected: FAIL — `Cannot find module '../src/session/buffer-store.js'`.
+
+- [ ] **Step 3: Implement buffer-store**
+
+Create `src/session/buffer-store.ts`:
+
+```typescript
+import type * as vscode from 'vscode';
+
+/** 1 day, matching desktop BUFFER_EXPIRATION_DAYS. */
+export const BUFFER_EXPIRY_MS = 24 * 60 * 60 * 1000;
+const BUFFERS_KEY = 'oid.session.buffers.v1';
+
+export interface WantedBuffer {
+  name: string;
+  expiresAt: number; // unix ms
+}
+
+export function pruneExpired(set: readonly WantedBuffer[], now: number): WantedBuffer[] {
+  return set.filter((b) => b.expiresAt >= now);
+}
+
+export function seedWatchList(
+  set: readonly WantedBuffer[],
+  names: readonly string[],
+  now: number
+): WantedBuffer[] {
+  const result = [...set];
+  const known = new Set(result.map((b) => b.name));
+  for (const name of names) {
+    if (name.length === 0 || known.has(name)) continue;
+    result.push({ name, expiresAt: now + BUFFER_EXPIRY_MS });
+    known.add(name);
+  }
+  return result;
+}
+
+/**
+ * Desktop merge algorithm: drop buffers that left the held set since the last
+ * stop (removed) or expired; keep unexpired out-of-scope buffers; refresh every
+ * currently-held buffer with a fresh expiry.
+ */
+export function applyStop(
+  set: readonly WantedBuffer[],
+  held: readonly string[],
+  prevHeld: readonly string[],
+  now: number
+): WantedBuffer[] {
+  const heldSet = new Set(held);
+  const removed = new Set(prevHeld.filter((n) => !heldSet.has(n)));
+  const map = new Map<string, number>();
+  for (const b of set) {
+    if (removed.has(b.name)) continue;
+    if (b.expiresAt < now) continue;
+    map.set(b.name, b.expiresAt);
+  }
+  for (const name of held) {
+    map.set(name, now + BUFFER_EXPIRY_MS);
+  }
+  return [...map.entries()].map(([name, expiresAt]) => ({ name, expiresAt }));
+}
+
+/** Per-workspace auto-replot set; back it with `context.workspaceState`. */
+export class BufferStore {
+  private wanted: WantedBuffer[] = [];
+  private prevHeld: string[] = [];
+  private saveTimer: ReturnType<typeof setTimeout> | undefined;
+
+  constructor(private readonly memento: vscode.Memento) {}
+
+  /** Seed once per debug session: load persisted, prune, merge watch list. */
+  startSession(watchList: readonly string[], now = Date.now()): void {
+    const stored = this.memento.get<WantedBuffer[]>(BUFFERS_KEY, []);
+    this.wanted = seedWatchList(pruneExpired(stored, now), watchList, now);
+    this.prevHeld = [];
+  }
+
+  /** Non-expired names to attempt to replot. */
+  names(now = Date.now()): string[] {
+    return pruneExpired(this.wanted, now).map((b) => b.name);
+  }
+
+  /** Capture currently-held buffers: refresh/drop/keep, then persist. */
+  recordHeld(held: readonly string[], now = Date.now()): void {
+    this.wanted = applyStop(this.wanted, held, this.prevHeld, now);
+    this.prevHeld = [...held];
+    this.saveDebounced();
+  }
+
+  /** Clear the in-session diff baseline at session end (keeps persisted set). */
+  reset(): void {
+    this.prevHeld = [];
+  }
+
+  private saveDebounced(delayMs = 100): void {
+    if (this.saveTimer) clearTimeout(this.saveTimer);
+    this.saveTimer = setTimeout(() => {
+      this.saveTimer = undefined;
+      void this.memento.update(BUFFERS_KEY, this.wanted);
+    }, delayMs);
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm run compile && npm test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/session/buffer-store.ts test/buffer-store.test.ts
+git commit -m "feat(session): add per-workspace buffer-store with desktop merge semantics"
+```
+
+---
+
+### Task 3: Wire buffer-store into session-manager + extension
+
+**Files:**
+- Modify: `openimagedebugger-vscode/src/session/session-manager.ts`
+- Modify: `openimagedebugger-vscode/test/session-manager.test.ts`
+- Modify: `openimagedebugger-vscode/src/extension.ts`
+
+**Interfaces:**
+- Consumes: `BufferStore` from Task 2.
+- Produces: `SessionDeps` now has `beginBufferSession: () => void`, `wantedBuffers: () => string[]`, `captureHeld: (held: string[]) => void` (replaces `getWatchList`).
+
+- [ ] **Step 1: Update session-manager deps and `onStopped`**
+
+In `src/session/session-manager.ts`, replace the `getWatchList` field in `SessionDeps`:
+
+```typescript
+  // remove: getWatchList: () => string[];
+  beginBufferSession: () => void;
+  wantedBuffers: () => string[];
+  captureHeld: (held: string[]) => void;
+```
+
+Replace the body of `onStopped` with:
+
+```typescript
+  async onStopped(threadId: number): Promise<void> {
+    if (this.replotting) return;
+    this.replotting = true;
+    try {
+      const frameId = await this.deps.resolveFrame(threadId);
+      try {
+        const syms = await this.deps.listScopeSymbols(frameId);
+        await this.deps.channel.setAvailableSymbols(syms.map((s) => s.name));
+      } catch (err) {
+        this.deps.warn(
+          `OID: could not list symbols: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+      if (!this.seeded) {
+        this.deps.beginBufferSession();
+        this.seeded = true;
+      }
+      const observed = await this.deps.channel.getObservedSymbols();
+      const targets = [...new Set([...observed, ...this.deps.wantedBuffers()])];
+      const succeeded: string[] = [];
+      for (const name of targets) {
+        if (await this.plotAtFrame(name, frameId, { warnOnError: true })) {
+          succeeded.push(name);
+        }
+      }
+      const held = [...new Set([...observed, ...succeeded])];
+      this.deps.captureHeld(held);
+    } catch {
+      // Auto-replot is best-effort and silent when frame resolution fails.
+    } finally {
+      this.replotting = false;
+    }
+  }
+```
+
+`reset()` stays as-is (`this.seeded = false`).
+
+- [ ] **Step 2: Update the session-manager tests for the new deps**
+
+In `test/session-manager.test.ts`, edit the `harness` to drive a fake buffer-store. Replace the `getWatchList: () => [],` line in `deps` with:
+
+```typescript
+    beginBufferSession: () => {
+      wanted = [...new Set([...wanted, ...seedNames])];
+    },
+    wantedBuffers: () => wanted,
+    captureHeld: (held) => {
+      wanted = [...new Set([...wanted, ...held])];
+    },
+```
+
+Add these locals near the top of `harness` (beside `let observed`):
+
+```typescript
+  let wanted: string[] = [];
+  let seedNames: string[] = [];
+```
+
+Add a setter to the returned object (beside `setObserved`):
+
+```typescript
+    setSeed(names: string[]) {
+      seedNames = names;
+    },
+```
+
+Replace the two watch-list tests with buffer-store equivalents:
+
+```typescript
+test('onStopped seeds the buffer set on first stop only', async () => {
+  const h = harness();
+  h.setSeed(['seed']);
+  h.setObserved(['live']);
+  await h.mgr.onStopped(1);
+  assert.equal(h.sent.length, 2); // live + seed
+
+  h.setObserved(['live']);
+  h.sent.length = 0;
+  await h.mgr.onStopped(1);
+  assert.equal(h.sent.length, 2); // live (observed) + seed (now in wanted), seeded not re-run
+});
+
+test('reset clears seeded so the buffer session is begun again', async () => {
+  const h = harness();
+  h.setSeed(['seed']);
+  h.setObserved([]);
+  await h.mgr.onStopped(1);
+  assert.equal(h.sent.length, 1); // seed
+
+  h.mgr.reset();
+  h.setObserved([]);
+  h.sent.length = 0;
+  await h.mgr.onStopped(1);
+  assert.equal(h.sent.length, 1); // seed again
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `npm run compile && npm test`
+Expected: FAIL — `extension.ts` still passes `getWatchList` (compile error) and/or session-manager tests fail until extension wiring is updated. Proceed to Step 4 before re-running.
+
+- [ ] **Step 4: Wire the store in `extension.ts`**
+
+In `src/extension.ts` add the import:
+
+```typescript
+import { BufferStore } from './session/buffer-store.js';
+```
+
+After `const viewer = new ViewerController(context);` add:
+
+```typescript
+  const bufferStore = new BufferStore(context.workspaceState);
+```
+
+In the `new SessionManager({ ... })` deps, replace `getWatchList: watchList,` with:
+
+```typescript
+    beginBufferSession: () => bufferStore.startSession(watchList()),
+    wantedBuffers: () => bufferStore.names(),
+    captureHeld: (held) => bufferStore.recordHeld(held),
+```
+
+In the `onDidTerminateDebugSession` handler, add `bufferStore.reset();` next to `manager.reset();`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `npm run compile && npm test`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/session/session-manager.ts test/session-manager.test.ts src/extension.ts
+git commit -m "feat(session): drive auto-replot from the persisted buffer set"
+```
+
+---
+
+### Task 4: Pref-store (extension, global)
+
+**Files:**
+- Create: `openimagedebugger-vscode/src/session/pref-store.ts`
+- Create: `openimagedebugger-vscode/test/pref-store.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `interface OidPrefs { rendering:{framerate:number}; export:{defaultSuffix:string}; ui:{ splitterSizes:number[]; minmaxVisible:boolean; contrastEnabled:boolean; linkViewsEnabled:boolean; listPosition?:string; colorspace?:string } }`
+  - `type PrefsDelta` (deep-partial of `OidPrefs`)
+  - `defaultPrefs(): OidPrefs`
+  - `mergePrefs(base, partial): OidPrefs`
+  - `class PrefStore { get(): OidPrefs; encode(): string; applyDelta(json): void }`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/pref-store.test.ts`:
+
+```typescript
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import {
+  defaultPrefs,
+  mergePrefs,
+  PrefStore,
+} from '../src/session/pref-store.js';
+
+test('defaultPrefs matches desktop SettingsConstants', () => {
+  const d = defaultPrefs();
+  assert.equal(d.rendering.framerate, 60);
+  assert.equal(d.export.defaultSuffix, 'Image File (*.png)');
+  assert.equal(d.ui.minmaxVisible, true);
+  assert.equal(d.ui.contrastEnabled, false);
+});
+
+test('mergePrefs deep-merges nested groups', () => {
+  const out = mergePrefs(defaultPrefs(), {
+    ui: { contrastEnabled: true, colorspace: 'bgra' },
+    rendering: { framerate: 30 },
+  });
+  assert.equal(out.ui.contrastEnabled, true);
+  assert.equal(out.ui.colorspace, 'bgra');
+  assert.equal(out.rendering.framerate, 30);
+  assert.equal(out.export.defaultSuffix, 'Image File (*.png)'); // untouched
+});
+
+test('PrefStore.applyDelta merges and encode round-trips', () => {
+  const store = new Map<string, unknown>();
+  const memento = {
+    get: <T>(k: string, dft: T): T => (store.has(k) ? (store.get(k) as T) : dft),
+    update: (k: string, v: unknown) => {
+      store.set(k, v);
+      return Promise.resolve();
+    },
+    keys: () => [...store.keys()],
+  };
+  const ps = new PrefStore(memento as never);
+  ps.applyDelta(JSON.stringify({ ui: { linkViewsEnabled: true } }));
+  assert.equal(ps.get().ui.linkViewsEnabled, true);
+  assert.equal(JSON.parse(ps.encode()).ui.linkViewsEnabled, true);
+});
+
+test('PrefStore.applyDelta ignores invalid JSON', () => {
+  const memento = { get: <T>(_k: string, d: T) => d, update: () => Promise.resolve(), keys: () => [] };
+  const ps = new PrefStore(memento as never);
+  ps.applyDelta('{not json');
+  assert.equal(ps.get().rendering.framerate, 60); // unchanged
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run compile && npm test`
+Expected: FAIL — `Cannot find module '../src/session/pref-store.js'`.
+
+- [ ] **Step 3: Implement pref-store**
+
+Create `src/session/pref-store.ts`:
+
+```typescript
+import type * as vscode from 'vscode';
+
+const PREFS_KEY = 'oid.session.prefs.v1';
+
+export interface OidPrefs {
+  rendering: { framerate: number };
+  export: { defaultSuffix: string };
+  ui: {
+    splitterSizes: number[];
+    minmaxVisible: boolean;
+    contrastEnabled: boolean;
+    linkViewsEnabled: boolean;
+    listPosition?: string;
+    colorspace?: string;
+  };
+}
+
+export type PrefsDelta = {
+  rendering?: Partial<OidPrefs['rendering']>;
+  export?: Partial<OidPrefs['export']>;
+  ui?: Partial<OidPrefs['ui']>;
+};
+
+export function defaultPrefs(): OidPrefs {
+  return {
+    rendering: { framerate: 60 },
+    export: { defaultSuffix: 'Image File (*.png)' },
+    ui: {
+      splitterSizes: [],
+      minmaxVisible: true,
+      contrastEnabled: false,
+      linkViewsEnabled: false,
+    },
+  };
+}
+
+export function mergePrefs(base: OidPrefs, partial: PrefsDelta): OidPrefs {
+  return {
+    rendering: { ...base.rendering, ...partial.rendering },
+    export: { ...base.export, ...partial.export },
+    ui: { ...base.ui, ...partial.ui },
+  };
+}
+
+/** Global UI prefs; back it with `context.globalState`. */
+export class PrefStore {
+  private prefs: OidPrefs;
+  private saveTimer: ReturnType<typeof setTimeout> | undefined;
+
+  constructor(private readonly memento: vscode.Memento) {
+    this.prefs = mergePrefs(defaultPrefs(), this.memento.get<PrefsDelta>(PREFS_KEY, {}));
+  }
+
+  get(): OidPrefs {
+    return this.prefs;
+  }
+
+  /** Full snapshot to send as ApplySessionState (type 6). */
+  encode(): string {
+    return JSON.stringify(this.prefs);
+  }
+
+  /** Merge a SessionStateChanged (type 7) partial; persist debounced. */
+  applyDelta(json: string): void {
+    let partial: PrefsDelta;
+    try {
+      partial = JSON.parse(json) as PrefsDelta;
+    } catch (err) {
+      console.warn('OID: invalid SessionStateChanged JSON', err);
+      return;
+    }
+    this.prefs = mergePrefs(this.prefs, partial);
+    this.saveDebounced();
+  }
+
+  private saveDebounced(delayMs = 100): void {
+    if (this.saveTimer) clearTimeout(this.saveTimer);
+    this.saveTimer = setTimeout(() => {
+      this.saveTimer = undefined;
+      void this.memento.update(PREFS_KEY, this.prefs);
+    }, delayMs);
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm run compile && npm test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/session/pref-store.ts test/pref-store.test.ts
+git commit -m "feat(session): add global pref-store"
+```
+
+---
+
+### Task 5: IPC codecs for types 6/7 (extension)
+
+**Files:**
+- Modify: `openimagedebugger-vscode/src/ipc/message-exchange.ts`
+- Create: `openimagedebugger-vscode/test/message-exchange-session.test.ts`
+
+**Interfaces:**
+- Produces: `buildApplySessionState(json, mode?): Uint8Array`; `InboundMessage` gains `{ kind: 'sessionStateChanged'; json: string }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/message-exchange-session.test.ts`:
+
+```typescript
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import {
+  MessageType,
+  buildApplySessionState,
+  decodeInbound,
+} from '../src/ipc/message-exchange.js';
+
+test('buildApplySessionState encodes type 6 + JSON string', () => {
+  const json = '{"rendering":{"framerate":60}}';
+  const bytes = buildApplySessionState(json);
+  assert.equal(bytes[0], MessageType.ApplySessionState);
+  const len = bytes[4] | (bytes[5] << 8) | (bytes[6] << 16) | (bytes[7] << 24);
+  assert.equal(len, new TextEncoder().encode(json).length);
+  assert.equal(new TextDecoder().decode(bytes.subarray(8)), json);
+});
+
+test('decodeInbound parses SessionStateChanged JSON', () => {
+  const json = '{"ui":{"contrastEnabled":true}}';
+  const enc = new TextEncoder().encode(json);
+  const parts = new Uint8Array(4 + 4 + enc.length);
+  new DataView(parts.buffer).setUint32(0, MessageType.SessionStateChanged, true);
+  new DataView(parts.buffer).setUint32(4, enc.length, true);
+  parts.set(enc, 8);
+  const decoded = decodeInbound(parts);
+  assert.equal(decoded.kind, 'sessionStateChanged');
+  if (decoded.kind === 'sessionStateChanged') {
+    assert.equal(JSON.parse(decoded.json).ui.contrastEnabled, true);
+  }
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run compile && npm test`
+Expected: FAIL — `buildApplySessionState is not exported`.
+
+- [ ] **Step 3: Implement the codecs**
+
+In `src/ipc/message-exchange.ts`, after `buildExportSelectedBuffer`, add:
+
+```typescript
+/** Encode an ApplySessionState (type 6) message carrying a prefs JSON snapshot. */
+export function buildApplySessionState(
+  json: string,
+  mode: WasmLengthMode = 'wasm32'
+): Uint8Array {
+  const parts: number[] = [];
+  pushU32(parts, MessageType.ApplySessionState);
+  pushString(parts, json, mode);
+  return new Uint8Array(parts);
+}
+```
+
+In the `InboundMessage` union, add before `| { kind: 'unknown'; ... }`:
+
+```typescript
+  | { kind: 'sessionStateChanged'; json: string }
+```
+
+In the `decodeInbound` `switch`, add before `default:`:
+
+```typescript
+    case MessageType.SessionStateChanged:
+      return { kind: 'sessionStateChanged', json: readString() };
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm run compile && npm test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ipc/message-exchange.ts test/message-exchange-session.test.ts
+git commit -m "feat(ipc): add ApplySessionState/SessionStateChanged codecs"
+```
+
+---
+
+### Task 6: Pref lifecycle wiring (extension)
+
+**Files:**
+- Modify: `openimagedebugger-vscode/src/webview/panel.ts`
+- Modify: `openimagedebugger-vscode/src/extension.ts`
+
+**Interfaces:**
+- Consumes: `buildApplySessionState` (Task 5), `PrefStore` (Task 4).
+- Produces: `ViewerController.setSessionStateChangedHandler(fn)`, `ViewerController.queueSessionRestore(json)`.
+
+- [ ] **Step 1: Add session hooks to `ViewerController`**
+
+In `src/webview/panel.ts`, add `buildApplySessionState` to the import from `../ipc/message-exchange.js`.
+
+Add fields after `onExportBufferRequest`:
+
+```typescript
+  private onSessionStateChanged: ((json: string) => void) | undefined;
+  private sessionRestoreJson: string | undefined;
+  private restoreSent = false;
+```
+
+Add methods next to `setExportBufferRequestHandler`:
+
+```typescript
+  setSessionStateChangedHandler(handler: (json: string) => void): void {
+    this.onSessionStateChanged = handler;
+  }
+
+  /** Queue a prefs snapshot; sent now if ready, else on viewer-ready. */
+  queueSessionRestore(json: string): void {
+    this.sessionRestoreJson = json;
+    this.restoreSent = false;
+    void this.maybeSendSessionRestore();
+  }
+
+  private async maybeSendSessionRestore(): Promise<void> {
+    if (!this.ready || this.restoreSent || this.sessionRestoreJson === undefined) return;
+    this.restoreSent = true;
+    await this.sendFrame(buildApplySessionState(this.sessionRestoreJson));
+  }
+```
+
+In `onDidReceiveMessage`, in the `viewer-ready` branch, after `for (const w of this.readyWaiters.splice(0)) w();` add:
+
+```typescript
+        void this.maybeSendSessionRestore();
+```
+
+In the `oid-ipc-out` decode chain, after the `exportRequest` branch add:
+
+```typescript
+        } else if (decoded.kind === 'sessionStateChanged') {
+          this.onSessionStateChanged?.(decoded.json);
+```
+
+In both `panel.onDidDispose(...)` and `dispose()`, add `this.restoreSent = false;` next to `this.ready = false;`.
+
+- [ ] **Step 2: Wire `extension.ts`**
+
+In `src/extension.ts` add the import:
+
+```typescript
+import { PrefStore } from './session/pref-store.js';
+```
+
+After `const bufferStore = new BufferStore(context.workspaceState);` add:
+
+```typescript
+  const prefStore = new PrefStore(context.globalState);
+
+  viewer.setSessionStateChangedHandler((json) => prefStore.applyDelta(json));
+
+  const restorePrefs = (): void => {
+    viewer.queueSessionRestore(prefStore.encode());
+  };
+```
+
+In the `stopped` handler's `if (!openedThisSession) { ... }` block, after `viewer.openBeside();` add `restorePrefs();`.
+
+In the `oid.openPanel` command, change the body to:
+
+```typescript
+    vscode.commands.registerCommand('oid.openPanel', () => {
+      viewer.openBeside();
+      restorePrefs();
+    }),
+```
+
+In the export handler (`viewer.setExportBufferRequestHandler`), change the final `'Image File (*.png)'` argument to:
+
+```typescript
+      prefStore.get().export.defaultSuffix
+```
+
+- [ ] **Step 3: Compile and test**
+
+Run: `npm run compile && npm test`
+Expected: compiles; all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/webview/panel.ts src/extension.ts
+git commit -m "feat(session): restore and persist UI prefs over IPC"
+```
+
+---
+
+### Task 7: C++ session_state_codec (prefs only)
+
+**Files:**
+- Create: `OpenImageDebugger/src/ui/messaging/session_state_codec.h`
+- Create: `OpenImageDebugger/src/ui/messaging/session_state_codec.cpp`
+- Create: `OpenImageDebugger/src/ui/messaging/session_state_apply.cpp`
+- Create: `OpenImageDebugger/tests/test_session_state_codec.cpp`
+- Modify: `OpenImageDebugger/src/CMakeLists.txt`
+- Modify: `OpenImageDebugger/tests/CMakeLists.txt`
+
+**Interfaces:**
+- Produces: `parse_session_state_json(QByteArray, SessionStateFields&) -> bool`; `serialize_session_state_delta(DataCallbacks, SessionStateExtraInputs) -> QByteArray`; `apply_session_state_fields(SessionStateFields, SettingsApplier&)`.
+
+(All files use the standard OID MIT license header — copy it from any existing file in `src/ui/messaging/`.)
+
+- [ ] **Step 1: Write the failing native test**
+
+Create `tests/test_session_state_codec.cpp` (with license header):
+
+```cpp
+#include <QCoreApplication>
+#include <gtest/gtest.h>
+
+#include "ui/messaging/session_state_codec.h"
+
+using namespace oid;
+
+namespace {
+QCoreApplication& GetApplication() {
+    static int argc = 1;
+    static std::string app_name = "test";
+    static char* argv[] = {app_name.data(), nullptr};
+    static QCoreApplication application(argc, argv);
+    return application;
+}
+} // namespace
+
+TEST(SessionStateCodec, ParsesPrefs) {
+    GetApplication();
+    const auto json = QByteArray(
+        R"({"rendering":{"framerate":30},"ui":{"contrastEnabled":true,)"
+        R"("listPosition":"bottom","colorspace":"bgra"}})");
+    SessionStateFields fields;
+    ASSERT_TRUE(parse_session_state_json(json, fields));
+    ASSERT_TRUE(fields.framerate.has_value());
+    EXPECT_DOUBLE_EQ(*fields.framerate, 30.0);
+    ASSERT_TRUE(fields.contrast_enabled.has_value());
+    EXPECT_TRUE(*fields.contrast_enabled);
+    ASSERT_TRUE(fields.list_position.has_value());
+    EXPECT_EQ(*fields.list_position, QStringLiteral("bottom"));
+    ASSERT_TRUE(fields.colorspace.has_value());
+    EXPECT_EQ(*fields.colorspace, QStringLiteral("bgra"));
+}
+
+TEST(SessionStateCodec, SerializeIsPrefsOnly) {
+    GetApplication();
+    SettingsManager::DataCallbacks callbacks;
+    callbacks.getRenderFramerate = [] { return 60.0; };
+    callbacks.getDefaultExportSuffix = [] { return QStringLiteral("Image File (*.png)"); };
+    callbacks.getSplitterSizes = [] { return QList<int>{100, 200}; };
+    callbacks.getMinMaxVisible = [] { return true; };
+    callbacks.getContrastEnabled = [] { return false; };
+    callbacks.getLinkViewsEnabled = [] { return false; };
+
+    SessionStateExtraInputs extra;
+    extra.getColorspace = [] { return QStringLiteral("rgba"); };
+    extra.getListPosition = [] { return QStringLiteral("left"); };
+
+    const auto json = serialize_session_state_delta(callbacks, extra);
+    EXPECT_TRUE(json.contains("\"framerate\""));
+    EXPECT_TRUE(json.contains("\"colorspace\""));
+    EXPECT_FALSE(json.contains("\"held\""));     // no buffer keys
+    EXPECT_FALSE(json.contains("\"buffers\""));
+}
+```
+
+- [ ] **Step 2: Create the header**
+
+Create `src/ui/messaging/session_state_codec.h` (with license header):
+
+```cpp
+#ifndef SESSION_STATE_CODEC_H_
+#define SESSION_STATE_CODEC_H_
+
+#include <functional>
+#include <optional>
+
+#include <QByteArray>
+#include <QList>
+#include <QString>
+
+#include "ui/main_window/settings_manager.h"
+
+namespace oid {
+
+class SettingsApplier;
+
+struct SessionStateFields {
+    std::optional<double> framerate;
+    std::optional<QString> default_export_suffix;
+    std::optional<QList<int>> splitter_sizes;
+    std::optional<QString> list_position;
+    std::optional<bool> minmax_visible;
+    std::optional<bool> minmax_compact;
+    std::optional<bool> contrast_enabled;
+    std::optional<bool> link_views_enabled;
+    std::optional<QString> colorspace;
+};
+
+struct SessionStateExtraInputs {
+    std::function<QString()> getListPosition;
+    std::function<QString()> getColorspace;
+};
+
+bool parse_session_state_json(const QByteArray& json, SessionStateFields& out);
+
+void apply_session_state_fields(const SessionStateFields& fields,
+                                SettingsApplier& applier);
+
+QByteArray serialize_session_state_delta(
+    const SettingsManager::DataCallbacks& callbacks,
+    const SessionStateExtraInputs& extra);
+
+} // namespace oid
+
+#endif // SESSION_STATE_CODEC_H_
+```
+
+- [ ] **Step 3: Implement parse + serialize**
+
+Create `src/ui/messaging/session_state_codec.cpp` (with license header):
+
+```cpp
+#include "session_state_codec.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+
+namespace oid {
+
+namespace {
+
+std::optional<bool> read_bool(const QJsonObject& obj, const char* key) {
+    if (!obj.contains(key)) return std::nullopt;
+    return obj.value(key).toBool();
+}
+
+std::optional<double> read_double(const QJsonObject& obj, const char* key) {
+    if (!obj.contains(key)) return std::nullopt;
+    return obj.value(key).toDouble();
+}
+
+std::optional<QString> read_string(const QJsonObject& obj, const char* key) {
+    if (!obj.contains(key)) return std::nullopt;
+    return obj.value(key).toString();
+}
+
+} // namespace
+
+bool parse_session_state_json(const QByteArray& json, SessionStateFields& out) {
+    const auto doc = QJsonDocument::fromJson(json);
+    if (!doc.isObject()) return false;
+    const auto root = doc.object();
+
+    if (const auto rendering = root.value(QStringLiteral("rendering")).toObject();
+        !rendering.isEmpty()) {
+        out.framerate = read_double(rendering, "framerate");
+    }
+    if (const auto exp = root.value(QStringLiteral("export")).toObject();
+        !exp.isEmpty()) {
+        out.default_export_suffix = read_string(exp, "defaultSuffix");
+    }
+    if (const auto ui = root.value(QStringLiteral("ui")).toObject(); !ui.isEmpty()) {
+        out.list_position = read_string(ui, "listPosition");
+        out.minmax_visible = read_bool(ui, "minmaxVisible");
+        out.minmax_compact = read_bool(ui, "minmaxCompact");
+        out.contrast_enabled = read_bool(ui, "contrastEnabled");
+        out.link_views_enabled = read_bool(ui, "linkViewsEnabled");
+        out.colorspace = read_string(ui, "colorspace");
+        if (ui.contains(QStringLiteral("splitterSizes"))) {
+            const auto arr = ui.value(QStringLiteral("splitterSizes")).toArray();
+            auto sizes = QList<int>{};
+            for (const auto& v : arr) sizes.append(v.toInt());
+            out.splitter_sizes = sizes;
+        }
+    }
+    return true;
+}
+
+QByteArray serialize_session_state_delta(
+    const SettingsManager::DataCallbacks& callbacks,
+    const SessionStateExtraInputs& extra) {
+    auto rendering = QJsonObject{};
+    rendering.insert(QStringLiteral("framerate"), callbacks.getRenderFramerate());
+
+    auto exp = QJsonObject{};
+    exp.insert(QStringLiteral("defaultSuffix"), callbacks.getDefaultExportSuffix());
+
+    auto ui = QJsonObject{};
+    auto sizes = QJsonArray{};
+    for (const int s : callbacks.getSplitterSizes()) sizes.append(s);
+    ui.insert(QStringLiteral("splitterSizes"), sizes);
+    ui.insert(QStringLiteral("minmaxVisible"), callbacks.getMinMaxVisible());
+    ui.insert(QStringLiteral("contrastEnabled"), callbacks.getContrastEnabled());
+    ui.insert(QStringLiteral("linkViewsEnabled"), callbacks.getLinkViewsEnabled());
+    if (extra.getListPosition) {
+        if (const auto p = extra.getListPosition(); !p.isEmpty()) {
+            ui.insert(QStringLiteral("listPosition"), p);
+        }
+    }
+    if (extra.getColorspace) {
+        if (const auto c = extra.getColorspace(); !c.isEmpty()) {
+            ui.insert(QStringLiteral("colorspace"), c);
+        }
+    }
+
+    auto root = QJsonObject{};
+    root.insert(QStringLiteral("rendering"), rendering);
+    root.insert(QStringLiteral("export"), exp);
+    root.insert(QStringLiteral("ui"), ui);
+    return QJsonDocument{root}.toJson(QJsonDocument::Compact);
+}
+
+} // namespace oid
+```
+
+- [ ] **Step 4: Implement apply (separate TU so the test need not link SettingsApplier)**
+
+Create `src/ui/messaging/session_state_apply.cpp` (with license header):
+
+```cpp
+#include "session_state_codec.h"
+
+#include "ui/main_window/settings_applier.h"
+
+namespace oid {
+
+namespace {
+
+QString colorspace_channel_from_char(const QChar& character) {
+    switch (character.toLatin1()) {
+    case 'b': return QStringLiteral("blue");
+    case 'g': return QStringLiteral("green");
+    case 'r': return QStringLiteral("red");
+    case 'a': return QStringLiteral("alpha");
+    default: return {};
+    }
+}
+
+} // namespace
+
+void apply_session_state_fields(const SessionStateFields& fields,
+                                SettingsApplier& applier) {
+    if (fields.framerate.has_value()) {
+        applier.apply_rendering_settings(*fields.framerate);
+    }
+    if (fields.default_export_suffix.has_value()) {
+        applier.apply_export_settings(*fields.default_export_suffix);
+    }
+    if (fields.list_position.has_value()) {
+        applier.apply_ui_list_position(*fields.list_position);
+    }
+    if (fields.splitter_sizes.has_value()) {
+        applier.apply_ui_splitter_sizes(*fields.splitter_sizes);
+    }
+    if (fields.minmax_compact.has_value() && fields.minmax_visible.has_value()) {
+        applier.apply_ui_minmax_compact(*fields.minmax_compact,
+                                        *fields.minmax_visible);
+    } else if (fields.minmax_visible.has_value()) {
+        applier.apply_ui_minmax_visible(*fields.minmax_visible);
+    }
+    if (fields.colorspace.has_value()) {
+        const auto& cs = *fields.colorspace;
+        QString ch1, ch2, ch3, ch4;
+        if (cs.size() > 0) ch1 = colorspace_channel_from_char(cs.at(0));
+        if (cs.size() > 1) ch2 = colorspace_channel_from_char(cs.at(1));
+        if (cs.size() > 2) ch3 = colorspace_channel_from_char(cs.at(2));
+        if (cs.size() > 3) ch4 = colorspace_channel_from_char(cs.at(3));
+        applier.apply_ui_colorspace(ch1, ch2, ch3, ch4);
+    }
+    if (fields.contrast_enabled.has_value()) {
+        applier.apply_ui_contrast_enabled(*fields.contrast_enabled);
+    }
+    if (fields.link_views_enabled.has_value()) {
+        applier.apply_ui_link_views_enabled(*fields.link_views_enabled);
+    }
+}
+
+} // namespace oid
+```
+
+- [ ] **Step 5: Register in CMake**
+
+In `src/CMakeLists.txt`, in the SOURCES list right after `ui/messaging/message_handler.cpp`, add:
+
+```cmake
+    ui/messaging/session_state_apply.cpp
+    ui/messaging/session_state_codec.cpp
+```
+
+In `tests/CMakeLists.txt`, after the `TransportTests` block, add:
+
+```cmake
+# Test for session state JSON codec
+add_executable(test_session_state_codec
+    test_session_state_codec.cpp
+)
+
+target_include_directories(test_session_state_codec
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src
+)
+
+target_link_libraries(test_session_state_codec
+    PRIVATE
+    Qt6::Core
+    GTest::gtest_main
+    GTest::gtest
+)
+
+target_sources(test_session_state_codec PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ui/messaging/session_state_codec.cpp
+)
+
+add_test(NAME SessionStateCodec COMMAND test_session_state_codec)
+```
+
+- [ ] **Step 6: Build and run the test**
+
+Run: `cmake build && cmake --build build --target test_session_state_codec && ctest --test-dir build -R SessionStateCodec --output-on-failure`
+Expected: PASS (2 tests).
+
+- [ ] **Step 7: Verify apply compiles in the main target**
+
+Run: `ninja -C build src/CMakeFiles/oidwindow.dir/ui/messaging/session_state_apply.cpp.o`
+Expected: builds with no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/bruno/ws/OpenImageDebugger
+git add src/ui/messaging/session_state_codec.h src/ui/messaging/session_state_codec.cpp \
+  src/ui/messaging/session_state_apply.cpp tests/test_session_state_codec.cpp \
+  src/CMakeLists.txt tests/CMakeLists.txt
+git commit -m "feat(session): add prefs-only session_state_codec"
+```
+
+---
+
+### Task 8: C++ MessageHandler decode type 6 + main_window wiring
+
+**Files:**
+- Modify: `OpenImageDebugger/src/ui/messaging/message_handler.h`
+- Modify: `OpenImageDebugger/src/ui/messaging/message_handler.cpp`
+- Modify: `OpenImageDebugger/src/ui/main_window/main_window.cpp`
+
+**Interfaces:**
+- Consumes: `parse_session_state_json`, `apply_session_state_fields` (Task 7), `SettingsApplier`.
+- Produces: `MessageHandler::Dependencies.settings_applier` (non-owning, may be null).
+
+- [ ] **Step 1: Extend the handler header**
+
+In `src/ui/messaging/message_handler.h`:
+- After `struct WindowState;` add `class SettingsApplier;`.
+- In the `Dependencies` struct, after the `select_stage` field, add:
+
+```cpp
+        // Non-owning; applies inbound ApplySessionState. May be null where no
+        // session state is ever received (e.g. desktop).
+        SettingsApplier* settings_applier = nullptr;
+```
+
+- In the private methods, after `void decode_plot_buffer_contents();` add:
+
+```cpp
+    void decode_apply_session_state() const;
+```
+
+- [ ] **Step 2: Implement the decode in the handler**
+
+In `src/ui/messaging/message_handler.cpp`, add includes after `#include "ui/main_window/main_window.h"`:
+
+```cpp
+#include "ui/main_window/settings_applier.h"
+#include "ui/messaging/session_state_codec.h"
+```
+
+Add the method before `void MessageHandler::decode_incoming_messages()`:
+
+```cpp
+void MessageHandler::decode_apply_session_state() const {
+    auto message_decoder = MessageDecoder{deps_.transport};
+    auto json = std::string{};
+    message_decoder.read(json);
+
+    if (deps_.settings_applier == nullptr) {
+        return;
+    }
+    auto fields = SessionStateFields{};
+    if (!parse_session_state_json(QByteArray::fromStdString(json), fields)) {
+        std::cerr << "[OID] Invalid ApplySessionState JSON" << std::endl;
+        return;
+    }
+    apply_session_state_fields(fields, *deps_.settings_applier);
+}
+```
+
+In the `decode_incoming_messages()` switch, before `default:` add:
+
+```cpp
+    case MessageType::ApplySessionState:
+        decode_apply_session_state();
+        break;
+```
+
+- [ ] **Step 3: Construct the applier before the handler in `main_window.cpp`**
+
+In `src/ui/main_window/main_window.cpp`, move the `settings_applier_` construction so it precedes the message-handler construction. Insert this block immediately before the `// Initialize message handler` comment:
+
+```cpp
+    // Initialize settings applier (before the message handler so inbound
+    // ApplySessionState can be applied through it)
+    settings_applier_ = std::make_unique<SettingsApplier>(
+        SettingsApplier::Dependencies{ui_mutex_,
+                                      state_,
+                                      ui_components_,
+                                      buffer_data_,
+                                      channel_names_,
+                                      render_framerate_,
+                                      default_export_suffix_,
+                                      *this},
+        this);
+
+```
+
+Then delete the original `// Initialize settings applier` block (the duplicate `settings_applier_ = std::make_unique<SettingsApplier>(...)` that sits just before `connect_settings_signals();`).
+
+- [ ] **Step 4: Pass the applier into both handler dependency lists**
+
+In `main_window.cpp`, in **both** the `#ifdef __EMSCRIPTEN__` and `#else` `MessageHandler::Dependencies{ ... }` initializers, change the trailing `set_currently_selected_stage(stage); }}` to add the applier:
+
+```cpp
+            [this](const std::shared_ptr<Stage>& stage) {
+                set_currently_selected_stage(stage);
+            },
+            settings_applier_.get()},
+        this);
+```
+
+- [ ] **Step 5: Skip the QSettings load under EMSCRIPTEN**
+
+In `main_window.cpp`, replace:
+
+```cpp
+    // Load settings (must be done before initialization)
+    settings_manager_->load_settings();
+```
+
+with:
+
+```cpp
+    // Load settings (must be done before initialization).
+    // On WASM the extension owns persistence and prefs arrive via
+    // ApplySessionState (IPC type 6); skip the local QSettings load.
+#ifndef __EMSCRIPTEN__
+    settings_manager_->load_settings();
+#endif
+```
+
+- [ ] **Step 6: Build the affected objects (desktop path)**
+
+Run:
+```bash
+ninja -C build src/CMakeFiles/oidwindow.dir/ui/messaging/message_handler.cpp.o \
+  src/CMakeFiles/oidwindow.dir/ui/main_window/main_window.cpp.o
+```
+Expected: builds with no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ui/messaging/message_handler.h src/ui/messaging/message_handler.cpp \
+  src/ui/main_window/main_window.cpp
+git commit -m "feat(session): decode ApplySessionState in MessageHandler"
+```
+
+---
+
+### Task 9: C++ WASM persist → SessionStateChanged (prefs only)
+
+**Files:**
+- Modify: `OpenImageDebugger/src/ui/main_window/main_window.cpp`
+
+**Interfaces:**
+- Consumes: `serialize_session_state_delta`, `SessionStateExtraInputs` (Task 7); `MessageComposer`/`MessageType` (`ipc/message_exchange.h`).
+
+- [ ] **Step 1: Add includes**
+
+In `src/ui/main_window/main_window.cpp`, add near the other local includes:
+
+```cpp
+#include "ipc/message_exchange.h"
+#include "ui/messaging/session_state_codec.h"
+```
+
+- [ ] **Step 2: Emit prefs as type 7 on WASM persist**
+
+In `main_window.cpp`, in `MainWindow::persist_settings()`, replace the final line `SettingsManager::persist_settings(callbacks);` with:
+
+```cpp
+#ifdef __EMSCRIPTEN__
+    // The VS Code extension owns persistence on WASM: serialize prefs only and
+    // stream them as SessionStateChanged (IPC type 7). Buffers are handled
+    // extension-side via GetObservedSymbols, not here.
+    SessionStateExtraInputs extra;
+    extra.getColorspace = [this] {
+        const auto to_char = [](const QString& name) -> QChar {
+            if (name == QStringLiteral("red")) return QLatin1Char('r');
+            if (name == QStringLiteral("green")) return QLatin1Char('g');
+            if (name == QStringLiteral("blue")) return QLatin1Char('b');
+            if (name == QStringLiteral("alpha")) return QLatin1Char('a');
+            return {};
+        };
+        auto colorspace = QString{};
+        for (const auto& name : {channel_names_.name_channel_1,
+                                 channel_names_.name_channel_2,
+                                 channel_names_.name_channel_3,
+                                 channel_names_.name_channel_4}) {
+            if (const auto character = to_char(name); !character.isNull()) {
+                colorspace.append(character);
+            }
+        }
+        return colorspace;
+    };
+    extra.getListPosition = [this] {
+        auto* const splitter = ui_components_.ui->splitter;
+        const auto vertical = splitter->orientation() == Qt::Vertical;
+        const auto list_last =
+            splitter->indexOf(ui_components_.ui->frame_list) != 0;
+        if (vertical) {
+            return QString(list_last ? QStringLiteral("bottom")
+                                     : QStringLiteral("top"));
+        }
+        return QString(list_last ? QStringLiteral("right")
+                                 : QStringLiteral("left"));
+    };
+
+    const auto json = serialize_session_state_delta(callbacks, extra);
+    if (postmessage_transport_ != nullptr) {
+        auto composer = MessageComposer{};
+        composer.push(MessageType::SessionStateChanged)
+            .push(std::string(json.constData(),
+                              static_cast<std::size_t>(json.size())))
+            .send(*postmessage_transport_);
+    }
+#else
+    SettingsManager::persist_settings(callbacks);
+#endif
+```
+
+(Note: `minmaxCompact` is intentionally not emitted — no readable runtime state; the codec applies `minmaxVisible` alone when it is absent.)
+
+- [ ] **Step 3: Build the object (desktop path verifies includes + non-EMSCRIPTEN branch)**
+
+Run: `ninja -C build src/CMakeFiles/oidwindow.dir/ui/main_window/main_window.cpp.o`
+Expected: builds with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ui/main_window/main_window.cpp
+git commit -m "feat(session): emit prefs as SessionStateChanged from WASM persist"
+```
+
+---
+
+### Task 10: Build WASM and sync to the extension
+
+**Files:**
+- Modify (binary): `openimagedebugger-vscode/media/oidwindow.{wasm,js}`, `media/version.json`
+
+- [ ] **Step 1: Build the WASM viewer (exercises both EMSCRIPTEN paths)**
+
+Run: `cd /Users/bruno/ws/OpenImageDebugger && bash wasm/scripts/build-wasm.sh --reconfigure`
+Expected: exits 0; `build-wasm/src/oidwindow.{wasm,js}` produced. (`--reconfigure` is required because new source files were added to `src/CMakeLists.txt`.)
+
+- [ ] **Step 2: Pack and sync to the extension media folder**
+
+Run: `bash wasm/scripts/pack.sh`
+Expected: copies artifacts into `openimagedebugger-vscode/media/`.
+
+- [ ] **Step 3: Commit the media update (extension repo)**
+
+```bash
+cd /Users/bruno/ws/openimagedebugger-vscode
+git add media/oidwindow.wasm media/oidwindow.js media/version.json
+git commit -m "chore(media): rebuild WASM with persistence redesign"
+```
+
+---
+
+### Task 11: Manual verification
+
+No code; confirm behavioral parity and no regressions. Run the extension (F5) against a CodeLLDB session.
+
+- [ ] **Step 1: Prefs persist globally** — change framerate / toggle contrast / move splitter, reload the VS Code window, reopen the viewer → settings restored.
+
+- [ ] **Step 2: Buffers auto-replot per-workspace** — plot buffers, restart VS Code, start debugging, stop with those variables in scope → they auto-replot.
+
+- [ ] **Step 3: Removal sticks** — remove a buffer from the viewer, continue/stop again → it does not come back; after restart it stays gone.
+
+- [ ] **Step 4: Expiry** — a buffer not seen for >24 h is not replotted (can be checked with a temporary short expiry or by inspecting `workspaceState`).
+
+- [ ] **Step 5: No regressions** — autocomplete in the viewer search box still lists in-scope symbols; manual plot (`oid.plot`) still works; `oid.watchOnStop` still seeds on first run.
+
+- [ ] **Step 6: Desktop untouched** — run desktop OID (GDB/LLDB) and confirm its QSettings INI is still read/written normally.
+
+---
+
+## Self-review
+
+| Spec section | Task |
+|--------------|------|
+| §2 Architecture (extension source of truth, two subsystems) | 2–10 |
+| §3 Buffer persistence (seed, refresh, removal-diff, expiry, per-workspace) | 2, 3 |
+| §4 UI-pref persistence (fields, type 6/7, SettingsApplier, skip QSettings, minmaxCompact omitted) | 4–9 |
+| §5 Data model / storage keys / wire format / module layout | 2, 4, 5, 7 |
+| §6 Regression safeguards (autocomplete, ordering, desktop) | 3, 8, 11 |
+| §7 Error handling (invalid JSON, expiry, timeouts) | 2, 4, 8 |
+| §8 Testing (ext unit, native codec, manual) | 2, 4, 5, 7, 11 |
+| §9 Success criteria | 11 |
+| Removal of old conflated module | 1 |
+
+**Placeholder scan:** none — every code step contains full content.
+
+**Type consistency:** `BufferStore` API (`startSession`/`names`/`recordHeld`/`reset`) consistent across Tasks 2–3; `SessionDeps` new fields (`beginBufferSession`/`wantedBuffers`/`captureHeld`) consistent across Task 3 impl + tests + extension wiring; `PrefStore` (`get`/`encode`/`applyDelta`) consistent across Tasks 4 + 6; wire JSON shape (`rendering.framerate`, `ui.*`) identical in TS pref-store (Task 4), TS tests (Task 5), and C++ codec (Task 7); `buildApplySessionState` / `sessionStateChanged` consistent across Tasks 5–6; `SessionStateFields` / `SessionStateExtraInputs` consistent across Tasks 7–9.

--- a/docs/superpowers/plans/2026-06-29-ifdef-consolidation.md
+++ b/docs/superpowers/plans/2026-06-29-ifdef-consolidation.md
@@ -1,0 +1,1015 @@
+# Platform `#ifdef` Consolidation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove scattered `#ifdef __EMSCRIPTEN__` from the codebase by routing all WASM/native divergence through a single `src/platform/` boundary, using compile-time separation (CMake-selected translation units + injected strategy objects).
+
+**Architecture:** A new `src/platform/` directory owns every platform branch. Tangled shared+divergent logic is factored behind small interfaces/free functions (`ITransport` factory, `RenderScheduler`, `GlDialect`, `app_platform`, `session_persistence`, `ui_dialogs`) wired at one composition point. Wholly-disjoint method bodies (`GLCanvas`) are split into CMake-selected `_native.cpp`/`_wasm.cpp` translation units. After the work, `#ifdef __EMSCRIPTEN__` survives only inside `src/platform/` and in the single `GLCanvas` base-class line in `gl_canvas.h`.
+
+**Tech Stack:** C++20, Qt6 (6.11), CMake (≥3.28), Emscripten/Qt-for-WebAssembly, GoogleTest.
+
+## Global Constraints
+
+- Pure restructuring: **no behavior change**. Moved bodies must be logic-equivalent to the originals.
+- The MIT license header block (lines 1-24 of every existing source file) must be copied verbatim to every new file.
+- All new code lives in `namespace oid` (or `namespace oid::platform` for platform helpers), matching existing style: 4-space indent, trailing-`_` private members, `[[nodiscard]]` on pure getters.
+- Transport interface type is `oid::ITransport` (in `src/ipc/transport.h`).
+- The only permitted `#ifdef __EMSCRIPTEN__` outside `src/platform/` after this work is the `GLCanvas` base-class block in `src/ui/gl_canvas.h`.
+- Do NOT touch unrelated guards: `Q_OS_DARWIN` (`event_handler.cpp:78`), Python-version guards (`python_native_interface.*`), thirdparty.
+
+### Per-task verification cycle
+
+Every task ends with this cycle (substitute your build dir if not `cmake-build-debug`):
+
+```bash
+# 1. Native configure + build (always required)
+cmake -S . -B cmake-build-debug -DBUILD_TESTS=ON >/dev/null
+cmake --build cmake-build-debug --target oidwindow -j 4
+
+# 2. Native tests (always required)
+ctest --test-dir cmake-build-debug --output-on-failure
+
+# 3. WASM build (required IF EMSDK is set up; otherwise note "skipped: no EMSDK")
+#    Needs: source $EMSDK/emsdk_env.sh ; Qt6 wasm kit at $QT6_WASM_DIR
+emcmake cmake -S . -B build-wasm -DQt6_DIR="$QT6_WASM_DIR/lib/cmake/Qt6" >/dev/null
+cmake --build build-wasm --target oidwindow -j 4
+```
+
+`Expected:` both builds succeed; ctest reports all pass. If EMSDK is unavailable, the WASM
+step is skipped and the task is marked "WASM-build-unverified" for a later pass — but the
+code MUST still be written so it would compile under Emscripten.
+
+---
+
+## File Structure
+
+**New (`src/platform/`):**
+
+| File | Responsibility |
+|------|----------------|
+| `platform_config.h` | `constexpr bool kIsWasm` |
+| `transport_factory.h` / `_native.cpp` / `_wasm.cpp` | build the right `ITransport` |
+| `render_scheduler.h` / `_native.cpp` / `_wasm.cpp` | run-now vs defer-to-GL-queue |
+| `gl_dialect.h` / `_native.cpp` / `_wasm.cpp` | shader version, texel/icon formats, GL caps |
+| `app_platform.h` / `_native.cpp` / `_wasm.cpp` | surface format, CLI parse, JS hooks, viewer-ready, disconnect guard |
+| `session_persistence.h` / `_native.cpp` / `_wasm.cpp` | persist + load settings |
+| `ui_dialogs.h` / `_native.cpp` / `_wasm.cpp` | export + context menu + async wiring |
+
+**New (`src/ui/`):** `gl_canvas_native.cpp`, `gl_canvas_wasm.cpp`.
+
+**Modified:** `src/CMakeLists.txt`, `src/oid_window.cpp`, `src/ui/gl_canvas.{h,cpp}`, `src/ui/messaging/message_handler.{h,cpp}`, `src/ui/main_window/main_window.{h,cpp}`, `src/ui/main_window/main_window_initializer.cpp`, `src/ui/events/event_handler.{h,cpp}`, `src/visualization/shader.cpp`, `src/ui/gl_text_renderer.cpp`, `src/visualization/components/buffer.cpp`.
+
+---
+
+## Task 1: Platform scaffold + config + CMake wiring
+
+**Files:**
+- Create: `src/platform/platform_config.h`
+- Modify: `src/CMakeLists.txt` (the `SOURCES` list, ~line 45-80)
+
+**Interfaces:**
+- Produces: `oid::platform::kIsWasm` (`constexpr bool`).
+
+- [ ] **Step 1: Create `src/platform/platform_config.h`**
+
+```cpp
+// <MIT header lines 1-24 copied verbatim>
+#ifndef PLATFORM_PLATFORM_CONFIG_H_
+#define PLATFORM_PLATFORM_CONFIG_H_
+
+namespace oid::platform {
+
+#ifdef __EMSCRIPTEN__
+inline constexpr bool kIsWasm = true;
+#else
+inline constexpr bool kIsWasm = false;
+#endif
+
+} // namespace oid::platform
+
+#endif // PLATFORM_PLATFORM_CONFIG_H_
+```
+
+- [ ] **Step 2: Add the platform-selected source list to `src/CMakeLists.txt`**
+
+Immediately after the closing `)` of `set(SOURCES ...)` (currently line 80), insert:
+
+```cmake
+if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  list(APPEND SOURCES
+    platform/transport_factory_wasm.cpp
+    platform/render_scheduler_wasm.cpp
+    platform/gl_dialect_wasm.cpp
+    platform/app_platform_wasm.cpp
+    platform/session_persistence_wasm.cpp
+    platform/ui_dialogs_wasm.cpp
+    ui/gl_canvas_wasm.cpp)
+else()
+  list(APPEND SOURCES
+    platform/transport_factory_native.cpp
+    platform/render_scheduler_native.cpp
+    platform/gl_dialect_native.cpp
+    platform/app_platform_native.cpp
+    platform/session_persistence_native.cpp
+    platform/ui_dialogs_native.cpp
+    ui/gl_canvas_native.cpp)
+endif()
+```
+
+> NOTE: the listed `.cpp` files do not exist yet. Each later task creates its pair. To keep the build green between tasks, create each new file referenced by CMake **before** building. Task 1's build step therefore also creates empty-but-valid stubs (below) for every file in the list, which later tasks fill in.
+
+- [ ] **Step 3: Create compiling stubs for every platform `.cpp` in the list**
+
+For each of the 12 platform `.cpp` files and the 2 `gl_canvas_*` files, create a file containing only the MIT header plus `#include "platform/platform_config.h"` (and nothing else). Example `src/platform/transport_factory_native.cpp`:
+
+```cpp
+// <MIT header lines 1-24>
+#include "platform/platform_config.h"
+// Implemented in Task 2.
+```
+
+Create the analogous stub for: `transport_factory_wasm.cpp`, `render_scheduler_native.cpp`, `render_scheduler_wasm.cpp`, `gl_dialect_native.cpp`, `gl_dialect_wasm.cpp`, `app_platform_native.cpp`, `app_platform_wasm.cpp`, `session_persistence_native.cpp`, `session_persistence_wasm.cpp`, `ui_dialogs_native.cpp`, `ui_dialogs_wasm.cpp`. For `src/ui/gl_canvas_native.cpp` and `src/ui/gl_canvas_wasm.cpp` use `#include "ui/gl_canvas.h"` instead.
+
+- [ ] **Step 4: Run the verification cycle**
+
+Run the native configure+build+ctest from "Per-task verification cycle".
+`Expected:` configures (CMake sees the new sources), builds `oidwindow`, all tests pass. The stubs add no symbols, so nothing breaks.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/platform/platform_config.h src/CMakeLists.txt src/platform/*.cpp src/ui/gl_canvas_native.cpp src/ui/gl_canvas_wasm.cpp
+git commit -m "build(platform): scaffold src/platform boundary and CMake wiring"
+```
+
+---
+
+## Task 2: Transport factory
+
+**Files:**
+- Create: `src/platform/transport_factory.h`, fill `src/platform/transport_factory_native.cpp`, `src/platform/transport_factory_wasm.cpp`
+- Modify: `src/ui/main_window/main_window.cpp` (158-191, 362-367), `src/ui/main_window/main_window.h` (transport members)
+
+**Interfaces:**
+- Consumes: `oid::ITransport`, `oid::TcpTransport`, `oid::PostMessageTransport`.
+- Produces:
+  - `std::unique_ptr<ITransport> oid::platform::make_transport(const TransportDeps&)`
+  - `bool oid::platform::should_quit_on_disconnect(QTcpSocket& socket)`
+  - `struct TransportDeps { QTcpSocket& socket; }`
+
+- [ ] **Step 1: Create `src/platform/transport_factory.h`**
+
+```cpp
+// <MIT header>
+#ifndef PLATFORM_TRANSPORT_FACTORY_H_
+#define PLATFORM_TRANSPORT_FACTORY_H_
+
+#include <memory>
+
+class QTcpSocket;
+
+namespace oid {
+class ITransport;
+namespace platform {
+
+struct TransportDeps {
+    QTcpSocket& socket; // ignored on WASM, used by the native TCP transport
+};
+
+std::unique_ptr<ITransport> make_transport(const TransportDeps& deps);
+
+// True only on native when the TCP socket has dropped; always false on WASM.
+bool should_quit_on_disconnect(QTcpSocket& socket);
+
+} // namespace platform
+} // namespace oid
+
+#endif // PLATFORM_TRANSPORT_FACTORY_H_
+```
+
+- [ ] **Step 2: Fill `src/platform/transport_factory_native.cpp`**
+
+```cpp
+// <MIT header>
+#include "platform/transport_factory.h"
+
+#include <QTcpSocket>
+
+#include "ipc/tcp_transport.h"
+
+namespace oid::platform {
+
+std::unique_ptr<ITransport> make_transport(const TransportDeps& deps) {
+    return std::make_unique<TcpTransport>(deps.socket);
+}
+
+bool should_quit_on_disconnect(QTcpSocket& socket) {
+    return socket.state() == QAbstractSocket::UnconnectedState;
+}
+
+} // namespace oid::platform
+```
+
+- [ ] **Step 3: Fill `src/platform/transport_factory_wasm.cpp`**
+
+```cpp
+// <MIT header>
+#include "platform/transport_factory.h"
+
+#include "ipc/postmessage_transport.h"
+
+namespace oid::platform {
+
+std::unique_ptr<ITransport> make_transport(const TransportDeps& /*deps*/) {
+    auto transport = std::make_unique<PostMessageTransport>();
+    oid_set_postmessage_transport(transport.get());
+    return transport;
+}
+
+bool should_quit_on_disconnect(QTcpSocket& /*socket*/) {
+    return false;
+}
+
+} // namespace oid::platform
+```
+
+- [ ] **Step 4: Replace the transport ifdef in `main_window.cpp`**
+
+In `MainWindow`'s constructor, replace the whole `#ifdef __EMSCRIPTEN__ ... #endif` block (currently 158-191) with:
+
+```cpp
+    // Initialize message handler
+    transport_ = platform::make_transport({socket_});
+    message_handler_ = std::make_unique<MessageHandler>(
+        MessageHandler::Dependencies{
+            ui_mutex_,
+            buffer_data_,
+            state_,
+            ui_components_,
+            *transport_,
+            [] { return get_icon_size(); },
+            [this] { return std::make_shared<Stage>(*this); },
+            [this](const std::shared_ptr<Stage>& stage) {
+                set_currently_selected_stage(stage);
+            },
+            settings_applier_.get()},
+        this);
+```
+
+Add `#include "platform/transport_factory.h"` to the includes. In `loop()`, replace the native-only disconnect block (362-367) with:
+
+```cpp
+    if (platform::should_quit_on_disconnect(socket_)) [[unlikely]] {
+        QApplication::quit();
+        return;
+    }
+```
+
+- [ ] **Step 5: Update `main_window.h` transport members**
+
+Find the two platform-specific members (`std::unique_ptr<PostMessageTransport> postmessage_transport_;` and `std::unique_ptr<TcpTransport> tcp_transport_;`, each likely ifdef-guarded) and replace both with a single unguarded member:
+
+```cpp
+    std::unique_ptr<ITransport> transport_;
+```
+
+Add `#include "ipc/transport.h"` and remove now-unused `postmessage_transport.h` / `tcp_transport.h` includes from the header if present (keep them in the `.cpp` only where needed). `socket_` stays as-is (still used by the native factory and held by `MainWindow`).
+
+- [ ] **Step 6: Run the verification cycle** (native + WASM + ctest). `Expected:` both build; tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/platform/transport_factory.* src/ui/main_window/main_window.cpp src/ui/main_window/main_window.h
+git commit -m "refactor(platform): select transport via make_transport factory"
+```
+
+---
+
+## Task 3: Render scheduler
+
+**Files:**
+- Create: `src/platform/render_scheduler.h`, fill `_native.cpp`, `_wasm.cpp`
+- Modify: `src/ui/messaging/message_handler.{h,cpp}`, `src/ui/main_window/main_window.cpp` (scheduler construction + wiring into `MessageHandler::Dependencies`)
+
+**Interfaces:**
+- Consumes: `oid::GLCanvas` (for the WASM scheduler).
+- Produces:
+  - `struct oid::RenderScheduler { virtual ~; virtual void run_gl(std::function<void()>); virtual void run_icon_gl(std::function<void()>); }`
+  - `std::unique_ptr<RenderScheduler> oid::platform::make_render_scheduler(GLCanvas& canvas)`
+  - `MessageHandler::Dependencies` gains `RenderScheduler& scheduler;` (inserted after `transport`).
+
+- [ ] **Step 1: Create `src/platform/render_scheduler.h`**
+
+```cpp
+// <MIT header>
+#ifndef PLATFORM_RENDER_SCHEDULER_H_
+#define PLATFORM_RENDER_SCHEDULER_H_
+
+#include <functional>
+#include <memory>
+
+namespace oid {
+class GLCanvas;
+
+class RenderScheduler {
+  public:
+    virtual ~RenderScheduler() = default;
+    // Runs GL work that must execute on the GL thread/context: immediately on
+    // native, deferred to the QRhi render callback on WASM.
+    virtual void run_gl(std::function<void()> task) = 0;
+    virtual void run_icon_gl(std::function<void()> task) = 0;
+};
+
+namespace platform {
+std::unique_ptr<RenderScheduler> make_render_scheduler(GLCanvas& canvas);
+}
+} // namespace oid
+
+#endif // PLATFORM_RENDER_SCHEDULER_H_
+```
+
+- [ ] **Step 2: Fill `src/platform/render_scheduler_native.cpp`**
+
+```cpp
+// <MIT header>
+#include "platform/render_scheduler.h"
+
+namespace oid {
+namespace {
+class ImmediateScheduler final : public RenderScheduler {
+  public:
+    void run_gl(std::function<void()> task) override { task(); }
+    void run_icon_gl(std::function<void()> task) override { task(); }
+};
+} // namespace
+
+namespace platform {
+std::unique_ptr<RenderScheduler> make_render_scheduler(GLCanvas& /*canvas*/) {
+    return std::make_unique<ImmediateScheduler>();
+}
+} // namespace platform
+} // namespace oid
+```
+
+- [ ] **Step 3: Fill `src/platform/render_scheduler_wasm.cpp`**
+
+```cpp
+// <MIT header>
+#include "platform/render_scheduler.h"
+
+#include "ui/gl_canvas.h"
+
+namespace oid {
+namespace {
+class DeferredScheduler final : public RenderScheduler {
+  public:
+    explicit DeferredScheduler(GLCanvas& canvas) : canvas_{canvas} {}
+    void run_gl(std::function<void()> task) override {
+        canvas_.schedule_gl(std::move(task));
+    }
+    void run_icon_gl(std::function<void()> task) override {
+        canvas_.schedule_icon_gl(std::move(task));
+    }
+
+  private:
+    GLCanvas& canvas_;
+};
+} // namespace
+
+namespace platform {
+std::unique_ptr<RenderScheduler> make_render_scheduler(GLCanvas& canvas) {
+    return std::make_unique<DeferredScheduler>(canvas);
+}
+} // namespace platform
+} // namespace oid
+```
+
+- [ ] **Step 4: Add `scheduler` to `MessageHandler::Dependencies`**
+
+In `message_handler.h`, insert after the `ITransport& transport;` line (65):
+
+```cpp
+        RenderScheduler& scheduler;
+```
+
+Add `#include "platform/render_scheduler.h"` to `message_handler.h` (forward-declared `RenderScheduler` is already in that header; the include is for the reference member's completeness at call sites — include it in the `.cpp` if a forward declaration suffices in the header). Use a forward declaration `class RenderScheduler;` in the header and `#include` in the `.cpp`.
+
+- [ ] **Step 5: Replace the 5 scheduling ifdefs in `message_handler.cpp`**
+
+Each site currently reads `#ifdef __EMSCRIPTEN__ <canvas->schedule_*(lambda)> #else <lambda body inline> #endif`. Rewrite each so the lambda is defined once and handed to the scheduler. The two representative rewrites:
+
+Icon paint (112-138 region) — keep the `the_dialect()`-based `QImage` construction (Task 5 supplies it; until then keep the existing RGBA/RGB ifdef untouched and only convert the *scheduling* ifdef):
+
+```cpp
+    deps_.scheduler.run_icon_gl(paint_icon);
+```
+
+Stage GL init/update (241-311 region) — wrap the existing WASM lambda body and reuse it for both platforms:
+
+```cpp
+    deps_.scheduler.run_gl([this, stage, params, variable_name_str,
+                            ac_enabled = deps_.state.ac_enabled]() mutable {
+        // ... exact body from the former #ifdef __EMSCRIPTEN__ branch ...
+    });
+```
+
+> The former native `#else` branch (immediate `buffer_update`) is now produced by `ImmediateScheduler` running the same lambda synchronously. Verify the lambda body is logic-equivalent to BOTH former branches: the WASM branch did stage init + map insert + select; the native branch did the same work inline. If the two former branches differ in more than now-vs-later, preserve the union of their effects and note the diff in the commit body.
+
+- [ ] **Step 6: Construct + inject the scheduler in `main_window.cpp`**
+
+Before building `MessageHandler` (the block edited in Task 2), add:
+
+```cpp
+    render_scheduler_ =
+        platform::make_render_scheduler(*ui_components_.ui->bufferPreview);
+```
+
+and add `*render_scheduler_,` to the `Dependencies` aggregate immediately after `*transport_,`. Add member `std::unique_ptr<RenderScheduler> render_scheduler_;` to `main_window.h` and `#include "platform/render_scheduler.h"`.
+
+- [ ] **Step 7: Run the verification cycle.** `Expected:` both build; tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/platform/render_scheduler.* src/ui/messaging/message_handler.h src/ui/messaging/message_handler.cpp src/ui/main_window/main_window.cpp src/ui/main_window/main_window.h
+git commit -m "refactor(platform): inject RenderScheduler to drop GL scheduling ifdefs"
+```
+
+---
+
+## Task 4: GL backend translation-unit split
+
+**Files:**
+- Modify: `src/ui/gl_canvas.h` (declarations only), `src/ui/gl_canvas.cpp` (keep shared, remove platform bodies)
+- Fill: `src/ui/gl_canvas_native.cpp`, `src/ui/gl_canvas_wasm.cpp`
+- Modify: `src/ui/main_window/main_window.cpp` (`prepare_gl_draw`), `src/ui/main_window/main_window.h`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: unchanged public `GLCanvas` API. The base-class `#ifdef` in `gl_canvas.h` is the single permitted exception.
+
+- [ ] **Step 1: Add a shared ctor-tail hook to `gl_canvas.h`**
+
+Inside the private section, declare:
+
+```cpp
+    void platform_ctor_init(); // defined per-platform in gl_canvas_<platform>.cpp
+```
+
+Leave the base-class `#ifdef`, the per-platform override declarations (74-96), and the WASM-only members (152-163) exactly as they are — these declarations are allowed to stay under the one base-class-aligned ifdef.
+
+- [ ] **Step 2: Move the WASM method bodies into `src/ui/gl_canvas_wasm.cpp`**
+
+Cut from `gl_canvas.cpp` the bodies currently inside `#ifdef __EMSCRIPTEN__ ... #else` (the block starting at 165 through just before `#else` at 299): `render_width`, `render_height`, `init_gl_state`, `initialize`, `render`, `releaseResources`, `resizeEvent`, `schedule_gl`, `schedule_icon_gl`, `drain_gl_queue`, `drain_icon_gl_queue`. Paste them into `gl_canvas_wasm.cpp` under:
+
+```cpp
+// <MIT header>
+#include "ui/gl_canvas.h"
+
+#include <rhi/qrhi.h>
+
+#include "main_window/main_window.h"
+#include "ui/gl_text_renderer.h"
+
+namespace oid {
+// ... pasted WASM bodies ...
+
+void GLCanvas::platform_ctor_init() {
+    setApi(Api::OpenGL);
+    connect(this, &QRhiWidget::renderFailed, this, [this] {
+        initialized_ = false;
+        first_paint_completed_ = false;
+    });
+}
+} // namespace oid
+```
+
+- [ ] **Step 3: Move the native method bodies into `src/ui/gl_canvas_native.cpp`**
+
+Cut from `gl_canvas.cpp` the bodies inside the `#else ... #endif` (300-345): native `render_width`, `render_height`, `initializeGL`, `paintGL`, `resizeGL`. Paste into:
+
+```cpp
+// <MIT header>
+#include "ui/gl_canvas.h"
+
+#include <iostream>
+
+#include "main_window/main_window.h"
+#include "ui/gl_text_renderer.h"
+
+namespace oid {
+// ... pasted native bodies ...
+
+void GLCanvas::platform_ctor_init() {}
+} // namespace oid
+```
+
+- [ ] **Step 4: Clean up `gl_canvas.cpp`**
+
+Remove the now-empty `#ifdef __EMSCRIPTEN__ ... #endif` span (165-346) entirely. In the constructor, the base-class init list keeps its `#ifdef` (base type differs); replace the platform-specific ctor *body* statements (the WASM `setApi`/`connect` at 51-57) with a single call `platform_ctor_init();`. Move the `#include <rhi/qrhi.h>` (31-33) out of `gl_canvas.cpp` (it is now only needed in `gl_canvas_wasm.cpp`).
+
+- [ ] **Step 5: Handle `prepare_gl_draw` in `main_window`**
+
+Leave `MainWindow::prepare_gl_draw()` (`main_window.cpp:320-343`) and its declaration in `main_window.h` under their existing `#ifdef __EMSCRIPTEN__`. This is a WASM-only render hook tied to the QRhi lifecycle; keeping it WASM-only avoids dead native code and introduces no scattered ifdef beyond the GL-backend boundary already established here. (Document in the commit that this ifdef pair is intentionally retained as part of the GL-backend type-level boundary.)
+
+- [ ] **Step 6: Run the verification cycle.** `Expected:` native builds using `gl_canvas_native.cpp`; WASM builds using `gl_canvas_wasm.cpp`; tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ui/gl_canvas.h src/ui/gl_canvas.cpp src/ui/gl_canvas_native.cpp src/ui/gl_canvas_wasm.cpp
+git commit -m "refactor(gl): split GLCanvas platform bodies into per-platform TUs"
+```
+
+---
+
+## Task 5: GL dialect & capabilities
+
+**Files:**
+- Create: `src/platform/gl_dialect.h`, fill `_native.cpp`, `_wasm.cpp`
+- Modify: `src/visualization/shader.cpp` (228-252), `src/ui/gl_text_renderer.cpp` (203-215), `src/visualization/components/buffer.cpp` (736-757, 810-813), `src/ui/messaging/message_handler.cpp` (112-126)
+
+**Interfaces:**
+- Produces:
+  - `struct oid::GlDialect { std::string_view version_directive; std::string_view fragment_preamble; bool uses_out_color; QImage::Format icon_image_format; int icon_bytes_per_pixel; bool has_texture_wrap_r; GLuint texture_internal_format(GLenum tex_type, GLenum tex_format) const; };`
+  - `const GlDialect& oid::the_dialect();`
+
+- [ ] **Step 1: Create `src/platform/gl_dialect.h`**
+
+```cpp
+// <MIT header>
+#ifndef PLATFORM_GL_DIALECT_H_
+#define PLATFORM_GL_DIALECT_H_
+
+#include <string_view>
+
+#include <GL/gl.h>
+#include <QImage>
+
+namespace oid {
+
+struct GlDialect {
+    std::string_view version_directive;
+    std::string_view fragment_preamble;
+    bool uses_out_color;
+    QImage::Format icon_image_format;
+    int icon_bytes_per_pixel;
+    bool has_texture_wrap_r;
+    GLuint texture_internal_format(GLenum tex_type, GLenum tex_format) const;
+};
+
+const GlDialect& the_dialect();
+
+} // namespace oid
+
+#endif // PLATFORM_GL_DIALECT_H_
+```
+
+- [ ] **Step 2: Fill `src/platform/gl_dialect_native.cpp`**
+
+```cpp
+// <MIT header>
+#include "platform/gl_dialect.h"
+
+namespace oid {
+
+GLuint GlDialect::texture_internal_format(GLenum /*tex_type*/,
+                                          GLenum /*tex_format*/) const {
+    return GL_RGBA32F;
+}
+
+const GlDialect& the_dialect() {
+    static const GlDialect dialect{
+        .version_directive = "#version 120\n",
+        .fragment_preamble = "",
+        .uses_out_color = false,
+        .icon_image_format = QImage::Format_RGB888,
+        .icon_bytes_per_pixel = 3,
+        .has_texture_wrap_r = true,
+    };
+    return dialect;
+}
+
+} // namespace oid
+```
+
+- [ ] **Step 3: Fill `src/platform/gl_dialect_wasm.cpp`**
+
+```cpp
+// <MIT header>
+#include "platform/gl_dialect.h"
+
+namespace oid {
+
+GLuint GlDialect::texture_internal_format(GLenum tex_type,
+                                          GLenum tex_format) const {
+    if (tex_type == GL_FLOAT) {
+        if (tex_format == GL_RED) return GL_R32F;
+        if (tex_format == GL_RG) return GL_RG32F;
+        if (tex_format == GL_RGB) return GL_RGB32F;
+        return GL_RGBA32F;
+    }
+    if (tex_format == GL_RED) return GL_R8;
+    if (tex_format == GL_RG) return GL_RG8;
+    if (tex_format == GL_RGB) return GL_RGB8;
+    return GL_RGBA8;
+}
+
+const GlDialect& the_dialect() {
+    static const GlDialect dialect{
+        .version_directive = "#version 300 es\n",
+        .fragment_preamble = "precision mediump float;\n"
+                             "precision mediump int;\n"
+                             "out vec4 oid_fragColor;\n",
+        .uses_out_color = true,
+        .icon_image_format = QImage::Format_RGBA8888,
+        .icon_bytes_per_pixel = 4,
+        .has_texture_wrap_r = false,
+    };
+    return dialect;
+}
+
+} // namespace oid
+```
+
+- [ ] **Step 4: Rewrite `shader.cpp::compile()` to use the dialect**
+
+Replace the `#ifdef __EMSCRIPTEN__ ... #else ... #endif` (228-252) with a single dialect-driven build. The GLES `adapt_shader_source_for_gles` call is gated by `the_dialect().uses_out_color`:
+
+```cpp
+    const auto& dialect = the_dialect();
+    std::ostringstream full_source;
+    full_source << dialect.version_directive << dialect.fragment_preamble;
+    if (dialect.uses_out_color && type == GL_FRAGMENT_SHADER) {
+        // (the "out vec4 oid_fragColor" decl is already in fragment_preamble)
+    }
+    const auto body = dialect.uses_out_color
+        ? adapt_shader_source_for_gles(type, std::string{source})
+        : std::string{source};
+    full_source << get_texel_format_define() << get_source_channel_define()
+                << "#define PIXEL_LAYOUT " << pixel_layout_ << "\n" << body;
+    const auto source_string = full_source.str();
+    const auto* src_ptr = source_string.c_str();
+    gl_canvas_.glShaderSource(shader, 1, &src_ptr, nullptr);
+```
+
+Add `#include "platform/gl_dialect.h"`. Confirm the native shader still receives the same effective text it did before (version 120 + defines + raw source). The former native path passed 6 separate strings; concatenating them into one is behaviorally identical to `glShaderSource`.
+
+- [ ] **Step 5: Apply the dialect in the remaining sites**
+
+- `gl_text_renderer.cpp` (203-215): replace its version `#ifdef` with `the_dialect().version_directive` / `.fragment_preamble`, mirroring Step 4.
+- `message_handler.cpp` (112-126): replace the RGBA/RGB `#ifdef` with `the_dialect().icon_bytes_per_pixel` and `the_dialect().icon_image_format`:
+  ```cpp
+  const auto bytes_per_line = icon_width * the_dialect().icon_bytes_per_pixel;
+  const auto bufferIcon = QImage{stage->get_buffer_icon().data(), icon_width,
+                                 icon_height, bytes_per_line,
+                                 the_dialect().icon_image_format};
+  ```
+- `buffer.cpp` (736-757): replace the internal-format `#ifdef` with
+  `const auto internal_format = the_dialect().texture_internal_format(tex_type, tex_format);`
+- `buffer.cpp` (810-813): replace the `#ifndef __EMSCRIPTEN__` WRAP_R guard with
+  `if (the_dialect().has_texture_wrap_r) { gl_canvas_ref().glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE); }`
+
+Add `#include "platform/gl_dialect.h"` to each of these three files.
+
+- [ ] **Step 6: Run the verification cycle.** `Expected:` both build; tests pass; rendered output unchanged (no behavior change).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/platform/gl_dialect.* src/visualization/shader.cpp src/ui/gl_text_renderer.cpp src/visualization/components/buffer.cpp src/ui/messaging/message_handler.cpp
+git commit -m "refactor(gl): route shader/texture format divergence through GlDialect"
+```
+
+---
+
+## Task 6: App bootstrap & lifecycle hooks
+
+**Files:**
+- Create: `src/platform/app_platform.h`, fill `_native.cpp`, `_wasm.cpp`
+- Modify: `src/oid_window.cpp` (28-86), `src/ui/main_window/main_window.cpp` (32-44 includes, 371-378 viewer-ready), `src/ui/main_window/main_window_initializer.cpp` (362, 383)
+
+**Interfaces:**
+- Consumes: `oid::ConnectionSettings`, `oid::MainWindow`.
+- Produces:
+  - `void oid::platform::configure_surface_format();`
+  - `oid::ConnectionSettings oid::platform::parse_connection_settings(int argc, char** argv);`
+  - `void oid::platform::install_inbound_hooks();`
+  - `void oid::platform::notify_viewer_ready_once(bool window_ready, bool first_paint_done);`
+
+- [ ] **Step 1: Create `src/platform/app_platform.h`**
+
+```cpp
+// <MIT header>
+#ifndef PLATFORM_APP_PLATFORM_H_
+#define PLATFORM_APP_PLATFORM_H_
+
+#include "ui/main_window/connection_settings.h" // adjust to actual path of ConnectionSettings
+
+namespace oid::platform {
+
+void configure_surface_format();
+ConnectionSettings parse_connection_settings(int argc, char** argv);
+void install_inbound_hooks();
+// WASM: emits oid_notify_viewer_ready exactly once when both flags are true.
+// Native: no-op.
+void notify_viewer_ready_once(bool window_ready, bool first_paint_done);
+
+} // namespace oid::platform
+
+#endif // PLATFORM_APP_PLATFORM_H_
+```
+
+> Before writing, grep for the real definition of `ConnectionSettings` and use its actual header path in the include.
+
+- [ ] **Step 2: Fill `src/platform/app_platform_native.cpp`**
+
+```cpp
+// <MIT header>
+#include "platform/app_platform.h"
+
+#include <QCommandLineParser>
+#include <QCoreApplication>
+
+namespace oid::platform {
+
+void configure_surface_format() {}
+
+ConnectionSettings parse_connection_settings(int /*argc*/, char** /*argv*/) {
+    auto parser = QCommandLineParser{};
+    parser.addOptions({
+        {"h", "hostname", "hostname", "127.0.0.1"},
+        {"p", "port", "port", "9588"},
+    });
+    parser.parse(QCoreApplication::arguments());
+    auto settings = ConnectionSettings{};
+    settings.url = parser.value("h").toStdString();
+    settings.port = static_cast<uint16_t>(parser.value("p").toUInt());
+    return settings;
+}
+
+void install_inbound_hooks() {}
+void notify_viewer_ready_once(bool, bool) {}
+
+} // namespace oid::platform
+```
+
+> `parse_connection_settings` reads `QCoreApplication::arguments()`, so it must be called after `QApplication` is constructed (it already is in `main()`). `argc/argv` are unused but kept for symmetry.
+
+- [ ] **Step 3: Fill `src/platform/app_platform_wasm.cpp`**
+
+Move the `EM_JS(... oid_install_js_hooks ...)` block and `#include <emscripten.h>` here from `oid_window.cpp`. Implement:
+
+```cpp
+// <MIT header>
+#include "platform/app_platform.h"
+
+#include <QSurfaceFormat>
+#include <emscripten.h>
+
+#include "ipc/postmessage_transport.h"
+
+namespace oid {
+// EM_JS hook (moved verbatim from oid_window.cpp) installing window.oidOnMessage
+EM_JS(void, oid_install_js_hooks, (), { /* ... verbatim ... */ });
+
+namespace platform {
+
+void configure_surface_format() {
+    auto format = QSurfaceFormat{};
+    format.setRenderableType(QSurfaceFormat::OpenGLES);
+    format.setVersion(3, 0);
+    format.setProfile(QSurfaceFormat::CoreProfile);
+    QSurfaceFormat::setDefaultFormat(format);
+}
+
+ConnectionSettings parse_connection_settings(int, char**) {
+    return ConnectionSettings{};
+}
+
+void install_inbound_hooks() { oid_install_js_hooks(); }
+
+void notify_viewer_ready_once(bool window_ready, bool first_paint_done) {
+    static bool sent = false;
+    if (!sent && window_ready && first_paint_done) {
+        oid_notify_viewer_ready();
+        sent = true;
+    }
+}
+
+} // namespace platform
+} // namespace oid
+```
+
+> Grep for the existing declaration of `oid_notify_viewer_ready` and include its header. If it is declared in `main_window.cpp` only, move its declaration to an appropriate IPC header so both files see it.
+
+- [ ] **Step 4: Rewrite `oid_window.cpp::main()`**
+
+```cpp
+// <MIT header + remaining includes>
+#include "platform/app_platform.h"
+
+int main(int argc, char* argv[]) {
+    oid::platform::configure_surface_format();
+    auto app = QApplication{argc, argv};
+    const auto settings = oid::platform::parse_connection_settings(argc, argv);
+    oid::platform::install_inbound_hooks();
+    auto window = oid::MainWindow{settings};
+    window.showWindow();
+    return QApplication::exec();
+}
+```
+
+Remove the `#ifdef __EMSCRIPTEN__` includes/EM_JS block (28-54) and both `#ifdef` blocks in the old `main()` (57-83).
+
+- [ ] **Step 5: Replace the viewer-ready ifdef in `main_window.cpp::loop()`**
+
+Replace the WASM-only block (371-378) with:
+
+```cpp
+    platform::notify_viewer_ready_once(
+        is_window_ready(), gl_canvas_ptr_->has_completed_first_paint());
+```
+
+Add `#include "platform/app_platform.h"`. Remove the now-unused `emscripten.h` include and EM_JS from `main_window.cpp` if present (they live in `app_platform_wasm.cpp` now).
+
+- [ ] **Step 6: Fold the `main_window_initializer.cpp` ifdefs (362, 383)**
+
+Read both blocks. If they reference WASM-only symbols, wrap them in a small `platform::` helper added to `app_platform.h`; if both branches type-check on both platforms, replace with `if constexpr (platform::kIsWasm) { ... } else { ... }` (include `platform/platform_config.h`). Pick per-block; document the choice in the commit.
+
+- [ ] **Step 7: Run the verification cycle.** `Expected:` both build; tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/platform/app_platform.* src/oid_window.cpp src/ui/main_window/main_window.cpp src/ui/main_window/main_window_initializer.cpp
+git commit -m "refactor(platform): move app bootstrap and lifecycle hooks behind app_platform"
+```
+
+---
+
+## Task 7: Session persistence
+
+**Files:**
+- Create: `src/platform/session_persistence.h`, fill `_native.cpp`, `_wasm.cpp`
+- Modify: `src/ui/main_window/main_window.cpp` (292-294 load, 479-526 persist), `main_window.h` if needed
+
+**Interfaces:**
+- Consumes: the existing `SessionStateCallbacks`/`SessionStateExtraInputs`, `SettingsManager`, `serialize_session_state_delta`, `MessageComposer`, `ITransport`, `ChannelNames`, `UIComponents`.
+- Produces:
+  - `void oid::platform::persist_session(const SessionStateCallbacks& callbacks, const PersistDeps& deps);`
+  - `void oid::platform::load_settings_if_local(SettingsManager& mgr);`
+  - `struct PersistDeps { ITransport* transport; const ChannelNames& channel_names; UIComponents& ui_components; };`
+
+> Grep for the exact types of `callbacks`, `SessionStateExtraInputs`, `serialize_session_state_delta`, and `MessageType::SessionStateChanged` before writing; use real names/paths.
+
+- [ ] **Step 1: Create `src/platform/session_persistence.h`** with the two declarations and `PersistDeps` struct (real member types from the grep).
+
+- [ ] **Step 2: Fill `_native.cpp`**
+
+```cpp
+// <MIT header>
+#include "platform/session_persistence.h"
+#include "ui/main_window/settings_manager.h"
+
+namespace oid::platform {
+
+void persist_session(const SessionStateCallbacks& callbacks,
+                     const PersistDeps& /*deps*/) {
+    SettingsManager::persist_settings(callbacks);
+}
+
+void load_settings_if_local(SettingsManager& mgr) { mgr.load_settings(); }
+
+} // namespace oid::platform
+```
+
+- [ ] **Step 3: Fill `_wasm.cpp`** — move the colorspace/list-position serialization and `SessionStateChanged` send (the body of `main_window.cpp:479-523`) here, reading from `deps.channel_names`, `deps.ui_components`, `deps.transport`. `load_settings_if_local` is a no-op.
+
+- [ ] **Step 4: Replace the call sites in `main_window.cpp`**
+
+- Persistence block (479-526) becomes:
+  ```cpp
+  platform::persist_session(callbacks,
+                            {transport_.get(), channel_names_, ui_components_});
+  ```
+- Startup load (292-294) becomes:
+  ```cpp
+  platform::load_settings_if_local(*settings_manager_);
+  ```
+Add `#include "platform/session_persistence.h"`.
+
+- [ ] **Step 5: Run the verification cycle.** `Expected:` both build; tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/platform/session_persistence.* src/ui/main_window/main_window.cpp
+git commit -m "refactor(platform): move session persistence behind platform layer"
+```
+
+---
+
+## Task 8: UI event-loop / dialog semantics
+
+**Files:**
+- Create: `src/platform/ui_dialogs.h`, fill `_native.cpp`, `_wasm.cpp`
+- Modify: `src/ui/events/event_handler.{h,cpp}` (379-465 export, 491-505 menu), `src/ui/main_window/main_window.cpp` (260-273 async wiring)
+
+**Interfaces:**
+- Consumes: `oid::Stage`, `oid::Buffer`, `oid::UIEventHandler`, `oid::MessageHandler`, Qt widgets.
+- Produces:
+  - `void oid::platform::request_buffer_export(const ExportRequest& req);`
+  - `void oid::platform::show_buffer_context_menu(QWidget& parent, QPoint global_pos, const QString& buffer_name, UIEventHandler& handler);`
+  - `void oid::platform::wire_async_export_signals(UIEventHandler& event_handler, MessageHandler& message_handler);`
+  - `struct ExportRequest { ... }` (fields chosen from the two former branches — grep both).
+
+> Read BOTH branches of `export_buffer` (379-465) before designing `ExportRequest`. The native branch opens `QFileDialog`; the WASM branch gathers contrast and emits `exportBufferRequested`. The struct must carry everything both need (stage, buffer name, contrast list, the emitting object).
+
+- [ ] **Step 1: Create `src/platform/ui_dialogs.h`** with the three declarations and `ExportRequest`.
+
+- [ ] **Step 2: Fill `_native.cpp`** — paste the former `#else` body of `export_buffer` (QFileDialog flow) into `request_buffer_export`; paste the stack-`QMenu`+`exec()` body into `show_buffer_context_menu`; `wire_async_export_signals` is a no-op.
+
+- [ ] **Step 3: Fill `_wasm.cpp`** — paste the former `#ifdef` body (gather contrast, `emit exportBufferRequested`) into `request_buffer_export`; paste the heap-`QMenu`+`popup()` body into `show_buffer_context_menu`; `wire_async_export_signals` performs the `connect()` calls from `main_window.cpp:260-273`.
+
+- [ ] **Step 4: Reduce `event_handler.cpp` call sites**
+
+- `export_buffer` (379-465) collapses to a single `platform::request_buffer_export({...});`.
+- The context-menu ifdef (491-505) collapses to `platform::show_buffer_context_menu(*ui_components_.ui->imageList, globalPos, buffer_name.toString(), *this);`.
+Add `#include "platform/ui_dialogs.h"`.
+
+- [ ] **Step 5: Make the signals unconditional + replace the wiring**
+
+In `event_handler.h` / `message_handler.h`, ensure `exportBufferRequested`, `request_export_buffer`, `exportSelectedBufferRequested`, `export_selected_buffer`, `bufferRemoved` are declared unconditionally (remove any `#ifdef` around them; an unused signal/slot is harmless on native). In `main_window.cpp`, replace the WASM-only connect block (260-273) with:
+
+```cpp
+    platform::wire_async_export_signals(*event_handler_, *message_handler_);
+```
+
+- [ ] **Step 6: Run the verification cycle.** `Expected:` both build; native export still opens a file dialog; WASM still emits the signal; tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/platform/ui_dialogs.* src/ui/events/event_handler.h src/ui/events/event_handler.cpp src/ui/messaging/message_handler.h src/ui/main_window/main_window.cpp
+git commit -m "refactor(platform): move export/context-menu dialog semantics behind ui_dialogs"
+```
+
+---
+
+## Task 9: Grep gate & cleanup sweep
+
+**Files:**
+- Modify: any file still violating the invariant (expected: none beyond the GLCanvas line)
+- Optional create: `scripts/check_platform_ifdefs.sh`
+
+- [ ] **Step 1: Run the grep gate**
+
+```bash
+grep -rn "__EMSCRIPTEN__" src --include=*.cpp | grep -v "src/platform/"
+```
+
+`Expected:` empty output. If any line remains, route it through the appropriate platform helper from Tasks 2-8 (do not leave it).
+
+```bash
+grep -rn "__EMSCRIPTEN__" src --include=*.h | grep -v "src/platform/"
+```
+
+`Expected:` exactly two lines — the `GLCanvas` base-class block in `gl_canvas.h` (and its paired override/member declarations count as the same allowed block). Confirm nothing else (e.g. stray transport members) remains.
+
+- [ ] **Step 2: (Optional) Add a CI check script `scripts/check_platform_ifdefs.sh`**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+violations=$(grep -rn "__EMSCRIPTEN__" src --include=*.cpp | grep -v "src/platform/" || true)
+if [[ -n "$violations" ]]; then
+  echo "Platform ifdefs leaked outside src/platform/:" >&2
+  echo "$violations" >&2
+  exit 1
+fi
+echo "OK: no platform ifdefs in .cpp outside src/platform/"
+```
+
+`chmod +x scripts/check_platform_ifdefs.sh` and run it; expect "OK".
+
+- [ ] **Step 3: Final full verification**
+
+Run the native build + ctest and (if EMSDK available) the WASM build one last time. `Expected:` all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/check_platform_ifdefs.sh 2>/dev/null || true
+git commit -m "chore(platform): enforce platform-ifdef boundary via grep gate" --allow-empty
+```
+
+---
+
+## Self-Review Notes (for the implementer)
+
+- **Spec coverage:** Tasks 2-8 map 1:1 onto the spec's 7 design units (Transport→T2, RenderScheduler→T3, GL backend→T4, GL dialect→T5, Bootstrap→T6, Persistence→T7, UI dialogs→T8). Scaffold (T1) and the grep gate (T9) bracket them.
+- **Known unknowns to resolve by grepping before writing (do NOT guess):** exact path/fields of `ConnectionSettings`; declaration site of `oid_notify_viewer_ready`; exact types of `SessionStateCallbacks` / `SessionStateExtraInputs` / `serialize_session_state_delta` / `MessageType`; the full field set needed by `ExportRequest`. Each task flags its own grep.
+- **Equivalence risk:** the highest-risk move is Task 3 (scheduler) — the former native and WASM branches of the stage-init path must be confirmed logic-equivalent modulo now-vs-later. Diff both former branches before deleting them.
+- **Type consistency:** `make_transport` / `make_render_scheduler` / `the_dialect` / `persist_session` / `request_buffer_export` names are used identically in their producing and consuming tasks.

--- a/docs/superpowers/plans/2026-06-29-ifdef-consolidation.md
+++ b/docs/superpowers/plans/2026-06-29-ifdef-consolidation.md
@@ -16,28 +16,40 @@
 - Transport interface type is `oid::ITransport` (in `src/ipc/transport.h`).
 - The only permitted `#ifdef __EMSCRIPTEN__` outside `src/platform/` after this work is the `GLCanvas` base-class block in `src/ui/gl_canvas.h`.
 - Do NOT touch unrelated guards: `Q_OS_DARWIN` (`event_handler.cpp:78`), Python-version guards (`python_native_interface.*`), thirdparty.
+- **CMake registration (every task that creates platform `.cpp` files):** in the same task,
+  add each new `_native.cpp` under the `else()` branch and each `_wasm.cpp` (and
+  `gl_canvas_wasm.cpp`) under the `if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")` branch of the
+  platform block created in Task 1 (`src/CMakeLists.txt`). Paths are relative to `src/` (e.g.
+  `platform/transport_factory_native.cpp`). A task's commit `git add` must include
+  `src/CMakeLists.txt`. The task is not green until BOTH builds compile the new file.
 
 ### Per-task verification cycle
 
-Every task ends with this cycle (substitute your build dir if not `cmake-build-debug`):
+The native build dir is `build/` and the WASM build is driven by the project script
+`wasm/scripts/build-wasm.sh` (build dir `build-wasm/`). Both are already configured. Every
+task ends with this cycle:
 
 ```bash
-# 1. Native configure + build (always required)
-cmake -S . -B cmake-build-debug -DBUILD_TESTS=ON >/dev/null
-cmake --build cmake-build-debug --target oidwindow -j 4
+# 1. Native build (always required) — build/ is pre-configured (ninja)
+cmake --build build --target oidwindow -j 4
 
 # 2. Native tests (always required)
-ctest --test-dir cmake-build-debug --output-on-failure
+ctest --test-dir build --output-on-failure
 
-# 3. WASM build (required IF EMSDK is set up; otherwise note "skipped: no EMSDK")
-#    Needs: source $EMSDK/emsdk_env.sh ; Qt6 wasm kit at $QT6_WASM_DIR
-emcmake cmake -S . -B build-wasm -DQt6_DIR="$QT6_WASM_DIR/lib/cmake/Qt6" >/dev/null
-cmake --build build-wasm --target oidwindow -j 4
+# 3. WASM build (always required — this is the verifier that catches mistakes inside
+#    #ifdef __EMSCRIPTEN__ that the native build cannot see). Incremental, ~seconds.
+bash wasm/scripts/build-wasm.sh
 ```
 
-`Expected:` both builds succeed; ctest reports all pass. If EMSDK is unavailable, the WASM
-step is skipped and the task is marked "WASM-build-unverified" for a later pass — but the
-code MUST still be written so it would compile under Emscripten.
+`Expected:` both builds report success (`Built target oidwindow`); ctest reports all pass.
+
+> WHY THE WASM BUILD IS MANDATORY, NOT OPTIONAL: a prior session proved that a
+> declaration/definition mismatch inside `#ifdef __EMSCRIPTEN__` compiled clean natively but
+> failed the WASM build. This refactor *moves* large amounts of `__EMSCRIPTEN__`-guarded code,
+> so a green native build is necessary but NOT sufficient. A task is not DONE until BOTH
+> builds are green. If `wasm/scripts/build-wasm.sh` fails to find its toolchain (EMSDK at
+> `~/emsdk`, Qt at `~/Qt/6.11.0/wasm_singlethread`), report BLOCKED — do not mark the task
+> done on the native build alone.
 
 ---
 
@@ -61,14 +73,19 @@ code MUST still be written so it would compile under Emscripten.
 
 ---
 
-## Task 1: Platform scaffold + config + CMake wiring
+## Task 1: Platform scaffold + config + CMake skeleton
 
 **Files:**
 - Create: `src/platform/platform_config.h`
 - Modify: `src/CMakeLists.txt` (the `SOURCES` list, ~line 45-80)
 
 **Interfaces:**
-- Produces: `oid::platform::kIsWasm` (`constexpr bool`).
+- Produces: `oid::platform::kIsWasm` (`constexpr bool`); an empty platform `if/else` source
+  block in `src/CMakeLists.txt` that each later task appends its own files to.
+
+> No empty stub files. Each later task creates its `.h`/`.cpp` AND appends those `.cpp` names
+> to the CMake block in the SAME task, so every task's diff is self-contained and the build is
+> green at every commit.
 
 - [ ] **Step 1: Create `src/platform/platform_config.h`**
 
@@ -90,56 +107,37 @@ inline constexpr bool kIsWasm = false;
 #endif // PLATFORM_PLATFORM_CONFIG_H_
 ```
 
-- [ ] **Step 2: Add the platform-selected source list to `src/CMakeLists.txt`**
+- [ ] **Step 2: Add the (initially empty) platform source block to `src/CMakeLists.txt`**
 
-Immediately after the closing `)` of `set(SOURCES ...)` (currently line 80), insert:
+Immediately after the closing `)` of `set(SOURCES ...)` (currently line 80), insert the
+skeleton. Each later task fills in its own `list(APPEND ...)` lines here:
 
 ```cmake
+# Platform-selected translation units. Each is appended by the task that creates it
+# (see docs/superpowers/plans/2026-06-29-ifdef-consolidation.md).
 if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   list(APPEND SOURCES
-    platform/transport_factory_wasm.cpp
-    platform/render_scheduler_wasm.cpp
-    platform/gl_dialect_wasm.cpp
-    platform/app_platform_wasm.cpp
-    platform/session_persistence_wasm.cpp
-    platform/ui_dialogs_wasm.cpp
-    ui/gl_canvas_wasm.cpp)
+    # platform/*_wasm.cpp and ui/gl_canvas_wasm.cpp appended per task
+  )
 else()
   list(APPEND SOURCES
-    platform/transport_factory_native.cpp
-    platform/render_scheduler_native.cpp
-    platform/gl_dialect_native.cpp
-    platform/app_platform_native.cpp
-    platform/session_persistence_native.cpp
-    platform/ui_dialogs_native.cpp
-    ui/gl_canvas_native.cpp)
+    # platform/*_native.cpp and ui/gl_canvas_native.cpp appended per task
+  )
 endif()
 ```
 
-> NOTE: the listed `.cpp` files do not exist yet. Each later task creates its pair. To keep the build green between tasks, create each new file referenced by CMake **before** building. Task 1's build step therefore also creates empty-but-valid stubs (below) for every file in the list, which later tasks fill in.
+A `list(APPEND SOURCES)` with only comments is a valid no-op.
 
-- [ ] **Step 3: Create compiling stubs for every platform `.cpp` in the list**
+- [ ] **Step 3: Run the verification cycle**
 
-For each of the 12 platform `.cpp` files and the 2 `gl_canvas_*` files, create a file containing only the MIT header plus `#include "platform/platform_config.h"` (and nothing else). Example `src/platform/transport_factory_native.cpp`:
+Run native build + ctest + WASM build from "Per-task verification cycle".
+`Expected:` both builds succeed unchanged (no new sources yet); all tests pass.
 
-```cpp
-// <MIT header lines 1-24>
-#include "platform/platform_config.h"
-// Implemented in Task 2.
-```
-
-Create the analogous stub for: `transport_factory_wasm.cpp`, `render_scheduler_native.cpp`, `render_scheduler_wasm.cpp`, `gl_dialect_native.cpp`, `gl_dialect_wasm.cpp`, `app_platform_native.cpp`, `app_platform_wasm.cpp`, `session_persistence_native.cpp`, `session_persistence_wasm.cpp`, `ui_dialogs_native.cpp`, `ui_dialogs_wasm.cpp`. For `src/ui/gl_canvas_native.cpp` and `src/ui/gl_canvas_wasm.cpp` use `#include "ui/gl_canvas.h"` instead.
-
-- [ ] **Step 4: Run the verification cycle**
-
-Run the native configure+build+ctest from "Per-task verification cycle".
-`Expected:` configures (CMake sees the new sources), builds `oidwindow`, all tests pass. The stubs add no symbols, so nothing breaks.
-
-- [ ] **Step 5: Commit**
+- [ ] **Step 4: Commit**
 
 ```bash
-git add src/platform/platform_config.h src/CMakeLists.txt src/platform/*.cpp src/ui/gl_canvas_native.cpp src/ui/gl_canvas_wasm.cpp
-git commit -m "build(platform): scaffold src/platform boundary and CMake wiring"
+git add src/platform/platform_config.h src/CMakeLists.txt
+git commit -m "build(platform): add platform_config.h and CMake source skeleton"
 ```
 
 ---

--- a/docs/superpowers/plans/2026-06-29-wasm-large-buffer-tiling.md
+++ b/docs/superpowers/plans/2026-06-29-wasm-large-buffer-tiling.md
@@ -1,0 +1,1038 @@
+# WASM Large-Buffer Tiling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the WASM viewer plot large buffers (e.g. 40000×2160, any dtype) that currently render blank, by chunking the buffer transport instead of sending one oversized frame.
+
+**Architecture:** Approach A — chunk only the *transport*. Large buffers are sent as `PlotBufferBegin` + N row-strip `PlotBufferChunk` + `PlotBufferEnd`. A new C++ `BufferAssembler` reassembles the chunks into one contiguous buffer, then the viewer runs its existing GL-tiling / contrast / pixel-hover pipeline unchanged. Small buffers and the desktop TCP path keep using the single `PlotBufferContents` message.
+
+**Tech Stack:** C++23 + Qt 6.11 + Emscripten (viewer, repo `OpenImageDebugger`); TypeScript ESM + `node:test` (extension, repo `openimagedebugger-vscode`); GoogleTest for C++ unit tests.
+
+## Global Constraints
+
+- Two repos: `OpenImageDebugger` (C++ viewer) and `openimagedebugger-vscode` (extension). Each task names its repo.
+- New IPC message type values are **additive**: `PlotBufferBegin = 10`, `PlotBufferChunk = 11`, `PlotBufferEnd = 12` (last existing is `BufferRemoved = 9`). Use these exact names and numbers in both repos.
+- Wire integers are little-endian; the extension encodes message type and lengths as `u32`, which matches the viewer's `wasm32` decode (`std::size_t` == 4 bytes under Emscripten). The chunked path is **only** used in `wasm32` mode.
+- Chunks are **full-width row strips**: a chunk carries rows `[row_offset, row_offset + row_count)`, exactly `row_count × stride` tightly-packed bytes.
+- Shared chunk budget: `8 MiB` (`8 * 1024 * 1024`). Name it `CHUNK_BUDGET` in the extension.
+- Commit messages: plain, no `Co-Authored-By:` / AI-attribution trailer.
+- Do not reformat or restructure unrelated code.
+
+---
+
+### Task 1: `BufferAssembler` (C++ core, repo `OpenImageDebugger`)
+
+A pure, Qt/GL-free data structure that reassembles row-strip chunks. Unit-tested in isolation like `test_raw_data_decode`.
+
+**Files:**
+- Create: `src/ipc/buffer_assembler.h`
+- Create: `src/ipc/buffer_assembler.cpp`
+- Create: `tests/test_buffer_assembler.cpp`
+- Modify: `tests/CMakeLists.txt` (add a test target after the `SessionStateCodec` block, line ~159)
+- Modify: `src/ipc/CMakeLists.txt:32-36` (add `buffer_assembler.cpp` to the `oidipc` library sources)
+
+**Interfaces:**
+- Produces: `oid::BufferAssembler` with `void begin(BeginParams)`, `bool chunk(const std::string& name, std::size_t row_offset, std::size_t row_count, std::span<const std::byte> bytes)`, `std::optional<AssembledBuffer> end(const std::string& name)`. `AssembledBuffer` holds `{variable_name, display_name, pixel_layout, transpose, width, height, channels, stride, type, bytes}`. `BeginParams` holds the same fields minus `bytes`, plus `total_byte_size`.
+
+- [ ] **Step 1: Write the header**
+
+Create `src/ipc/buffer_assembler.h` (omit the license header for brevity here — copy the 24-line MIT header block from `src/ipc/postmessage_transport.cpp` lines 1-24 verbatim above the `#ifndef`):
+
+```cpp
+#ifndef IPC_BUFFER_ASSEMBLER_H_
+#define IPC_BUFFER_ASSEMBLER_H_
+
+#include <cstddef>
+#include <map>
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace oid {
+
+// Geometry + completed bytes for a buffer reassembled from row-strip chunks.
+struct AssembledBuffer {
+    std::string variable_name;
+    std::string display_name;
+    std::string pixel_layout;
+    bool transpose{};
+    int width{};
+    int height{};
+    int channels{};
+    int stride{};
+    int type{};
+    std::vector<std::byte> bytes;
+};
+
+// Reassembles a large buffer sent as row-strip chunks. Pure data structure:
+// no Qt/GL/transport dependency, so it is unit-testable in isolation.
+class BufferAssembler {
+  public:
+    struct BeginParams {
+        std::string variable_name;
+        std::string display_name;
+        std::string pixel_layout;
+        bool transpose{};
+        int width{};
+        int height{};
+        int channels{};
+        int stride{};
+        int type{};
+        std::size_t total_byte_size{};
+    };
+
+    // Start (or restart) a transfer, allocating total_byte_size zeroed bytes.
+    void begin(BeginParams params);
+
+    // Copy a row-strip into the in-progress buffer at row_offset. Returns false
+    // (ignoring the data) if name is unknown, the strip size is wrong, or it
+    // would exceed total_byte_size.
+    [[nodiscard]] bool chunk(const std::string& name,
+                             std::size_t row_offset,
+                             std::size_t row_count,
+                             std::span<const std::byte> bytes);
+
+    // Finish the transfer, moving its bytes out and dropping the entry. Returns
+    // nullopt if name is unknown.
+    [[nodiscard]] std::optional<AssembledBuffer> end(const std::string& name);
+
+  private:
+    struct InProgress {
+        BeginParams params;
+        std::vector<std::byte> bytes;
+    };
+    std::map<std::string, InProgress, std::less<>> in_progress_{};
+};
+
+} // namespace oid
+
+#endif // IPC_BUFFER_ASSEMBLER_H_
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/test_buffer_assembler.cpp` (copy the MIT header block from `tests/test_raw_data_decode.cpp` lines 1-24 above the includes):
+
+```cpp
+#include "ipc/buffer_assembler.h"
+
+#include <gtest/gtest.h>
+
+using namespace oid;
+
+namespace {
+
+BufferAssembler::BeginParams make_begin(const std::string& name,
+                                        const int width,
+                                        const int height,
+                                        const int stride,
+                                        const std::size_t total) {
+    return BufferAssembler::BeginParams{.variable_name = name,
+                                        .display_name = name,
+                                        .pixel_layout = "rgba",
+                                        .transpose = false,
+                                        .width = width,
+                                        .height = height,
+                                        .channels = 1,
+                                        .stride = stride,
+                                        .type = 0,
+                                        .total_byte_size = total};
+}
+
+std::vector<std::byte> iota_bytes(const std::size_t n) {
+    std::vector<std::byte> v(n);
+    for (std::size_t i = 0; i < n; ++i) {
+        v[i] = static_cast<std::byte>(i & 0xff);
+    }
+    return v;
+}
+
+} // namespace
+
+TEST(BufferAssembler, ReassemblesRowStripsIntoContiguousBuffer) {
+    constexpr int stride = 8;
+    constexpr int height = 4;
+    constexpr int width = 8;
+    constexpr std::size_t total = stride * height;
+    const auto full = iota_bytes(total);
+
+    BufferAssembler a;
+    a.begin(make_begin("buf", width, height, stride, total));
+    ASSERT_TRUE(a.chunk("buf", 0, 2, std::span{full.data(), 2 * stride}));
+    ASSERT_TRUE(
+        a.chunk("buf", 2, 2, std::span{full.data() + 2 * stride, 2 * stride}));
+
+    const auto done = a.end("buf");
+    ASSERT_TRUE(done.has_value());
+    EXPECT_EQ(done->width, width);
+    EXPECT_EQ(done->height, height);
+    EXPECT_EQ(done->stride, stride);
+    EXPECT_EQ(done->bytes, full);
+}
+
+TEST(BufferAssembler, RejectsOverflowingChunk) {
+    constexpr int stride = 8;
+    constexpr int height = 2;
+    constexpr std::size_t total = stride * height;
+    BufferAssembler a;
+    a.begin(make_begin("buf", 8, height, stride, total));
+    const auto strip = iota_bytes(2 * stride);
+    // rows [1,3) do not fit in a 2-row buffer.
+    EXPECT_FALSE(a.chunk("buf", 1, 2, std::span{strip.data(), strip.size()}));
+}
+
+TEST(BufferAssembler, RejectsWrongSizedChunk) {
+    constexpr int stride = 8;
+    constexpr int height = 2;
+    constexpr std::size_t total = stride * height;
+    BufferAssembler a;
+    a.begin(make_begin("buf", 8, height, stride, total));
+    const auto strip = iota_bytes(stride + 1); // not a multiple of stride
+    EXPECT_FALSE(a.chunk("buf", 0, 1, std::span{strip.data(), strip.size()}));
+}
+
+TEST(BufferAssembler, RejectsChunkAndEndForUnknownBuffer) {
+    BufferAssembler a;
+    const auto strip = iota_bytes(8);
+    EXPECT_FALSE(a.chunk("missing", 0, 1, std::span{strip.data(), strip.size()}));
+    EXPECT_FALSE(a.end("missing").has_value());
+}
+
+TEST(BufferAssembler, InterleavedBuffersDoNotCorruptEachOther) {
+    constexpr int stride = 4;
+    constexpr int height = 1;
+    constexpr std::size_t total = stride * height;
+    BufferAssembler a;
+    a.begin(make_begin("a", 4, height, stride, total));
+    a.begin(make_begin("b", 4, height, stride, total));
+    const std::vector<std::byte> da{
+        std::byte{1}, std::byte{2}, std::byte{3}, std::byte{4}};
+    const std::vector<std::byte> db{
+        std::byte{5}, std::byte{6}, std::byte{7}, std::byte{8}};
+    ASSERT_TRUE(a.chunk("a", 0, 1, std::span{da.data(), da.size()}));
+    ASSERT_TRUE(a.chunk("b", 0, 1, std::span{db.data(), db.size()}));
+    EXPECT_EQ(a.end("a")->bytes, da);
+    EXPECT_EQ(a.end("b")->bytes, db);
+}
+```
+
+- [ ] **Step 3: Register the test target and library source**
+
+In `tests/CMakeLists.txt`, append after line 159 (`add_test(NAME SessionStateCodec ...)`):
+
+```cmake
+# Test buffer assembler (row-strip reassembly)
+add_executable(test_buffer_assembler
+    test_buffer_assembler.cpp
+)
+
+target_include_directories(test_buffer_assembler
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/ipc
+)
+
+target_link_libraries(test_buffer_assembler
+    PRIVATE
+    GTest::gtest_main
+    GTest::gtest
+)
+
+target_sources(test_buffer_assembler PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ipc/buffer_assembler.cpp
+)
+
+add_test(NAME BufferAssemblerTests COMMAND test_buffer_assembler)
+```
+
+In `src/ipc/CMakeLists.txt`, change lines 32-36 to add the new source:
+
+```cmake
+add_library(${PROJECT_NAME} ${OID_IPC_LIBRARY_TYPE}
+            buffer_assembler.cpp
+            message_exchange.cpp
+            raw_data_decode.cpp
+            tcp_transport.cpp
+            postmessage_transport.cpp)
+```
+
+- [ ] **Step 4: Run the test to verify it fails**
+
+Run (from repo root, using the existing CMake test build dir):
+```bash
+cmake --build cmake-build-debug --target test_buffer_assembler 2>&1 | tail -20
+```
+Expected: **compile failure** — `buffer_assembler.cpp` does not exist yet (no such file / unresolved `oid::BufferAssembler` members).
+
+- [ ] **Step 5: Write the implementation**
+
+Create `src/ipc/buffer_assembler.cpp` (copy the MIT header block from `src/ipc/postmessage_transport.cpp` lines 1-24):
+
+```cpp
+#include "buffer_assembler.h"
+
+#include <cstring>
+#include <utility>
+
+namespace oid {
+
+void BufferAssembler::begin(BeginParams params) {
+    const auto total = params.total_byte_size;
+    auto& entry = in_progress_[params.variable_name];
+    entry.params = std::move(params);
+    entry.bytes.assign(total, std::byte{});
+}
+
+bool BufferAssembler::chunk(const std::string& name,
+                            const std::size_t row_offset,
+                            const std::size_t row_count,
+                            const std::span<const std::byte> bytes) {
+    const auto it = in_progress_.find(name);
+    if (it == in_progress_.end()) {
+        return false;
+    }
+    auto& entry = it->second;
+    const auto stride = static_cast<std::size_t>(entry.params.stride);
+    const auto offset = row_offset * stride;
+    const auto expected = row_count * stride;
+    if (bytes.size() != expected ||
+        offset + bytes.size() > entry.bytes.size()) {
+        return false;
+    }
+    std::memcpy(entry.bytes.data() + offset, bytes.data(), bytes.size());
+    return true;
+}
+
+std::optional<AssembledBuffer> BufferAssembler::end(const std::string& name) {
+    const auto it = in_progress_.find(name);
+    if (it == in_progress_.end()) {
+        return std::nullopt;
+    }
+    auto& entry = it->second;
+    AssembledBuffer out{.variable_name = std::move(entry.params.variable_name),
+                        .display_name = std::move(entry.params.display_name),
+                        .pixel_layout = std::move(entry.params.pixel_layout),
+                        .transpose = entry.params.transpose,
+                        .width = entry.params.width,
+                        .height = entry.params.height,
+                        .channels = entry.params.channels,
+                        .stride = entry.params.stride,
+                        .type = entry.params.type,
+                        .bytes = std::move(entry.bytes)};
+    in_progress_.erase(it);
+    return out;
+}
+
+} // namespace oid
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+```bash
+cmake --build cmake-build-debug --target test_buffer_assembler 2>&1 | tail -5
+ctest --test-dir cmake-build-debug -R BufferAssemblerTests --output-on-failure
+```
+Expected: build succeeds; `5 tests passed`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ipc/buffer_assembler.h src/ipc/buffer_assembler.cpp tests/test_buffer_assembler.cpp tests/CMakeLists.txt src/ipc/CMakeLists.txt
+git commit -m "feat(ipc): add BufferAssembler for row-strip chunk reassembly"
+```
+
+---
+
+### Task 2: Add chunked message types to the viewer enum (C++, repo `OpenImageDebugger`)
+
+**Files:**
+- Modify: `src/ipc/message_exchange.h` (the `enum class MessageType`, lines ~50-65)
+
+**Interfaces:**
+- Produces: `MessageType::PlotBufferBegin = 10`, `PlotBufferChunk = 11`, `PlotBufferEnd = 12`.
+
+- [ ] **Step 1: Read the current enum**
+
+Run:
+```bash
+sed -n '50,65p' src/ipc/message_exchange.h
+```
+Confirm the last entry is `BufferRemoved = 9` (or note the exact existing tail to edit precisely).
+
+- [ ] **Step 2: Add the three values**
+
+In `src/ipc/message_exchange.h`, add the new enumerators immediately after `BufferRemoved = 9,` inside `enum class MessageType`:
+
+```cpp
+    BufferRemoved = 9,
+    PlotBufferBegin = 10,
+    PlotBufferChunk = 11,
+    PlotBufferEnd = 12,
+```
+
+- [ ] **Step 3: Verify it still compiles**
+
+```bash
+cmake --build cmake-build-debug --target test_message_exchange 2>&1 | tail -5
+```
+Expected: builds clean (no behavior change yet).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ipc/message_exchange.h
+git commit -m "feat(ipc): reserve PlotBufferBegin/Chunk/End message types"
+```
+
+---
+
+### Task 3: Extract `plot_buffer_from_fields` helper (C++ refactor, repo `OpenImageDebugger`)
+
+Pure refactor, no behavior change: split `decode_plot_buffer_contents` into a wire-reading half and a reusable "plot from owned bytes" half that the chunked-End handler (Task 4) will also call.
+
+**Files:**
+- Modify: `src/ui/messaging/message_handler.h` (add private method declaration)
+- Modify: `src/ui/messaging/message_handler.cpp:149-318`
+
+**Interfaces:**
+- Produces: `void MessageHandler::plot_buffer_from_fields(const std::string& variable_name_str, const std::string& display_name_str, const std::string& pixel_layout_str, bool transpose_buffer, int buff_width, int buff_height, int buff_channels, int buff_stride, BufferType buff_type, std::vector<std::byte> buff_contents);`
+
+- [ ] **Step 1: Declare the helper**
+
+In `src/ui/messaging/message_handler.h`, after the `void decode_plot_buffer_contents();` declaration (line ~90), add:
+
+```cpp
+    void plot_buffer_from_fields(const std::string& variable_name_str,
+                                 const std::string& display_name_str,
+                                 const std::string& pixel_layout_str,
+                                 bool transpose_buffer,
+                                 int buff_width,
+                                 int buff_height,
+                                 int buff_channels,
+                                 int buff_stride,
+                                 BufferType buff_type,
+                                 std::vector<std::byte> buff_contents);
+```
+
+- [ ] **Step 2: Move the body into the helper**
+
+In `src/ui/messaging/message_handler.cpp`, change `decode_plot_buffer_contents` so it only reads the wire and delegates. Replace the current function body (lines 149-318) so it reads:
+
+```cpp
+void MessageHandler::decode_plot_buffer_contents() {
+    auto variable_name_str = std::string{};
+    auto display_name_str = std::string{};
+    auto pixel_layout_str = std::string{};
+    auto transpose_buffer = bool{};
+    auto buff_width = int{};
+    auto buff_height = int{};
+    auto buff_channels = int{};
+    auto buff_stride = int{};
+    auto buff_type = BufferType{};
+    auto buff_contents = std::vector<std::byte>{};
+
+    auto message_decoder = MessageDecoder{deps_.transport};
+    message_decoder.read(variable_name_str)
+        .read(display_name_str)
+        .read(pixel_layout_str)
+        .read(transpose_buffer)
+        .read(buff_width)
+        .read(buff_height)
+        .read(buff_channels)
+        .read(buff_stride)
+        .read(buff_type)
+        .read(buff_contents);
+
+    plot_buffer_from_fields(variable_name_str,
+                            display_name_str,
+                            pixel_layout_str,
+                            transpose_buffer,
+                            buff_width,
+                            buff_height,
+                            buff_channels,
+                            buff_stride,
+                            buff_type,
+                            std::move(buff_contents));
+}
+
+void MessageHandler::plot_buffer_from_fields(
+    const std::string& variable_name_str,
+    const std::string& display_name_str,
+    const std::string& pixel_layout_str,
+    const bool transpose_buffer,
+    const int buff_width,
+    const int buff_height,
+    const int buff_channels,
+    const int buff_stride,
+    const BufferType buff_type,
+    std::vector<std::byte> buff_contents) {
+```
+
+Then leave the existing code that was at lines 173-318 (starting `const auto lock = std::unique_lock{deps_.ui_mutex};` through the final `deps_.state.request_render_update = true; }`) **exactly as-is** as the body of `plot_buffer_from_fields`, with one change: the float64 branch consumes the moved parameter —
+
+```cpp
+    const auto lock = std::unique_lock{deps_.ui_mutex};
+
+    if (buff_type == BufferType::Float64) {
+        deps_.buffer_data.held_buffers[variable_name_str] =
+            make_float_buffer_from_double(buff_contents);
+    } else {
+        deps_.buffer_data.held_buffers[variable_name_str] =
+            std::move(buff_contents);
+    }
+```
+
+(The `BufferParams` built later already passes `.pixel_layout = pixel_layout_str` and `.step = buff_stride`; those names are unchanged.)
+
+- [ ] **Step 3: Build the viewer to verify the refactor compiles**
+
+```bash
+cmake --build cmake-build-debug --target openimagedebugger 2>&1 | tail -15
+```
+Expected: builds clean. (If the viewer target name differs, list targets with `cmake --build cmake-build-debug --target help | grep -i oid`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ui/messaging/message_handler.h src/ui/messaging/message_handler.cpp
+git commit -m "refactor(messaging): extract plot_buffer_from_fields from decode"
+```
+
+---
+
+### Task 4: Wire chunked decode into `MessageHandler` (C++, repo `OpenImageDebugger`)
+
+**Files:**
+- Modify: `src/ui/messaging/message_handler.h` (include, member, three method declarations)
+- Modify: `src/ui/messaging/message_handler.cpp` (three decode methods + three dispatch cases)
+
+**Interfaces:**
+- Consumes: `oid::BufferAssembler` (Task 1); `MessageType::PlotBufferBegin/Chunk/End` (Task 2); `MessageHandler::plot_buffer_from_fields` (Task 3).
+
+- [ ] **Step 1: Add the assembler member and method declarations**
+
+In `src/ui/messaging/message_handler.h`, add near the top includes (after `#include "ipc/transport.h"`):
+
+```cpp
+#include "ipc/buffer_assembler.h"
+```
+
+Add three private method declarations after `void plot_buffer_from_fields(...);`:
+
+```cpp
+    void decode_plot_buffer_begin();
+    void decode_plot_buffer_chunk();
+    void decode_plot_buffer_end();
+```
+
+Add a private member alongside `Dependencies deps_;`:
+
+```cpp
+    BufferAssembler buffer_assembler_{};
+```
+
+- [ ] **Step 2: Implement the three decode methods**
+
+In `src/ui/messaging/message_handler.cpp`, add after `decode_plot_buffer_contents` / `plot_buffer_from_fields`:
+
+```cpp
+void MessageHandler::decode_plot_buffer_begin() {
+    auto p = BufferAssembler::BeginParams{};
+    auto type_int = int{};
+    auto message_decoder = MessageDecoder{deps_.transport};
+    message_decoder.read(p.variable_name)
+        .read(p.display_name)
+        .read(p.pixel_layout)
+        .read(p.transpose)
+        .read(p.width)
+        .read(p.height)
+        .read(p.channels)
+        .read(p.stride)
+        .read(type_int)
+        .read(p.total_byte_size);
+    p.type = type_int;
+    buffer_assembler_.begin(std::move(p));
+}
+
+void MessageHandler::decode_plot_buffer_chunk() {
+    auto variable_name_str = std::string{};
+    auto row_offset = std::size_t{};
+    auto row_count = std::size_t{};
+    auto bytes = std::vector<std::byte>{};
+    auto message_decoder = MessageDecoder{deps_.transport};
+    message_decoder.read(variable_name_str)
+        .read(row_offset)
+        .read(row_count)
+        .read(bytes);
+    if (!buffer_assembler_.chunk(
+            variable_name_str, row_offset, row_count, std::span{bytes})) {
+        std::cerr << "[Error] Dropped buffer chunk for: " << variable_name_str
+                  << std::endl;
+    }
+}
+
+void MessageHandler::decode_plot_buffer_end() {
+    auto variable_name_str = std::string{};
+    auto message_decoder = MessageDecoder{deps_.transport};
+    message_decoder.read(variable_name_str);
+
+    auto assembled = buffer_assembler_.end(variable_name_str);
+    if (!assembled.has_value()) [[unlikely]] {
+        std::cerr << "[Error] PlotBufferEnd for unknown buffer: "
+                  << variable_name_str << std::endl;
+        return;
+    }
+    plot_buffer_from_fields(assembled->variable_name,
+                            assembled->display_name,
+                            assembled->pixel_layout,
+                            assembled->transpose,
+                            assembled->width,
+                            assembled->height,
+                            assembled->channels,
+                            assembled->stride,
+                            static_cast<BufferType>(assembled->type),
+                            std::move(assembled->bytes));
+}
+```
+
+(`<iostream>` is already included in this file — `std::cerr` is used at line 227. `<span>` is included transitively via `buffer_assembler.h`.)
+
+- [ ] **Step 3: Add the dispatch cases**
+
+In `src/ui/messaging/message_handler.cpp`, inside the `switch (header)` in `decode_incoming_messages` (after the `PlotBufferContents` case, line ~369):
+
+```cpp
+    case MessageType::PlotBufferBegin:
+        decode_plot_buffer_begin();
+        break;
+    case MessageType::PlotBufferChunk:
+        decode_plot_buffer_chunk();
+        break;
+    case MessageType::PlotBufferEnd:
+        decode_plot_buffer_end();
+        break;
+```
+
+- [ ] **Step 4: Build the viewer**
+
+```bash
+cmake --build cmake-build-debug --target openimagedebugger 2>&1 | tail -15
+```
+Expected: builds clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/messaging/message_handler.h src/ui/messaging/message_handler.cpp
+git commit -m "feat(messaging): decode chunked PlotBuffer Begin/Chunk/End"
+```
+
+---
+
+### Task 5: Chunked encoder in the extension (TypeScript, repo `openimagedebugger-vscode`)
+
+**Files:**
+- Modify: `src/ipc/message-exchange.ts` (enum + four functions + constant)
+- Test: `test/message-exchange.test.ts` (add cases)
+
+**Interfaces:**
+- Produces: `CHUNK_BUDGET: number`; `buildPlotBufferBegin(p, mode)`, `buildPlotBufferChunk(variableName, rowOffset, rowCount, bytes, mode)`, `buildPlotBufferEnd(variableName, mode)`, `buildPlotBufferFrames(p, mode, budget?)` → `Uint8Array[]`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `test/message-exchange.test.ts`, add (adjust the import to include the new symbols; reuse the file's existing `node:test`/`assert` style):
+
+```ts
+import {
+  CHUNK_BUDGET,
+  buildPlotBufferFrames,
+  MessageType,
+} from '../src/ipc/message-exchange.js';
+
+function readU32(b: Uint8Array, off: number): number {
+  return (b[off] | (b[off + 1] << 8) | (b[off + 2] << 16) | (b[off + 3] << 24)) >>> 0;
+}
+
+test('small buffer encodes as a single PlotBufferContents frame', () => {
+  const pixels = new Uint8Array(64).map((_, i) => i);
+  const frames = buildPlotBufferFrames(
+    {
+      variableName: 'a', displayName: 'a', pixelLayout: 'rgba', transpose: false,
+      width: 8, height: 8, channels: 1, stride: 8, bufferType: 0, pixels,
+    },
+    'wasm32'
+  );
+  assert.equal(frames.length, 1);
+  assert.equal(readU32(frames[0], 0), MessageType.PlotBufferContents);
+});
+
+test('large buffer encodes as Begin + row-strip Chunks + End covering all bytes', () => {
+  const stride = 8, height = 4;
+  const pixels = new Uint8Array(stride * height).map((_, i) => i);
+  // budget 16 bytes => floor(16/8) = 2 rows per chunk => 2 chunks.
+  const frames = buildPlotBufferFrames(
+    {
+      variableName: 'a', displayName: 'a', pixelLayout: 'rgba', transpose: false,
+      width: 8, height, channels: 1, stride, bufferType: 0, pixels,
+    },
+    'wasm32',
+    16
+  );
+  assert.equal(frames.length, 4);
+  assert.equal(readU32(frames[0], 0), MessageType.PlotBufferBegin);
+  assert.equal(readU32(frames[1], 0), MessageType.PlotBufferChunk);
+  assert.equal(readU32(frames[2], 0), MessageType.PlotBufferChunk);
+  assert.equal(readU32(frames[3], 0), MessageType.PlotBufferEnd);
+
+  // Each chunk frame layout: u32 type, u32 nameLen, name, u32 rowOffset,
+  // u32 rowCount, u32 byteLen, bytes. nameLen == 1 ('a').
+  const collected: number[] = [];
+  for (const f of [frames[1], frames[2]]) {
+    let off = 4;
+    const nameLen = readU32(f, off); off += 4 + nameLen;
+    off += 4; // rowOffset
+    off += 4; // rowCount
+    const byteLen = readU32(f, off); off += 4;
+    for (let i = 0; i < byteLen; i++) collected.push(f[off + i]);
+  }
+  assert.deepEqual(new Uint8Array(collected), pixels);
+});
+
+test('CHUNK_BUDGET is 8 MiB', () => {
+  assert.equal(CHUNK_BUDGET, 8 * 1024 * 1024);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd /Users/bruno/ws/openimagedebugger-vscode && rm -rf out && npm run compile && npm test 2>&1 | tail -20
+```
+Expected: compile or test failure — `CHUNK_BUDGET` / `buildPlotBufferFrames` not exported.
+
+- [ ] **Step 3: Implement the encoder**
+
+In `src/ipc/message-exchange.ts`, add to the `MessageType` enum after `BufferRemoved = 9,`:
+
+```ts
+  PlotBufferBegin = 10,
+  PlotBufferChunk = 11,
+  PlotBufferEnd = 12,
+```
+
+Then add (after `buildPlotBufferContents`):
+
+```ts
+export const CHUNK_BUDGET = 8 * 1024 * 1024; // 8 MiB per chunk message
+
+export function buildPlotBufferBegin(
+  p: PlotBufferParams,
+  mode: WasmLengthMode
+): Uint8Array {
+  const parts: number[] = [];
+  pushU32(parts, MessageType.PlotBufferBegin);
+  pushString(parts, p.variableName, mode);
+  pushString(parts, p.displayName, mode);
+  pushString(parts, p.pixelLayout, mode);
+  parts.push(p.transpose ? 1 : 0);
+  pushI32(parts, p.width);
+  pushI32(parts, p.height);
+  pushI32(parts, p.channels);
+  pushI32(parts, p.stride);
+  pushI32(parts, p.bufferType);
+  pushU32(parts, p.pixels.length);
+  return new Uint8Array(parts);
+}
+
+export function buildPlotBufferChunk(
+  variableName: string,
+  rowOffset: number,
+  rowCount: number,
+  bytes: Uint8Array,
+  mode: WasmLengthMode
+): Uint8Array {
+  const parts: number[] = [];
+  pushU32(parts, MessageType.PlotBufferChunk);
+  pushString(parts, variableName, mode);
+  pushU32(parts, rowOffset);
+  pushU32(parts, rowCount);
+  pushU32(parts, bytes.length);
+  for (const b of bytes) {
+    parts.push(b);
+  }
+  return new Uint8Array(parts);
+}
+
+export function buildPlotBufferEnd(
+  variableName: string,
+  mode: WasmLengthMode
+): Uint8Array {
+  const parts: number[] = [];
+  pushU32(parts, MessageType.PlotBufferEnd);
+  pushString(parts, variableName, mode);
+  return new Uint8Array(parts);
+}
+
+/**
+ * Encode a plot buffer as frames. Small buffers (<= budget) use a single
+ * PlotBufferContents; larger buffers are split into full-width row strips
+ * carried by PlotBufferBegin + N PlotBufferChunk + PlotBufferEnd.
+ */
+export function buildPlotBufferFrames(
+  p: PlotBufferParams,
+  mode: WasmLengthMode,
+  budget: number = CHUNK_BUDGET
+): Uint8Array[] {
+  if (p.pixels.length <= budget) {
+    return [buildPlotBufferContents(p, mode)];
+  }
+  const frames: Uint8Array[] = [buildPlotBufferBegin(p, mode)];
+  const rowsPerChunk = Math.max(1, Math.floor(budget / p.stride));
+  for (let row = 0; row < p.height; row += rowsPerChunk) {
+    const rowCount = Math.min(rowsPerChunk, p.height - row);
+    const start = row * p.stride;
+    const end = start + rowCount * p.stride;
+    frames.push(
+      buildPlotBufferChunk(
+        p.variableName,
+        row,
+        rowCount,
+        p.pixels.subarray(start, end),
+        mode
+      )
+    );
+  }
+  frames.push(buildPlotBufferEnd(p.variableName, mode));
+  return frames;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd /Users/bruno/ws/openimagedebugger-vscode && npm run compile && npm test 2>&1 | tail -20
+```
+Expected: all tests pass, including the three new cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/bruno/ws/openimagedebugger-vscode
+git add src/ipc/message-exchange.ts test/message-exchange.test.ts
+git commit -m "feat(ipc): chunk large plot buffers into Begin/Chunk/End frames"
+```
+
+---
+
+### Task 6: Stop boxing bytes in the webview bridge (TypeScript, repo `openimagedebugger-vscode`)
+
+**Files:**
+- Modify: `src/webview/panel.ts:249` and `src/webview/panel.ts:295`
+
+**Interfaces:** none new — same `postMessage` shape, payload becomes a `Uint8Array` instead of a boxed `number[]`. The inbound bridge already normalizes via `toUint8Array(...)` (panel.ts:44-52), which accepts `Uint8Array`.
+
+- [ ] **Step 1: Replace `Array.from(bytes)` on the two large-payload sends**
+
+In `src/webview/panel.ts`, line 249 (in `sendFrame`):
+
+```ts
+    this.panel?.webview.postMessage({ type: 'oid-ipc-forward', payload: bytes });
+```
+
+And line 295 (in `sendPlotBuffer`):
+
+```ts
+    this.panel?.webview.postMessage({ type: 'oid-ipc-forward', payload: bytes });
+```
+
+(Leave line 57 — the small viewer→host `oid-ipc-out` send — unchanged.)
+
+- [ ] **Step 2: Compile and run the suite**
+
+```bash
+cd /Users/bruno/ws/openimagedebugger-vscode && npm run compile && npm test 2>&1 | tail -10
+```
+Expected: compiles, all tests pass (no test references the boxed form).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/bruno/ws/openimagedebugger-vscode
+git add src/webview/panel.ts
+git commit -m "perf(webview): forward plot frames as Uint8Array, not boxed array"
+```
+
+---
+
+### Task 7: Send frames from the session pipeline (TypeScript, repo `openimagedebugger-vscode`)
+
+Switch `SessionManager` from "encode one frame, send it" to "encode N frames, send each in order".
+
+**Files:**
+- Modify: `src/session/session-manager.ts` (`SessionDeps.encode` → `encodeFrames`; `plotAtFrame` loop)
+- Modify: `src/extension.ts:8` (import) and `src/extension.ts:59` (deps wiring)
+- Test: `test/session-manager.test.ts` (update the fake deps)
+
+**Interfaces:**
+- Consumes: `buildPlotBufferFrames` (Task 5).
+- Produces: `SessionDeps.encodeFrames: (p: PlotBufferParams) => Uint8Array[]`.
+
+- [ ] **Step 1: Update the failing test**
+
+In `test/session-manager.test.ts`, find where the fake `SessionDeps` is built and replace its `encode` with `encodeFrames`. Locate the current property:
+
+```bash
+cd /Users/bruno/ws/openimagedebugger-vscode && grep -n "encode" test/session-manager.test.ts
+```
+
+Replace the `encode: (p) => ...` line with one returning an array, e.g.:
+
+```ts
+    encodeFrames: (p) => [new Uint8Array([p.width & 0xff, p.height & 0xff])],
+```
+
+If the test asserts on `sink.sendPlotBuffer` call counts, the count is now "frames per plot" (1 here) — keep the fake returning a single-element array so existing count assertions hold.
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cd /Users/bruno/ws/openimagedebugger-vscode && rm -rf out && npm run compile 2>&1 | tail -20
+```
+Expected: TypeScript error — `encodeFrames` not in `SessionDeps` / `encode` missing.
+
+- [ ] **Step 3: Update `SessionManager`**
+
+In `src/session/session-manager.ts`, change the `SessionDeps` field (line 22):
+
+```ts
+  encodeFrames: (p: PlotBufferParams) => Uint8Array[];
+```
+
+And in `plotAtFrame` (lines 96-97), replace:
+
+```ts
+      await this.deps.sink.ensureReady();
+      await this.deps.sink.sendPlotBuffer(this.deps.encode(p));
+```
+
+with:
+
+```ts
+      await this.deps.sink.ensureReady();
+      for (const frame of this.deps.encodeFrames(p)) {
+        await this.deps.sink.sendPlotBuffer(frame);
+      }
+```
+
+- [ ] **Step 4: Update `extension.ts` wiring**
+
+In `src/extension.ts`, change the import (line 8):
+
+```ts
+import { buildPlotBufferFrames } from './ipc/message-exchange.js';
+```
+
+And the deps wiring (line 59):
+
+```ts
+    encodeFrames: (p) => buildPlotBufferFrames(p, 'wasm32'),
+```
+
+- [ ] **Step 5: Run the suite**
+
+```bash
+cd /Users/bruno/ws/openimagedebugger-vscode && npm run compile && npm test 2>&1 | tail -15
+```
+Expected: compiles; all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/bruno/ws/openimagedebugger-vscode
+git add src/session/session-manager.ts src/extension.ts test/session-manager.test.ts
+git commit -m "feat(session): send plot buffers as chunked frame sequences"
+```
+
+---
+
+### Task 8: Widen transport length types (C++ defensive cleanup, repo `OpenImageDebugger`)
+
+Chunking already keeps every message ≤ 8 MiB, so the 2 GB `int` overflow can no longer trigger — but remove the latent footgun.
+
+**Files:**
+- Modify: `src/ipc/postmessage_transport.cpp:31-44` and the `oidEnqueueInbound` signature (lines 75-81)
+
+**Interfaces:** internal only.
+
+- [ ] **Step 1: Widen the length parameters**
+
+In `src/ipc/postmessage_transport.cpp`, change the `EM_JS` binding (lines 31-33) and `send` (line 40) to use unsigned 32-bit lengths:
+
+```cpp
+EM_JS(void, oid_send_to_js, (const void* ptr, unsigned len), {
+  window.oidSend(HEAPU8.slice(ptr, ptr + len));
+});
+```
+
+```cpp
+    oid_send_to_js(data.data(), static_cast<unsigned>(data.size()));
+```
+
+And `oidEnqueueInbound` (lines 75-81): change `const int len` to `const unsigned len` and the guard `len <= 0` to `len == 0`:
+
+```cpp
+extern "C" void oidEnqueueInbound(const std::uintptr_t ptr, const unsigned len) {
+    if (g_transport == nullptr || len == 0) {
+        return;
+    }
+    const auto* data = reinterpret_cast<const std::byte*>(ptr);
+    g_transport->enqueue_inbound({data, data + len});
+}
+```
+
+(If the WASM JS glue declares `oidEnqueueInbound`'s `len` argument type anywhere, it passes a JS number either way — no caller change needed. `unsigned` doubles the safe range to 4 GiB.)
+
+- [ ] **Step 2: Build transport test + viewer**
+
+```bash
+cmake --build cmake-build-debug --target test_transport 2>&1 | tail -5
+ctest --test-dir cmake-build-debug -R TransportTests --output-on-failure
+```
+Expected: builds; transport tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/ipc/postmessage_transport.cpp
+git commit -m "fix(ipc): widen postMessage transport length from int to unsigned"
+```
+
+---
+
+### Task 9: Manual verification (both repos)
+
+No code; confirm the feature end-to-end. Do this first if the blank-render cause was never confirmed from the console (see spec "Risks").
+
+- [ ] **Step 1: Rebuild the WASM viewer and copy artifacts into the extension's `media/`**
+
+Follow the project's existing WASM build path (the Emscripten toolchain that produces `oidwindow.js`/`oidwindow.wasm`), then place the artifacts where `openimagedebugger-vscode/media/` expects them, as in prior WASM updates.
+
+- [ ] **Step 2: Launch the extension and plot a large buffer of each dtype**
+
+In a debug session, plot a 40000×2160 buffer as uint8, uint16, float32 (and, if available, float64). For each:
+- Confirm the image **renders** (no longer blank).
+- Hover a pixel and confirm the **value readout is correct**.
+- Toggle contrast and confirm **auto-contrast** behaves.
+- Open the viewer DevTools console and confirm **no `[Error]` lines** (`Dropped buffer chunk`, `PlotBufferEnd for unknown buffer`, `Could not initialize OpenGL canvas`).
+
+- [ ] **Step 3: Record the result**
+
+If all dtypes render correctly, the feature is complete. If a multi-GB float64×4 buffer fails on memory (expected per the spec's Approach-A bound), note it as the known limitation rather than a regression. If a `[Error]` line *does* appear, capture it — it redirects to the GL/validation or DAP-read follow-ups noted in the spec.
+
+---
+
+## Notes for the implementer
+
+- **Drain cadence:** `decode_incoming_messages` processes one message per call (driven by the render loop). A chunked buffer therefore arrives over several loop ticks; the assembler holds state across ticks, so this is correct. For very many chunks (e.g. float64×4) the spread-out delivery is a touch slow but not incorrect — batching the drain is an optional future optimization, not part of this plan.
+- **Desktop/TCP untouched:** only the extension emits chunked frames (`wasm32` mode). The Python/TCP bridge keeps sending `PlotBufferContents`; the viewer still decodes it via the unchanged path.
+- The `out/` directory caveat for the extension: `rm -rf out` before `npm run compile` when you need a clean test baseline.

--- a/docs/superpowers/specs/2026-06-23-oid-wasm-vscode-design.md
+++ b/docs/superpowers/specs/2026-06-23-oid-wasm-vscode-design.md
@@ -1,0 +1,315 @@
+# OID WASM viewer + VS Code extension
+
+**Date:** 2026-06-23  
+**Status:** Approved for implementation  
+**Goal:** Ship full feature parity with desktop Open Image Debugger inside VS Code on macOS and Linux, by compiling `oidwindow` to Qt6 WebAssembly and replacing the GDB/LLDB Python bridge with a TypeScript extension that talks to CodeLLDB via DAP.
+
+---
+
+## 1. Decisions
+
+| Topic | Choice |
+|-------|--------|
+| Scope | Full parity with desktop OID |
+| Debugger | CodeLLDB only (DAP) |
+| Viewer | Qt6 for WebAssembly (`oidwindow` port) |
+| Bridge | TypeScript in the extension (port `oidscripts`) |
+| Platforms (v1) | macOS + Linux |
+| Repository layout | Separate extension repo; WASM published as npm artifact from OID repo |
+| Recommended approach | Published WASM artifact + `ITransport` abstraction (Approach 1) |
+
+### Approaches considered
+
+1. **Published WASM artifact + transport abstraction (chosen)** — OID repo builds and publishes `@openimagedebugger/viewer-wasm`; extension is pure TypeScript; OBP v1 is the sole wire format; `ITransport` abstracts TCP vs postMessage.
+2. **Extension-owned WASM build** — Extension CI builds OID from a pinned source tag. Rejected: duplicates build tooling; WASM fixes still require OID upstream changes.
+3. **Passive WASM viewer** — Extension owns all orchestration; WASM only renders. Rejected: diverges from full parity goal and requires large `oidwindow` refactor.
+
+---
+
+## 2. Architecture
+
+```mermaid
+flowchart TB
+    subgraph ext["VS Code Extension (separate repo)"]
+        DAP["CodeLLDB DAP client"]
+        TB["TypeBridge (TS port of oidscripts)"]
+        OBPenc["OBP v1 encoder/decoder"]
+        WV["Webview host"]
+        DAP --> TB
+        TB --> OBPenc
+        OBPenc <-->|postMessage| WV
+    end
+
+    subgraph oid["OID repo — WASM artifact"]
+        WASM["oidwindow (Qt6 WASM)"]
+        TR["Transport shim (postMessage)"]
+        WASM --> TR
+    end
+
+    subgraph dbg["Debug session"]
+        LLDB["CodeLLDB adapter"]
+    end
+
+    DAP <-->|evaluate / readMemory / stopped| LLDB
+    WV --> WASM
+```
+
+### Role split
+
+| Component today | WASM + VS Code equivalent | Repo |
+|-----------------|---------------------------|------|
+| `oidscripts` (Python) | TypeScript extension (`codelldb-bridge`, `typebridge`) | Extension |
+| `oidbridge` (C++) | Extension orchestration (no process spawn) | Extension |
+| `oidwindow` (Qt desktop) | `oidwindow` (Qt6 WASM) | OID → npm |
+| TCP + legacy IPC | OBP v1 `Envelope` over `postMessage` | Both |
+| GDB/LLDB Python APIs | CodeLLDB DAP | Extension |
+
+Desktop OID (GDB/LLDB Python path) remains unchanged for v1. WASM is an additional build target.
+
+---
+
+## 3. Data flow and buffer lifecycle
+
+```mermaid
+sequenceDiagram
+    participant LLDB as CodeLLDB
+    participant Ext as Extension (TS)
+    participant WASM as oidwindow WASM
+    participant TB as TypeBridge
+
+    Note over Ext,WASM: Session start
+    Ext->>WASM: Open webview, load Qt WASM
+    WASM->>Ext: postMessage: ViewerReady
+
+    Note over LLDB,Ext: Breakpoint hit
+    LLDB->>Ext: stopped event
+    Ext->>TB: get_available_symbols()
+    TB->>LLDB: evaluate (frame vars)
+    Ext->>WASM: OBP SymbolListUpdate
+
+    loop Each watched buffer
+        Ext->>TB: get_buffer_metadata(name)
+        TB->>LLDB: evaluate + readMemory
+        Ext->>WASM: OBP PlotBuffer
+        WASM->>WASM: decode, upload tiles, render
+    end
+
+    Note over WASM,Ext: User adds buffer in UI
+    WASM->>Ext: OBP PlotBufferRequest
+    Ext->>TB: get_buffer_metadata()
+    Ext->>WASM: OBP PlotBuffer
+```
+
+### Stop handler
+
+Port of `OpenImageDebuggerEvents.stop_handler`:
+
+1. Ensure webview is open and WASM reports ready.
+2. For each observed buffer: fetch metadata + pixel data, send `PlotBuffer`.
+3. Refresh symbol autocomplete list via `SymbolListUpdate`.
+
+### Buffer fetch
+
+Port of `get_buffer_metadata` + `serialize_plot_buffer`:
+
+- TypeBridge resolves the variable expression via CodeLLDB `evaluate`.
+- Reads raw bytes via DAP `readMemory` using `memoryReference` from the evaluate result.
+- Extension tiles large buffers per `BufferPayload` in `docs/protocol/obp/v1/buffer.proto`.
+- Sends a single `PlotBuffer` envelope to WASM.
+
+### Event loop
+
+Desktop polls `oid_run_event_loop` at ~30 Hz for UI→bridge messages. In WASM, inbound `postMessage` events drive the same `MessageHandler` code path. No polling loop is required in the extension.
+
+### Session persistence
+
+Extension reads/writes `SessionState` proto to VS Code `globalState` / workspace storage. On WASM ready, push a `SessionState` envelope to restore watched buffers, contrast, link-views, and related UI state.
+
+---
+
+## 4. OBP protocol completion
+
+Legacy `MessageComposer` / `MessageDecoder` over TCP must be fully replaced by OBP v1 for the WASM path. Desktop may migrate in parallel.
+
+| Legacy message | OBP v1 equivalent | Status |
+|----------------|-------------------|--------|
+| `PlotBufferContents` | `Envelope.plot_buffer` | Done |
+| `SetAvailableSymbols` | `Envelope.symbol_list` | Proto exists |
+| `GetObservedSymbols` / response | `Envelope.session_state` | Proto exists; map watched buffer list |
+| `PlotBufferRequest` (UI→bridge) | `Envelope.plot_buffer_request` | **New — add to proto** |
+| Export PNG / Octave | `Envelope.export_request` / `export_result` | Proto exists; WASM requests export, extension writes file |
+
+### Proto addition (`docs/protocol/obp/v1/control.proto`)
+
+```protobuf
+message PlotBufferRequest {
+  string variable_name = 1;
+}
+
+// Add to Envelope.oneof body:
+//   PlotBufferRequest plot_buffer_request = 18;
+```
+
+### postMessage framing
+
+```typescript
+interface OidMessage {
+  type: 'obp';
+  sequence: number;
+  payload: Uint8Array;  // serialized Envelope
+}
+```
+
+Both sides use `sequence` for request/response pairing. Tile large `PlotBuffer` payloads before hitting practical postMessage size limits (~64 MB).
+
+---
+
+## 5. OID repo changes
+
+### Transport abstraction
+
+Introduce `src/ipc/transport.h`:
+
+```cpp
+class ITransport {
+ public:
+  virtual void send(std::span<const std::byte> data) = 0;
+  virtual bool receive(std::vector<std::byte>& out) = 0;
+};
+// TcpTransport (desktop) | PostMessageTransport (emscripten)
+```
+
+Refactor `MessageComposer`, `MessageDecoder`, and `MessageHandler` to use `ITransport*` instead of `QTcpSocket*`.
+
+### WASM build target
+
+New CMake target `oidwindow_wasm` (or conditional on `CMAKE_SYSTEM_NAME STREQUAL "Emscripten"`):
+
+- Requires Qt 6.x WASM kit + Emscripten 3.x.
+- Compile definition: `OID_TRANSPORT_POSTMESSAGE`.
+- `PostMessageTransport` uses `EM_ASM` to call `window.oidSend` / receive via `window.oidOnMessage`.
+- WASM `main()`: no TCP connect; signal ready to extension via postMessage handshake.
+
+### Artifact publishing
+
+OID CI builds and publishes npm package `@openimagedebugger/viewer-wasm@<oid-version>` containing:
+
+- `oidwindow.wasm`, `oidwindow.js`, Qt runtime files, `loader.html`
+- `protocol_version` compatibility metadata
+
+Extension pins this package version to OID releases.
+
+---
+
+## 6. VS Code extension (separate repo)
+
+**Repository name (proposed):** `openimagedebugger-vscode`
+
+```
+openimagedebugger-vscode/
+├── package.json
+├── src/
+│   ├── extension.ts
+│   ├── debugger/
+│   │   ├── codelldb-bridge.ts    # BridgeInterface impl
+│   │   └── dap-client.ts
+│   ├── typebridge/
+│   │   ├── index.ts
+│   │   ├── opencv-mat.ts
+│   │   └── eigen-matrix.ts
+│   ├── obp/                      # protoc-generated TS from OID protos
+│   ├── session/
+│   │   ├── session-manager.ts
+│   │   └── persistence.ts
+│   └── webview/
+│       ├── panel.ts
+│       └── loader.html
+├── media/                        # from @openimagedebugger/viewer-wasm
+└── test/
+```
+
+### Activation
+
+- `onDebug` with debugger type `lldb` (CodeLLDB).
+- Track `stopped`, `terminated`, and thread/frame changes via `DebugAdapterTracker` or debug session events.
+
+### Commands
+
+| Command | Purpose |
+|---------|---------|
+| `oid.plot` | Plot variable under cursor (port GDB/LLDB `plot` command) |
+| `oid.openPanel` | Open or focus viewer webview panel |
+| `oid.export` | Trigger export; WASM sends `ExportRequest`, extension writes file |
+
+### TypeBridge port
+
+| Python source | TypeScript target | DAP API |
+|---------------|-------------------|---------|
+| `lldbbridge.get_buffer_metadata` | `codelldb-bridge.ts` | `evaluate` + `readMemory` |
+| `typebridge.TypeBridge` | `typebridge/index.ts` | LLDB type info via evaluate |
+| OpenCV `Mat` parser | `opencv-mat.ts` | `data`, `step`, dims via evaluate |
+| Eigen matrix parser | `eigen-matrix.ts` | same pattern |
+| Custom types (`oidtypes/`) | workspace settings or TS plugins | user-provided |
+
+`queue_request` from `BridgeInterface` serializes work on the extension main thread. CodeLLDB DAP is async-safe (unlike GDB).
+
+---
+
+## 7. Error handling
+
+| Failure | Behavior |
+|---------|----------|
+| WASM fails to load | Webview error panel with OID version and requirements |
+| OBP version mismatch | Refuse connection; prompt to update extension or WASM package |
+| Variable not plottable | `Envelope.error` to WASM; status bar notification |
+| `readMemory` fails | Retry once; then error with variable name |
+| Debug session ends | Exit signal; close or disable panel |
+| Buffer exceeds GL texture limit | Tile via existing `BufferPayload` logic |
+
+---
+
+## 8. Testing
+
+### OID repo
+
+- Unit tests: `PostMessageTransport` + OBP round-trip (extend `docs/protocol/obp/v1/conformance/`).
+- WASM smoke test: headless Playwright loads wasm, sends sample `PlotBuffer`, asserts no crash.
+- Desktop regression suite unchanged.
+
+### Extension repo
+
+- Unit tests: TypeBridge with mocked DAP fixture JSON from real LLDB sessions.
+- Integration test: CodeLLDB on `testbench/` binary, breakpoint hit, assert `PlotBuffer` received.
+- Manual matrix: macOS + Linux; OpenCV `Mat` + raw buffer types.
+
+---
+
+## 9. Delivery phases
+
+| Phase | Deliverable | Parity checkpoint |
+|-------|-------------|-------------------|
+| P0 | `ITransport` abstraction + `PlotBufferRequest` proto | Infrastructure |
+| P1 | WASM builds; loads in webview; renders test `PlotBuffer` | Rendering |
+| P2 | Extension + CodeLLDB stop → plot one OpenCV `Mat` | Core loop |
+| P3 | Symbol list, watched buffers, auto-update on stop | Session management |
+| P4 | Auto-contrast, rotation, go-to, pixel values, link views | UI features |
+| P5 | Export PNG/Octave, session persistence, Eigen + custom types | Full parity |
+| P6 | Marketplace publish, user documentation | Ship |
+
+---
+
+## 10. Success criteria
+
+- User can debug a C++ app with CodeLLDB in VS Code on macOS or Linux, hit a breakpoint, and plot an OpenCV `Mat` with the same core interactions as desktop OID (zoom, pan, contrast, pixel values).
+- WASM viewer artifact version is pinned and compatible with the extension via OBP `protocol_version`.
+- Desktop GDB/LLDB workflow is not regressed.
+- Extension installs from `.vsix` or VS Code Marketplace without native OID binaries (only the WASM npm package bundled in the extension).
+
+---
+
+## Self-review (spec)
+
+- **Placeholder scan:** No TBD sections. All requirements are explicit.
+- **Internal consistency:** Architecture, data flow, proto additions, and delivery phases align. Extension owns bridge; OID owns viewer WASM.
+- **Scope check:** Single implementation plan scope. Extension repo creation is noted but implementation plan for OID repo changes is the first deliverable.
+- **Ambiguity check:** v1 platforms are macOS + Linux only. Full parity is the P6 target, not P2. Export file writes are handled by the extension host, not WASM filesystem.

--- a/docs/superpowers/specs/2026-06-24-oid-vscode-p2-codelldb-design.md
+++ b/docs/superpowers/specs/2026-06-24-oid-vscode-p2-codelldb-design.md
@@ -88,7 +88,7 @@ byteCount = rows * step0
 pixels    = readMemory(dataRef, byteCount)   // base64 → Uint8Array
 ```
 
-OID buffer-type values (`symbols.py`): `UINT8=0, FLOAT32=1, UINT16=2, INT16=3, INT32=4, FLOAT64=6`. The resulting `PlotBufferParams` is `{ variableName, displayName, pixelLayout, transpose:false, width:cols, height:rows, channels, stride:row_stride, bufferType:type_value, pixels }`.
+OID buffer-type values (`symbols.py`, mirroring OpenCV depth codes): `UINT8=0, UINT16=2, INT16=3, INT32=4, FLOAT32=5, FLOAT64=6`. The resulting `PlotBufferParams` is `{ variableName, displayName, pixelLayout, transpose:false, width:cols, height:rows, channels, stride:row_stride, bufferType:type_value, pixels }`.
 
 The testbench (`testbench/main.cpp`) defines a faithful `cv::Mat` shape — `data`, `cols`, `rows`, `flags`, `step.buf[2]` with `step.buf[0] = cols*channels*sizeof(T)`, `step.buf[1] = channels` — so these expressions resolve against it.
 

--- a/docs/superpowers/specs/2026-06-24-oid-vscode-p2-codelldb-design.md
+++ b/docs/superpowers/specs/2026-06-24-oid-vscode-p2-codelldb-design.md
@@ -1,0 +1,164 @@
+# OID VS Code P2: CodeLLDB → WASM viewer bridge — Design
+
+**Date:** 2026-06-24
+**Status:** Approved for implementation
+**Supersedes/refines:** `docs/superpowers/plans/2026-06-24-oid-vscode-p2-codelldb.md`
+**Parent spec:** `docs/superpowers/specs/2026-06-23-oid-wasm-vscode-design.md` (phase P2)
+
+**Goal:** Plot a live OpenCV `cv::Mat` from a CodeLLDB debug session into the existing WASM viewer, replacing the hardcoded smoke-test buffer with a real CodeLLDB → metadata → pixels → IPC pipeline. P2 is **extension-only**: no OpenImageDebugger (OID) C++/WASM repo changes.
+
+---
+
+## 1. Context: what already exists
+
+P1 is done. Establishing the actual state (not the P1 spec's intent) is essential because the implementation diverged from the spec on the wire format.
+
+**OID repo (`OpenImageDebugger`):** The Qt6 WASM `oidwindow` builds, loads in a webview, and renders. It is driven by the **legacy binary `MessageComposer` format** (`PlotBufferContents`, message type `3`) over `postMessage`, **not** the OBP v1 protobuf the P1 spec called "the sole wire format." The viewer signals readiness via an `oid-control` / `viewer-ready` message and consumes inbound IPC frames through `window.oidOnMessage(Uint8Array)`.
+
+**Extension repo (`openimagedebugger-vscode`, sibling of the OID repo):** Already scaffolded with a working smoke-test loop:
+
+- `src/extension.ts` — registers `oid.openPanel` only.
+- `src/webview/panel.ts` — creates the webview, inlines the loader HTML, and on `viewer-ready` pushes a hardcoded 2×2 RGB buffer encoded by `buildPlotBufferContents` → `oid-ipc-forward` → `oidOnMessage`.
+- `src/ipc/message-exchange.ts` — TypeScript port of `buildPlotBufferContents` with a `wasm32` length mode (`MessageType.PlotBufferContents = 3`).
+- `src/typebridge/`, `src/debugger/`, `src/session/` — empty stubs.
+
+**postMessage contract (already in use, P2 keeps it):**
+
+| Direction | Message | Meaning |
+|-----------|---------|---------|
+| webview → extension | `{ type: 'oid-control', event: 'viewer-ready' }` | Viewer ready to receive buffers |
+| extension → webview | `{ type: 'oid-ipc-forward', payload: number[] }` | Encoded `PlotBufferContents` frame |
+| webview → extension | `{ type: 'oid-ipc-out', payload: number[] }` | Viewer → host IPC (unused in P2) |
+
+**P2's actual job:** swap the hardcoded smoke-test buffer for a real `cv::Mat` read.
+
+---
+
+## 2. Decisions
+
+| Topic | Choice | Rationale |
+|-------|--------|-----------|
+| Metadata read | CodeLLDB DAP `evaluate` expressions | Fewest round-trips; mirrors the Python bridge's field logic directly; `data` address comes from the evaluate result's `memoryReference`. |
+| Wire format | Legacy binary `PlotBufferContents` (`wasm32` mode) | Smallest diff to a working pipeline; matches what the WASM viewer already consumes. OBP protobuf is **deferred**, not pursued in P2. |
+| Pixel transfer | Existing `number[]`-through-`postMessage` copy | Known-inefficient but functional; no-copy/transferable path deferred (P2+). |
+| Trigger | `oid.plot` command **and** `oid.watchOnStop` config | `oid.plot` for ad-hoc inspection; `oid.watchOnStop` re-plots named buffers on every stop. Matches desktop OID feel. |
+| Scope boundary | Extension-only | No OID repo C++/WASM changes in P2. |
+| Verification | Full Mat type map ported; **uint8-first** against the testbench | Type decode is cheap to port fully; verification starts with uint8, then float32. |
+
+---
+
+## 3. Components (all in `openimagedebugger-vscode/src`)
+
+| File | Responsibility | Ports from (OID `resources/oidscripts`) |
+|------|----------------|------------------------------------------|
+| `typebridge/buffer-metadata.ts` | `OID_TYPES_*` enum, `bytesPerChannel(type)`, stride/size helpers. Pure functions. | `sysinfo.py`, `symbols.py` |
+| `typebridge/opencv-mat.ts` | Pure flags-decode: given raw field values, produce `PlotBufferParams` **minus pixels**. No DAP coupling. | `oidtypes/opencv.py` (`Mat`) |
+| `debugger/dap-client.ts` | Thin DAP wrappers over the active session: `evaluate(expr, frameId)`, `readMemory(memoryReference, count)`, resolve current stopped `threadId`/`frameId`. | `debuggers/lldbbridge.py` (DAP subset) |
+| `debugger/codelldb-bridge.ts` | Orchestrates one plot: resolve variable expression → `evaluate` fields → `opencv-mat` decode → compute byte count → `readMemory` → assemble full `PlotBufferParams`. | `lldbbridge.get_buffer_metadata` |
+| `session/session-manager.ts` | `DebugAdapterTracker` for debug type `lldb`; caches stopped `threadId`/`frameId`; runs the `oid.watchOnStop` list on `stopped`; exposes `plotVariable(name)`. | `OpenImageDebuggerEvents.stop_handler` |
+| `webview/panel.ts` (modify) | Extract `ViewerController.sendPlotBuffer(params)`; make the panel a singleton; move the smoke-test behind a default-off flag. | — |
+| `extension.ts` (modify) | Register `oid.plot` / `oid.openPanel`; read `oid.watchOnStop`; wire `SessionManager` ↔ `ViewerController`. | — |
+
+Each unit has one clear purpose. `opencv-mat.ts` and `buffer-metadata.ts` are pure and unit-testable without a debug session. `dap-client.ts` is the only unit touching the VS Code Debug API, so the bridge can be tested against a mock.
+
+---
+
+## 4. cv::Mat metadata extraction (port of `opencv.py`)
+
+OpenCV constants: `CV_CN_SHIFT = 3`, `CV_CN_MAX = 512`, `CV_MAT_CN_MASK = ((CV_CN_MAX - 1) << CV_CN_SHIFT)`, `CV_DEPTH_MAX = (1 << CV_CN_SHIFT)`, `CV_MAT_TYPE_MASK = (CV_DEPTH_MAX * CV_CN_MAX - 1)`.
+
+For a Mat variable expression `M`:
+
+```text
+flags  = evaluate "M.flags"          (int)
+cols   = evaluate "M.cols"           (int)  → width
+rows   = evaluate "M.rows"           (int)  → height
+step0  = evaluate "M.step.buf[0]"    (int)  → row byte stride
+dataRef = evaluate("M.data").memoryReference
+
+channels   = ((flags & CV_MAT_CN_MASK) >> CV_CN_SHIFT) + 1
+type_value = (flags & CV_MAT_TYPE_MASK) & 7        → OID buffer type
+row_stride = step0 / channels                       (elements per row)
+  if type_value in {UINT16, INT16}:  row_stride /= 2
+  if type_value in {INT32, FLOAT32}: row_stride /= 4
+  if type_value == FLOAT64:          row_stride /= 8
+pixel_layout = channels >= 3 ? 'bgra' : 'rgba'
+
+byteCount = rows * step0
+pixels    = readMemory(dataRef, byteCount)   // base64 → Uint8Array
+```
+
+OID buffer-type values (`symbols.py`): `UINT8=0, FLOAT32=1, UINT16=2, INT16=3, INT32=4, FLOAT64=6`. The resulting `PlotBufferParams` is `{ variableName, displayName, pixelLayout, transpose:false, width:cols, height:rows, channels, stride:row_stride, bufferType:type_value, pixels }`.
+
+The testbench (`testbench/main.cpp`) defines a faithful `cv::Mat` shape — `data`, `cols`, `rows`, `flags`, `step.buf[2]` with `step.buf[0] = cols*channels*sizeof(T)`, `step.buf[1] = channels` — so these expressions resolve against it.
+
+---
+
+## 5. Data flow
+
+```text
+CodeLLDB `stopped`
+  → DebugAdapterTracker caches threadId + top frameId
+  → SessionManager.onStopped():
+       for each name in oid.watchOnStop:  plotVariable(name)
+
+oid.plot command (symbol under cursor, else input box)
+  → if no stopped frame: warn "Pause in a debug session first"
+  → else plotVariable(name)
+
+plotVariable(name):
+  CodeLldbBridge.getBufferMetadata(name)      // §4
+  → buildPlotBufferContents(params, 'wasm32') // existing encoder
+  → ViewerController.sendPlotBuffer(bytes)
+  → panel.webview.postMessage({type:'oid-ipc-forward', payload:[...bytes]})
+  → webview oidOnMessage(Uint8Array)          // viewer renders
+```
+
+If the panel is not yet open or `viewer-ready` has not fired, `ViewerController` opens the panel and queues the buffer until `viewer-ready`.
+
+---
+
+## 6. Error handling
+
+| Failure | Behavior |
+|---------|----------|
+| Variable not found / not a `cv::Mat` | Status-bar warning; skip this name (don't abort other watches) |
+| Null `data` pointer (`0x0`) | Error notification naming the variable |
+| `evaluate` fails | Error naming the variable; skip |
+| `readMemory` fails | Retry once; then error |
+| `oid.plot` with no stopped frame | "Pause in a debug session first" |
+| Panel not ready / `viewer-ready` not seen | Open panel; queue buffer until ready |
+
+A failing watch entry never blocks the others; `onStopped` continues the loop.
+
+---
+
+## 7. Testing
+
+**Unit (no debug session):**
+- `buffer-metadata.test.ts` — `bytesPerChannel` / stride helpers across all OID types.
+- `opencv-mat.test.ts` — flags-decode for CV_8UC3, CV_8UC1, CV_32FC1, CV_16UC1 (channels, type_value, row_stride, pixel_layout) via fixtures.
+- `codelldb-bridge.test.ts` — `getBufferMetadata` orchestration against a **mocked DAP client** returning canned `evaluate` + `readMemory` responses (fixture `test/fixtures/cv-mat-variables.json`).
+- Keep existing `message-exchange.test.ts`.
+
+**Manual (verification):**
+1. Build the OID testbench; launch CodeLLDB from the extension dev host (`.vscode/launch.json`).
+2. Break in `testbench/main.cpp` `nest()`.
+3. `OID: Plot Variable` on `TestField`; confirm the image renders in the viewer panel.
+4. Set `oid.watchOnStop: ["TestField"]`; step/continue; confirm auto-replot on the next stop.
+5. Repeat uint8 first, then a float32 Mat.
+
+---
+
+## 8. Scope / deferred (P2+)
+
+Out of P2 by decision: OBP protobuf migration; no-copy / transferable pixel transfer; chunking buffers > 64 MB; `PlotBufferRequest` (WASM → extension) round-trip; CvMat / IplImage / Eigen types; symbol-autocomplete list (P3 — `SetAvailableSymbols`); multi-panel / multi-buffer UI management.
+
+---
+
+## Self-review (spec)
+
+- **Placeholder scan:** No TBD sections; all field expressions, constants, type values, and file responsibilities are explicit.
+- **Internal consistency:** §1 contract, §4 extraction, and §5 flow use the same message names (`oid-control`/`viewer-ready`, `oid-ipc-forward`) and the same `PlotBufferParams` shape as the existing `buildPlotBufferContents`. Decisions in §2 are reflected in every later section.
+- **Scope check:** Single implementation-plan scope — seven focused files, extension-only, no OID repo changes.
+- **Ambiguity check:** Wire format is legacy binary (not OBP) — stated explicitly to override the parent spec's intent. Verification is uint8-first with the full type map ported. `transpose` is always `false` in P2.

--- a/docs/superpowers/specs/2026-06-24-oid-vscode-p3-session-design.md
+++ b/docs/superpowers/specs/2026-06-24-oid-vscode-p3-session-design.md
@@ -1,0 +1,138 @@
+# OID VS Code P3: Session management — symbol list, watched buffers, auto-update — Design
+
+**Date:** 2026-06-24
+**Status:** Approved design
+**Parent spec:** `docs/superpowers/specs/2026-06-23-oid-wasm-vscode-design.md` (phase P3)
+**Builds on:** `docs/superpowers/specs/2026-06-24-oid-vscode-p2-codelldb-design.md` (P2: CodeLLDB → WASM bridge)
+
+**Goal:** Turn P2's one-shot plot into a live session loop. On every debugger stop the extension populates the viewer's symbol autocomplete, asks the viewer which buffers it is watching, and re-plots them with fresh data. The user can add a buffer by typing its name in the viewer itself. The watch list is **owned by the viewer** (desktop OID parity), seeded once from the `oid.watchOnStop` config.
+
+---
+
+## 1. Context: already exists (after P2)
+
+**OID viewer (`oidwindow`, WASM):** Compiles the **full** desktop `main_window` UI — `symbol_completer`, `symbol_search_input`, the `available_vars`-driven autocomplete, and `message_handler` which already speaks the complete protocol:
+
+| Type | Direction | Meaning |
+|------|-----------|---------|
+| `GetObservedSymbols = 0` | host → viewer | "Which buffers are you watching?" |
+| `GetObservedSymbolsResponse = 1` | viewer → host | list of watched buffer names |
+| `SetAvailableSymbols = 2` | host → viewer | populate autocomplete with in-scope names |
+| `PlotBufferContents = 3` | host → viewer | pixel data (P2 already uses this) |
+| `PlotBufferRequest = 4` | viewer → host | "plot the buffer named X" (user typed/picked it) |
+
+A buffer becomes "observed" in the viewer simply by being plotted (`PlotBufferContents`); `GetObservedSymbols` returns whatever the viewer currently shows. This is the desktop loop, and it requires **no OID repo changes** for P3.
+
+**Extension (`openimagedebugger-vscode`, after P2):**
+- `debugger/dap-client.ts` — `evaluate`, `readMemory`, resolve stopped frame.
+- `debugger/codelldb-bridge.ts` — `getBufferMetadata(variable, frameId)` → `PlotBufferParams`.
+- `typebridge/opencv-mat.ts`, `typebridge/buffer-metadata.ts` — pure decode.
+- `ipc/message-exchange.ts` — encodes `PlotBufferContents`; `PlotBufferParams` type.
+- `session/session-manager.ts` — transport-agnostic. Current `SessionDeps`: `source` (`getBufferMetadata`), `sink` (`ensureReady`/`sendPlotBuffer`), `encode`, `resolveFrame`, `getWatchList`, `warn`. `onStopped(threadId)` iterates the static `getWatchList()` config.
+- `webview/panel.ts` — owns the webview/transport. Outbound: `oid-ipc-forward` → `window.oidOnMessage`. Inbound: `window.oidSend` → `oid-ipc-out` post back to the extension.
+
+---
+
+## 2. Design decisions
+
+| Topic | Choice | Rationale |
+|-------|--------|-----------|
+| Watch source of truth | **Viewer-owned** | Desktop parity; enables in-viewer add/remove and `PlotBufferRequest`. `oid.watchOnStop` becomes a one-time seed. |
+| Sync mechanism | **Poll on stop** (`GetObservedSymbols` request/response), no event-push | Covers add (immediate via `PlotBufferRequest`) and remove (next stop's poll). Event-push would only react to mid-pause *removal*, which nothing needs — YAGNI. |
+| OID repo changes | **None** | Existing viewer protocol is sufficient. Reserved only if a concrete gap appears. |
+| Symbol enumeration | **Local + Arguments scopes, current frame** | Matches desktop "variables in scope"; plottability checked on plot, not pre-filtered. |
+| Cross-restart persistence | **Deferred to P5** | Parent phase table assigns "session persistence" to P5. P3's observed set is in-memory for the live session. |
+| Scope boundary | **Extension-only** | No OID C++/WASM changes. |
+
+---
+
+## 3. Components (all in `openimagedebugger-vscode/src`)
+
+| File | Change | Responsibility |
+|------|--------|----------------|
+| `debugger/symbol-enumerator.ts` | **new** | `listScopeSymbols(frameId)`: DAP `scopes(frameId)` → keep scopes named/typed Local or Arguments → `variables(ref)` → flat `{ name, type }[]`. Only file beyond `dap-client` touching DAP scope/variables. |
+| `ipc/message-exchange.ts` | **extend** | `encodeSetAvailableSymbols(names)` (type 2: count + length-prefixed strings, matching `MessageComposer`); `encodeGetObservedSymbols()` (type 0, header-only); `decodeInbound(bytes)` → discriminated union `{ kind: 'observedSymbols', names } \| { kind: 'plotRequest', name }` for types 1 and 4. |
+| `webview/panel.ts` | **extend** | Implement a `ViewerChannel`: `setAvailableSymbols(names)`, `getObservedSymbols(): Promise<string[]>` (send type 0, await correlated type-1 reply with timeout), and route inbound `oid-ipc-out` frames through `decodeInbound` → resolve the pending observed-symbols promise or invoke the `onPlotBufferRequest` callback. |
+| `session/session-manager.ts` | **extend** | Replace the static-list `onStopped` with the full loop (§4). Extend `SessionDeps` with `listScopeSymbols(frameId)`, and a `channel` exposing `setAvailableSymbols` + `getObservedSymbols` (the existing `sink` stays for plotting). Add `onPlotBufferRequest(name, threadId)` → reuse `plotVariable`. Track an in-memory `seeded` flag. |
+| `extension.ts` | **wire** | Build the channel/enumerator deps; on `stopped` call `onStopped`; register the channel's `onPlotBufferRequest` → `SessionManager`; dispose on session end. |
+
+The viewer-coupled correlation/decoding lives in `panel.ts` (the `ViewerChannel`); `session-manager.ts` stays VS-Code-free and unit-testable with mocks, preserving P2's separation.
+
+---
+
+## 4. Data flow
+
+```
+DebugAdapterTracker: stopped(threadId)
+  └─> SessionManager.onStopped(threadId)
+        frameId = resolveFrame(threadId)
+        1. syms = listScopeSymbols(frameId)                  // [{name,type}], Local+Arguments
+           channel.setAvailableSymbols(syms.map(s => s.name)) // → SetAvailableSymbols (autocomplete)
+        2. observed = await channel.getObservedSymbols()      // GetObservedSymbols → Response (timeout → [])
+        3. if (!seeded) { observed = union(observed, getWatchList()); seeded = true }
+        4. for name in observed:
+             try { meta = source.getBufferMetadata(name, frameId)
+                   sink.ensureReady(); sink.sendPlotBuffer(encode(meta)) }  // → PlotBufferContents
+             catch { warn("could not plot 'name'"); continue }              // P2 error policy
+
+Inbound (any time the viewer user adds a symbol):
+  oid-ipc-out → decodeInbound → { kind:'plotRequest', name }
+    └─> SessionManager.onPlotBufferRequest(name, currentThreadId)
+          → plotVariable(name, threadId)   // fetch + plot; viewer now lists it as observed
+```
+
+Add is immediate (`PlotBufferRequest`); remove is reflected at the next stop (poll returns the smaller set). On the first stop after a session/panel opens, the `oid.watchOnStop` names are unioned into the observed set and plotted, which makes the viewer start observing them.
+
+---
+
+## 5. Request/response correlation
+
+`getObservedSymbols()` stores a single `pendingObservedSymbols` resolver on the channel (at most one poll in flight per stop). An inbound type-1 frame resolves it with the decoded names. A 1000 ms timeout resolves it to `[]` and logs a warning — guarding against an old/loading viewer that never replies, so the stop loop never hangs. If a poll is issued while one is pending (defensive), the previous resolver is settled with `[]` first.
+
+---
+
+## 6. Error handling (extends P2 §6)
+
+| Failure | Behavior |
+|---------|----------|
+| `scopes`/`variables` enumeration fails | Skip `SetAvailableSymbols` this stop; warn; continue to plot loop |
+| `GetObservedSymbols` times out / no reply | Resolve `[]`; plot loop is a no-op this stop |
+| `PlotBufferRequest` for unknown/out-of-scope name | P2: status-bar warning naming the variable; no crash |
+| Per-buffer metadata / `readMemory` failure | P2: skip that buffer; loop continues |
+| `stopped` before panel/`viewer-ready` | P2: open panel, queue, replay on ready |
+
+A failing entry never aborts the loop; `onStopped` always processes every observed name.
+
+---
+
+## 7. Testing
+
+**Unit (no debug session):**
+- `symbol-enumerator.test.ts` — mocked DAP `scopes`/`variables` fixture → flat `{name,type}` list; verifies Local+Arguments scopes kept and others (Registers/Static) dropped.
+- `message-exchange.test.ts` (extend) — `encodeSetAvailableSymbols` and `encodeGetObservedSymbols` byte-match `MessageComposer` fixtures; `decodeInbound` parses type-1 and type-4 frames (incl. empty observed list, multi-name).
+- `session-manager.test.ts` — mocked `channel` + `source`: asserts (a) `setAvailableSymbols` sent with enumerated names; (b) observed set polled; (c) first-stop seed = union(observed, watchList) and `seeded` flag flips; (d) one `sendPlotBuffer` per observed name; (e) a throwing `getBufferMetadata` skips only that name; (f) `onPlotBufferRequest` calls `plotVariable`.
+- Channel correlation test — `getObservedSymbols()` resolves on inbound type-1, resolves `[]` on timeout.
+
+**Manual (verification):**
+1. Build OID testbench; launch CodeLLDB from extension dev host.
+2. Break in `testbench/main.cpp` `nest()`. Confirm the viewer's autocomplete lists `nest()`'s locals + arguments.
+3. Type `TestField` in the viewer's symbol box → confirm it plots (viewer-initiated `PlotBufferRequest`).
+4. Set `oid.watchOnStop: ["TestField"]`, restart → confirm it auto-plots on the first stop.
+5. Step/continue → confirm watched buffers re-plot with updated data.
+6. Remove `TestField` in the viewer → step → confirm it is **not** re-plotted.
+
+---
+
+## 8. Delivery / phase boundary
+
+- **In P3:** symbol enumeration → `SetAvailableSymbols`; viewer-owned observed set via `GetObservedSymbols` poll; auto-replot on stop; `PlotBufferRequest` inbound; `oid.watchOnStop` first-stop seed.
+- **Deferred:** cross-restart session persistence → **P5**; multi-panel / multi-buffer-layout management → later; OBP protobuf migration, no-copy pixel transfer → later; UI parity features (auto-contrast, rotation, go-to, link views) → **P4**.
+
+---
+
+## 9. Self-review (spec)
+
+- **Placeholder scan:** No TBD. Every component names concrete files and the message types it touches.
+- **Internal consistency:** Message-type numbers (§1) match encode/decode duties (§3) and the data flow (§4). Viewer-owned decision (§2) is realized by the poll + seed loop (§4) and the deferral of persistence to P5 (§2, §8).
+- **Scope check:** Single implementation-plan scope — one new file, three extended files, one wiring change; extension-only.
+- **Ambiguity check:** Watch source of truth is the viewer; `oid.watchOnStop` is a one-time seed, not an ongoing source. Symbol enumeration is current-frame Local+Arguments, unfiltered by plottability. `GetObservedSymbols` is request/response polled on stop, not event-pushed. Persistence is explicitly out of P3.

--- a/docs/superpowers/specs/2026-06-24-oid-wasm-vscode-qt611-design.md
+++ b/docs/superpowers/specs/2026-06-24-oid-wasm-vscode-qt611-design.md
@@ -1,0 +1,321 @@
+# OID WASM viewer + VS Code extension (Qt 6.11)
+
+**Date:** 2026-06-24  
+**Status:** Approved for implementation  
+**Supersedes:** `docs/superpowers/plans/2026-06-23-oid-wasm-vscode-design.md` (toolchain, wire format, and first-pass scope)  
+**Goal:** Compile `oidwindow` to Qt 6.11 WebAssembly and validate it in a VS Code webview using the **existing custom IPC protocol** (`MessageComposer` / `MessageDecoder`). First pass delivers OID repo P0–P1 plus a minimal extension smoke test.
+
+---
+
+## 1. Decisions
+
+| Topic | Choice |
+|-------|--------|
+| Qt version | **6.11.x** (desktop + WASM); upgrade to **6.12 LTS** when GA (~Sept 2026) |
+| Emscripten | **4.0.7** (required pairing for Qt 6.11 per [Qt WASM docs](https://doc.qt.io/qt-6/wasm.html)) |
+| Wire format | **Existing custom binary IPC** — no Protobuf, no OBP |
+| Transport | `ITransport` abstraction: `TcpTransport` (desktop) / `PostMessageTransport` (WASM) |
+| First-pass scope | OID P0–P1 + extension smoke stub (hardcoded `PlotBufferContents`) |
+| Out of scope (this pass) | CodeLLDB DAP bridge, TypeBridge, full parity (P2–P6) |
+| WASM artifact | `@openimagedebugger/viewer-wasm` npm package from OID CI |
+| Extension repo | Separate `openimagedebugger-vscode` (smoke stub only in this pass) |
+| Desktop baseline | Bump entire repo from Qt 6.4.2 → **6.11** |
+
+### Approaches considered
+
+1. **Official Qt 6.11 binary packages (chosen)** — Install desktop Qt 6.11 + `WebAssembly (single-threaded)` via Qt Online Installer or CI cache. Pin `emsdk 4.0.7`. Build with `qt-cmake` from the WASM kit.
+2. **Build Qt 6.11 WASM from source in CI** — Rejected: 1–2 hour builds; unnecessary for OID.
+3. **Track Qt 6.12 beta now** — Rejected: beta instability; Emscripten pairing not yet documented. Upgrade path documented for 6.12 LTS GA.
+
+---
+
+## 2. Architecture
+
+```mermaid
+flowchart TB
+    subgraph ext["VS Code Extension (smoke stub)"]
+        MC["MessageComposer (TS port)"]
+        WV["Webview host"]
+        MC -->|postMessage| WV
+    end
+
+    subgraph oid["OID repo — WASM artifact"]
+        WASM["oidwindow (Qt 6.11 WASM)"]
+        TR["PostMessageTransport"]
+        MH["MessageHandler + MessageDecoder"]
+        WASM --> MH --> TR
+    end
+
+    WV <-->|oid-ipc bytes| WASM
+```
+
+### Role split
+
+| Component today | WASM + VS Code equivalent | Repo |
+|-----------------|---------------------------|------|
+| `oidscripts` (Python) | TypeScript extension (future: `codelldb-bridge`) | Extension |
+| `oidbridge` (C++) | Extension orchestration (no process spawn) | Extension |
+| `oidwindow` (Qt desktop) | `oidwindow` (Qt 6.11 WASM) | OID → npm |
+| TCP + `MessageComposer` bytes | Same bytes over `postMessage` | Both |
+| GDB/LLDB Python APIs | CodeLLDB DAP (future P2+) | Extension |
+
+Desktop OID (GDB/LLDB Python path) remains unchanged. WASM is an additional build target.
+
+---
+
+## 3. Wire format
+
+### Message types (existing — no changes)
+
+Defined in `src/ipc/message_exchange.h`:
+
+| `MessageType` | Value | Direction |
+|---------------|-------|-----------|
+| `GetObservedSymbols` | 0 | UI → bridge |
+| `GetObservedSymbolsResponse` | 1 | bridge → UI |
+| `SetAvailableSymbols` | 2 | bridge → UI |
+| `PlotBufferContents` | 3 | bridge → UI |
+| `PlotBufferRequest` | 4 | UI → bridge |
+
+`PlotBufferRequest` already exists. No proto or enum additions required.
+
+### Serialization rules
+
+| Field type | On-wire format |
+|------------|----------------|
+| Primitive (`MessageType`, `int`, `bool`, `BufferType`, `size_t`, …) | `sizeof(T)` raw bytes, platform little-endian |
+| `string` | `size_t` length + UTF-8 bytes |
+| `deque<string>` / `QStringList` | count + repeated strings |
+| Pixel buffer | `size_t` length + raw bytes |
+
+### `PlotBufferContents` field order
+
+Matches `oid_bridge.cpp::plot_buffer`:
+
+1. `variable_name` (string)
+2. `display_name` (string)
+3. `pixel_layout` (string)
+4. `transpose` (bool)
+5. `width` (int)
+6. `height` (int)
+7. `channels` (int)
+8. `stride` (int)
+9. `buff_type` (`BufferType`)
+10. `buffer` (length-prefixed byte span)
+
+Reference tests: `tests/test_message_exchange.cpp`.
+
+### postMessage envelopes
+
+IPC payloads are wrapped for the webview boundary only. The `payload` bytes are **identical** to what `MessageComposer` writes over TCP.
+
+```typescript
+// Data plane — same bytes as TCP
+interface OidMessage {
+  type: 'oid-ipc';
+  payload: Uint8Array;
+}
+
+// Control plane — not part of MessageComposer stream
+interface OidControl {
+  type: 'oid-control';
+  event: 'viewer-ready';
+  version: string;  // OID release version, e.g. "1.0.42"
+}
+```
+
+Sequencing is not required for P1 (extension → WASM unidirectional smoke test). Add `sequence` later if bidirectional async messaging is needed.
+
+### Large buffers
+
+`postMessage` has practical size limits (~64 MB in Chromium). For P1 smoke test, use a small fixture buffer. Future P2+ should chunk large `PlotBufferContents` payloads or use `SharedArrayBuffer` if needed.
+
+---
+
+## 4. Data flow (first pass)
+
+```mermaid
+sequenceDiagram
+    participant Ext as Extension (smoke stub)
+    participant WASM as oidwindow WASM
+
+    Ext->>WASM: Open webview, load Qt WASM
+    WASM->>Ext: oid-control: viewer-ready
+
+    Ext->>Ext: Build PlotBufferContents via MessageComposer (TS)
+    Ext->>WASM: oid-ipc payload (raw IPC bytes)
+    WASM->>WASM: MessageDecoder → decode_plot_buffer_contents → render
+```
+
+### Event loop
+
+Desktop polls `oid_run_event_loop` at ~30 Hz for UI→bridge messages. In WASM, inbound `postMessage` events append to `PostMessageTransport`'s receive queue; `MessageHandler::decode_incoming_messages()` drains it. No polling loop in the extension.
+
+---
+
+## 5. OID repo changes
+
+### 5.1 Qt 6.11 baseline (whole repo)
+
+| File | Change |
+|------|--------|
+| `common.cmake` | `find_package(Qt6 6.11 REQUIRED COMPONENTS Network)` |
+| `src/CMakeLists.txt` | `find_package(Qt6 6.11 REQUIRED COMPONENTS Core Gui OpenGL OpenGLWidgets Widgets)` |
+| `README.md` | Qt 6.11 install instructions |
+| CI workflows | Qt 6.11 images or cached installer |
+
+### 5.2 Transport abstraction (P0)
+
+New `src/ipc/transport.h`:
+
+```cpp
+class ITransport {
+ public:
+  virtual void send(std::span<const std::byte> data) = 0;
+  virtual std::size_t receive(std::span<std::byte> dst) = 0;
+  virtual bool has_data() const = 0;
+  virtual ~ITransport() = default;
+};
+```
+
+Implementations:
+
+| Class | Platform | Backing |
+|-------|----------|---------|
+| `TcpTransport` | Desktop | `QTcpSocket` read/write (behavior identical to today) |
+| `PostMessageTransport` | Emscripten | JS queue via `EM_ASM` + `window.oidSend` / `window.oidOnMessage` |
+
+Refactor:
+
+- `MessageComposer::send(ITransport*)` — iterate blocks, call `transport->send()` per block (preserves current block-boundary semantics)
+- `MessageDecoder` — accept `ITransport&` instead of `QTcpSocket*`; `read_impl` uses `transport.receive()`
+- `MessageHandler::Dependencies` — `ITransport& transport` replaces `QTcpSocket& socket`
+- `MainWindow` — owns `std::unique_ptr<ITransport>`
+
+Compile definition for WASM: `OID_TRANSPORT_POSTMESSAGE`.
+
+**Not in scope:** `obp_channel`, protobuf, protoc codegen.
+
+### 5.3 WASM build target (P1)
+
+CMake conditional on `CMAKE_SYSTEM_NAME STREQUAL "Emscripten"`:
+
+| Setting | Value |
+|---------|-------|
+| Qt kit | `wasm-emscripten` (single-threaded) |
+| Emscripten | 4.0.7 via `emsdk install 4.0.7 && emsdk activate 4.0.7` |
+| Build driver | `qt-cmake` from Qt 6.11 WASM install |
+| Entry | `oid_window.cpp` — `__EMSCRIPTEN__`: no TCP connect; emit `viewer-ready` control message |
+
+New files:
+
+| File | Role |
+|------|------|
+| `src/ipc/tcp_transport.h` / `.cpp` | Desktop adapter |
+| `src/ipc/postmessage_transport.h` / `.cpp` | WASM adapter |
+| `cmake/EmscriptenWasm.cmake` | `Qt6_DIR` / `EMSDK` validation |
+| `wasm/loader.html` | Qt WASM bootstrap + `oidSend`/`oidOnMessage` glue |
+| `wasm/package.json` | `@openimagedebugger/viewer-wasm` metadata |
+| `.github/workflows/wasm.yml` | emsdk 4.0.7 + Qt 6.11 WASM CI |
+
+npm artifact contents: `oidwindow.wasm`, `oidwindow.js`, Qt runtime files, `loader.html`, `version.json` (OID release version).
+
+### 5.4 WebGL compatibility pass (P1 gate)
+
+`GLCanvas` / `GLTextRenderer` use desktop GL idioms that need GLES/WebGL 2 fixes:
+
+- Replace `GL_FRAMEBUFFER_EXT` → `GL_FRAMEBUFFER`
+- Verify FBO creation under WebGL 2
+- Confirm mipmap generation or fall back to `GL_NEAREST`
+- Skip `find_package(OpenGL 2.1)` for Emscripten builds (Qt provides GLES)
+
+P1 is not complete until WASM loads, receives `PlotBufferContents`, and renders without GL errors.
+
+### 5.5 Qt 6.12 upgrade path
+
+When Qt 6.12.0 LTS ships:
+
+1. Read Emscripten version from [Qt 6.12 Tools and Versions](https://wiki.qt.io/Qt_6.12_Tools_and_Versions) wiki
+2. Bump desktop + WASM to Qt 6.12.x
+3. Re-pin `emsdk` in CI
+4. Re-run desktop regression + WASM smoke
+
+---
+
+## 6. Extension smoke stub (P1+)
+
+Repository: `openimagedebugger-vscode` (new, minimal).
+
+```
+openimagedebugger-vscode/
+├── package.json              # command: oid.openPanel
+├── src/
+│   ├── extension.ts          # activate → open webview
+│   ├── ipc/
+│   │   └── message-exchange.ts   # TS port of MessageComposer
+│   └── webview/
+│       └── panel.ts          # load loader.html, relay postMessage
+├── media/                    # copied from @openimagedebugger/viewer-wasm
+└── test/
+    └── fixtures/
+        └── sample_plot_buffer.bin  # raw IPC bytes from C++ test fixture
+```
+
+`message-exchange.ts` must produce byte-identical output to C++ `MessageComposer` for the same logical message. Validate against `tests/test_message_exchange.cpp` fixture bytes.
+
+No DAP, no TypeBridge, no stop handler in this pass.
+
+---
+
+## 7. Error handling
+
+| Failure | Behavior |
+|---------|----------|
+| WASM fails to load | Webview error panel with OID version and Qt/Emscripten requirements |
+| Version mismatch | Warn if extension OID version ≠ `viewer-ready` version; allow smoke test to proceed |
+| Malformed IPC payload | `MessageDecoder` throws; log to console; no crash |
+| Buffer exceeds postMessage limit | P1 uses small fixture only; chunking deferred to P2+ |
+| Debug session ends | N/A in smoke stub |
+
+---
+
+## 8. Testing
+
+| Layer | Test |
+|-------|------|
+| OID unit | Existing `test_message_exchange.cpp` on `TcpTransport` |
+| OID unit | `PostMessageTransport` queue send/receive (`tests/test_transport.cpp`) |
+| OID WASM smoke | Playwright: load wasm, send `PlotBufferContents` bytes, assert no GL crash |
+| Desktop regression | Full test suite on Qt 6.11 |
+| Extension | TS codec byte-matches C++ fixture; webview smoke (manual or Playwright) |
+
+---
+
+## 9. Delivery phases
+
+| Phase | Deliverable | Done when |
+|-------|-------------|-----------|
+| **P0** | `ITransport` refactor + Qt 6.11 bump | Desktop builds; `test_message_exchange` passes |
+| **P1** | WASM build + GL compat + npm artifact | WASM renders test `PlotBufferContents` |
+| **P1+** | Extension smoke stub + TS codec | Webview loads artifact; fixture buffer visible |
+| P2+ | CodeLLDB bridge, TypeBridge, stop handler | *(future)* |
+| P3–P6 | Session management, UI parity, export, ship | *(future — see original design)* |
+
+---
+
+## 10. Success criteria (this pass)
+
+- Desktop OID builds and passes tests on Qt 6.11
+- `@openimagedebugger/viewer-wasm` publishes from CI with Qt 6.11 / Emscripten 4.0.7 metadata in `version.json`
+- Extension stub loads the artifact and renders a test `PlotBufferContents` message
+- Wire format is the existing `MessageComposer` binary protocol — no Protobuf dependency
+- Documented upgrade path to Qt 6.12 LTS when GA
+
+---
+
+## Self-review
+
+- **Placeholder scan:** No TBD sections.
+- **Internal consistency:** Transport carries existing IPC bytes; no OBP/protobuf references remain. Qt 6.11 + Emscripten 4.0.7 paired throughout. Scope limited to P0–P1+.
+- **Scope check:** Single implementation plan for OID repo; extension stub is minimal and separate repo.
+- **Ambiguity check:** `PlotBufferContents` field order pinned to `oid_bridge.cpp`. Version compatibility via OID release string, not a separate protocol version field. Chunking for large buffers explicitly deferred to P2+.

--- a/docs/superpowers/specs/2026-06-27-oid-editor-split-view-design.md
+++ b/docs/superpowers/specs/2026-06-27-oid-editor-split-view-design.md
@@ -1,0 +1,113 @@
+# OID VS Code: Editor split viewer — Design
+
+**Date:** 2026-06-27  
+**Status:** Approved  
+**Parent spec:** `docs/superpowers/specs/2026-06-23-oid-wasm-vscode-design.md`  
+**Builds on:** `docs/superpowers/specs/2026-06-27-oid-vscode-live-watch-design.md` (live watch + sidebar `WebviewView`)
+
+**Goal:** On debugger stop, show the OID WASM viewer in an **editor split beside source code** instead of the activity-bar sidebar, so the Run and Debug sidebar can open without hiding the viewer.
+
+---
+
+## 1. Problem
+
+The extension currently registers a `WebviewView` in the left activity bar. On breakpoint:
+
+1. VS Code focuses the **Run and Debug** view in the same primary sidebar.
+2. The extension calls `viewer.reveal()` on first stop to show OID.
+
+Both views share one sidebar slot — Debug wins; OID is hidden until the user clicks its activity-bar icon again.
+
+A secondary-sidebar default was attempted earlier but is blocked on Cursor (VS Code API 1.105.1; `secondarySidebar` contribution requires 1.106+).
+
+**Desired UX (approved):** Image **beside source** in an editor split on stop. **Editor only** — remove the sidebar view entirely.
+
+---
+
+## 2. Decision
+
+| Topic | Choice | Rationale |
+|-------|--------|-----------|
+| Host type | `WebviewPanel` | Native editor-area tab; supports `ViewColumn.Beside` split |
+| Open trigger | First `stopped` event per debug session | Same as today; avoids opening before user debugs |
+| Focus | `preserveFocus: true` on reveal | Keep keyboard in source while image appears |
+| Sidebar view | **Removed** | No competition with Debug; simpler manifest |
+| Layout API | `ViewColumn.Beside` | Standard VS Code split beside active editor |
+| No active editor | `ViewColumn.Two` fallback | Still show viewer if stop happens with no focused editor |
+| WASM lifetime | `retainContextWhenHidden: true` on panel webview | Same intent as current `WebviewView` registration option |
+| Session end | Dispose panel | Clean slate per debug session |
+| User closes panel mid-session | Recreate on next `ensureReady()` | Plot/open commands still work |
+| Configuration | None in v1 | YAGNI; single layout |
+
+**Rejected alternatives:**
+
+- `workbench.action.splitEditorRight` before open — mutates unrelated layout; brittle.
+- Fixed `ViewColumn.Two` always — stacks on existing column-2 tabs instead of true beside-active-editor split.
+- Keep sidebar + editor — user chose editor-only.
+
+---
+
+## 3. Components (`openimagedebugger-vscode`)
+
+| File | Change | Responsibility |
+|------|--------|----------------|
+| `package.json` | **modify** | Remove `viewsContainers` / `views`; keep commands and `engines ^1.85.0` |
+| `src/webview/panel.ts` | **modify** | `WebviewViewProvider` → singleton `WebviewPanel` owner; `openBeside()`, `dispose()` |
+| `src/extension.ts` | **modify** | Drop `registerWebviewViewProvider`; first stop → `openBeside()`; session end → `dispose()` |
+
+No changes to `session-manager.ts`, DAP bridge, or WASM media.
+
+---
+
+## 4. Data flow
+
+```
+DebugAdapterTracker: stopped(threadId)
+  if (!openedThisSession) { openedThisSession = true; viewer.openBeside() }
+  SessionManager.onStopped(threadId)
+    └─> sink.ensureReady()  // creates panel if disposed
+        └─> sink.sendPlotBuffer(...)
+
+oid.openPanel command
+  └─> viewer.openBeside()
+
+debug session terminated
+  └─> viewer.dispose(); manager.reset(); openedThisSession = false
+```
+
+**`ViewerController.openBeside()`:**
+
+1. If panel exists → `panel.reveal(column, true)` where `column` is `Beside` when an active editor exists, else `Two`.
+2. Else → `createWebviewPanel('oid.viewer', 'Open Image Debugger', column, { retainContextWhenHidden: true, enableScripts, localResourceRoots })`, set HTML, wire `viewer-ready` message, register `onDidDispose`.
+
+**`ViewerController.ensureReady()`:** if not ready, call `openBeside()`, then await `viewer-ready` (60s timeout, unchanged).
+
+---
+
+## 5. Error handling
+
+| Case | Behavior |
+|------|----------|
+| WASM load failure | Existing spinner/error UI in webview HTML |
+| `viewer-ready` timeout | `ensureReady()` rejects; session manager swallows per-variable failures on auto-replot |
+| Panel disposed mid-await | `onDidDispose` clears ready state; next plot recreates |
+| No debug session | Existing command guards unchanged |
+
+---
+
+## 6. Testing
+
+| Layer | What |
+|-------|------|
+| Unit | Existing `session-manager` tests unchanged (`PlotSink` mock) |
+| Compile | `npm run compile` in `openimagedebugger-vscode` |
+| Manual | Start CodeLLDB session with `oid.watchOnStop` → hit breakpoint → viewer opens right of source; Debug sidebar on left unaffected; subsequent stops update image; session end closes panel; `OID: Open Viewer Panel` opens split without debugging |
+
+---
+
+## 7. Out of scope
+
+- `oid.viewLocation` setting (sidebar vs editor)
+- Dual `secondarySidebar` + editor for VS Code 1.106+ hosts
+- Moving Debug panel or suppressing VS Code stop UI
+- Editor split column ratio persistence

--- a/docs/superpowers/specs/2026-06-27-oid-vscode-live-watch-design.md
+++ b/docs/superpowers/specs/2026-06-27-oid-vscode-live-watch-design.md
@@ -1,0 +1,88 @@
+# OID VS Code — Live Watch Set (auto-refresh plotted buffers on stop)
+
+**Date:** 2026-06-27
+**Repo:** `openimagedebugger-vscode` (branch `feat/p2-codelldb-bridge`)
+**Status:** Approved design
+
+## Problem
+
+A user plots a variable (via `oid.plot`), the image shows once, but it never
+updates on subsequent debugger stops. The only auto-update mechanism today is
+the `oid.watchOnStop` config list; when it is empty (the common case),
+`SessionManager.onStopped()` returns early and nothing is re-plotted.
+
+The user expectation is "plot whatever I'm looking at, and have it keep
+updating as I step." The extension currently has no memory of what was
+plotted, so it cannot refresh it.
+
+## Decision
+
+Implement a **viewer-independent, extension-owned live set** (Option A). The
+extension remembers the variable names it has plotted in the current debug
+session and re-plots them on every stop. This ships entirely in the extension:
+no C++ change, no WASM rebuild, no redeploy of the hosted GitHub Pages viewer,
+and it does not touch the fragile viewer→host IPC path (so the
+`MessageComposer::send` per-block fragmentation issue is irrelevant here).
+
+The fully viewer-authoritative model (querying the viewer's open buffers via
+`GetObservedSymbols` on each stop) is deliberately deferred — see *Deferred*.
+
+## Design
+
+### State & ownership
+`SessionManager` owns a per-session live set:
+
+```ts
+private readonly liveNames = new Set<string>();
+```
+
+The **effective re-plot set** on each stop is `liveNames ∪ watchOnStop` — the
+dynamic set the user builds by plotting, unioned with the static config list
+(which keeps working unchanged). The set is cleared when the debug session
+terminates, so each session starts fresh.
+
+### Behavior
+
+| Trigger | Behavior |
+|---|---|
+| `plotVariable(name, threadId)` (manual `oid.plot`) | Plot once. On **success**, add `name` to `liveNames`. On **failure**, warn (as today) and do **not** enroll. |
+| `onStopped(threadId)` | Resolve top frame, re-plot every name in the effective set. Failures are **silent** (no toast) and the name is **retained**, so a momentarily out-of-scope variable resumes updating when scope returns. Empty effective set → no-op. |
+| `reset()` | Clear `liveNames`. Called from `onDidTerminateDebugSession`. |
+| Overlap | If an `onStopped` re-plot is still in flight when the next stop arrives (rapid stepping), skip the new run rather than piling up DAP requests. |
+
+### Commands & config
+- `oid.plot` — unchanged entry point; now also enrolls the variable into the
+  live set via `plotVariable`.
+- **New** `oid.clearWatch` ("OID: Clear Live Watches") — empties `liveNames`
+  (leaves the `watchOnStop` config untouched). Provides the "stop watching"
+  affordance for the staleness caveat below.
+- `oid.watchOnStop` config — unchanged; now unioned into the effective set.
+
+### Error handling rationale
+Auto-replot failures are silent + retained (not dropped) because a variable
+commonly leaves and re-enters scope while stepping; dropping on first failure
+would lose it permanently. Manual plot keeps the existing warning toast so the
+user gets feedback when an explicit action fails.
+
+## Caveat (accepted)
+The extension is the source of truth, not the viewer. If the user closes a
+buffer *inside the viewer UI*, the extension does not know and keeps refreshing
+it. `oid.clearWatch` is the escape hatch. Precise viewer-side open/close
+tracking is the deferred Option B.
+
+## Testing (TDD)
+Extend `test/session-manager.test.ts`:
+- `plotVariable` success enrolls the name → a later `onStopped` re-plots it.
+- `plotVariable` failure does **not** enroll.
+- `onStopped` re-plots the union of live set + watch list, deduped.
+- `onStopped` failure is silent and retains the name.
+- Overlap guard: a second `onStopped` while one is in flight is skipped.
+- `reset()` clears the set.
+
+## Deferred — Option B (viewer-authoritative)
+On each stop, query the viewer's open buffers via `GetObservedSymbols` and
+re-plot exactly those. Requires fixing the viewer→host fragmentation
+(`MessageComposer::send(ITransport&)` in `src/ipc/message_exchange.h` coalescing
+all blocks into one `transport.send` so each logical frame is one postMessage),
+rebuilding the WASM, and redeploying it to GitHub Pages. Layers on top of this
+design later.

--- a/docs/superpowers/specs/2026-06-27-oid-vscode-p3-refine-design.md
+++ b/docs/superpowers/specs/2026-06-27-oid-vscode-p3-refine-design.md
@@ -1,0 +1,180 @@
+# OID VS Code P3 Refine: Viewer-owned session loop — Design
+
+**Date:** 2026-06-27  
+**Status:** Approved  
+**Parent spec:** `docs/superpowers/specs/2026-06-24-oid-vscode-p3-session-design.md`  
+**Supersedes (watch ownership):** `docs/superpowers/specs/2026-06-27-oid-vscode-live-watch-design.md`  
+**Builds on:** P2 CodeLLDB bridge, editor-split viewer (`2026-06-27-oid-editor-split-view-design.md`)
+
+**Goal:** Complete the original P3 session loop — WASM autocomplete from in-scope symbols, add variables from the viewer UI, and viewer-owned auto-replot on stop — replacing the interim extension-owned `liveNames` model.
+
+---
+
+## 1. Problem
+
+After P2 and live-watch shipping:
+
+| Capability | Status |
+|------------|--------|
+| Plot via command palette (`oid.plot`) | Works |
+| Auto-replot on stop | Works via extension-owned `liveNames ∪ watchOnStop` |
+| WASM symbol autocomplete (`SetAvailableSymbols`) | **Missing** — never sent |
+| Add variable from WASM symbol box (`PlotBufferRequest`) | **Missing** — `oid-ipc-out` not handled |
+| Viewer-owned watch set (`GetObservedSymbols` poll) | **Missing** — live-watch deferred this |
+
+Root cause for viewer→host IPC: `MessageComposer::send(ITransport&)` calls `transport.send()` once per internal block. TCP desktop treats this as one byte stream; **postMessage sends each block as a separate JS message**, so the extension receives fragmented frames and cannot `decodeInbound` them.
+
+Host→viewer messages built in TypeScript (`buildPlotBufferContents`, `buildSetAvailableSymbols`) are already single `Uint8Array` frames and work.
+
+---
+
+## 2. Decisions
+
+| Topic | Choice | Rationale |
+|-------|--------|-----------|
+| Watch source of truth | **Viewer-owned** (original P3) | Desktop parity; remove in viewer UI respected on next stop |
+| Replace live-watch | **Yes** — remove `liveNames` | User chose full P3 model |
+| `oid.plot` | Same as `PlotBufferRequest` — plot at frame; viewer observes via `PlotBufferContents` | One code path |
+| `oid.watchOnStop` | One-time seed on first stop: `observed ∪ watchList` | Original P3 §4 |
+| `oid.clearWatch` | **Remove command** | Viewer owns set; user removes buffers in UI |
+| Symbol enumeration | Local + Arguments scopes, current frame, unfiltered | Original P3 |
+| IPC fragmentation fix | **Coalesce in `MessageComposer::send(ITransport&)`** (OID repo) | One fix for all viewer→host messages; TCP-safe |
+| WASM delivery | Rebuild; copy artifacts to `openimagedebugger-vscode/media/` | Local WASM already used (not GitHub Pages) |
+| `GetObservedSymbols` timeout | 1000 ms → `[]` + warn | Original P3 §5; stop loop never hangs |
+| Cross-restart persistence | Deferred P5 | Unchanged |
+| OID UI parity (auto-contrast, etc.) | Deferred P4 | Unchanged |
+
+**Rejected:**
+
+- Extension-only chunk reassembly in `panel.ts` — duplicates framing; fragile.
+- JS coalesce in `window.oidSend` — bypasses C++ transport; doesn't help desktop.
+
+---
+
+## 3. Architecture
+
+### Stop loop (replaces `liveNames` replot)
+
+```
+DebugAdapterTracker: stopped(threadId)
+  └─> SessionManager.onStopped(threadId)
+        frameId = resolveFrame(threadId)
+        1. syms = listScopeSymbols(frameId)
+           channel.setAvailableSymbols(syms.map(s => s.name))
+        2. observed = await channel.getObservedSymbols()
+        3. if (!seeded) { observed = union(observed, getWatchList()); seeded = true }
+        4. for name in observed:
+             try plot → PlotBufferContents
+             catch warn (per-name); continue
+```
+
+### Viewer-initiated add (any time while paused)
+
+```
+oid-ipc-out → decodeInbound → PlotBufferRequest(name)
+  └─> SessionManager.onPlotBufferRequest(name, stoppedThreadId)
+        └─> plotAtFrame (warn on error)
+```
+
+### Session end
+
+```
+onDidTerminateDebugSession → viewer.dispose(); manager.reset()  // reset clears seeded only
+```
+
+---
+
+## 4. Components
+
+### OpenImageDebugger
+
+| File | Change |
+|------|--------|
+| `src/ipc/message_exchange.h` | `MessageComposer::send(ITransport&)` concatenates blocks → single `transport.send` |
+| `tests/test_message_exchange.cpp` | Assert mock transport receives one send with expected total length for type+string message |
+
+Rebuild WASM (`oidwindow.wasm`, `oidwindow.js`); copy into extension `media/`.
+
+### openimagedebugger-vscode
+
+| File | Change |
+|------|--------|
+| `debugger/symbol-enumerator.ts` | **new** — `listScopeSymbols(session, frameId): Promise<{name,type}[]>` |
+| `debugger/dap-client.ts` | **extend** — `scopes(frameId)`, `variables(ref)` if not present |
+| `ipc/message-exchange.ts` | No API change; ensure tests cover types 0,1,2,4 |
+| `webview/panel.ts` | **ViewerChannel**: `setAvailableSymbols`, `getObservedSymbols`, handle `oid-ipc-out`, `onPlotBufferRequest` callback |
+| `session/session-manager.ts` | P3 loop; remove `liveNames`; `seeded` flag; `onPlotBufferRequest` |
+| `extension.ts` | Wire channel, enumerator, inbound plot requests; remove `oid.clearWatch` |
+| `package.json` | Remove `oid.clearWatch` command contribution |
+| `test/session-manager.test.ts` | Rewrite for viewer-owned mocks |
+| `test/symbol-enumerator.test.ts` | **new** |
+
+---
+
+## 5. ViewerChannel (`panel.ts`)
+
+**Outbound:** `postMessage({ type: 'oid-ipc-forward', payload })` — unchanged.
+
+**Inbound:** On `oid-ipc-out`, `decodeInbound(payload)`:
+
+- `{ kind: 'observedSymbols', names }` → resolve pending `getObservedSymbols()` promise
+- `{ kind: 'plotRequest', name }` → invoke `onPlotBufferRequest(name)`
+- `{ kind: 'unknown' }` → ignore
+
+**`getObservedSymbols()`:** send `buildGetObservedSymbols()`; await type-1; 1000 ms timeout → `[]` and `console.warn`. At most one pending poll; supersede previous with `[]`.
+
+**`setAvailableSymbols(names)`:** send `buildSetAvailableSymbols(names, 'wasm32')` after `ensureReady()`.
+
+---
+
+## 6. Error handling
+
+| Failure | Behavior |
+|---------|----------|
+| Scope enumeration fails | Skip `SetAvailableSymbols`; warn; continue poll + plot |
+| `GetObservedSymbols` timeout | `[]`; no replot this stop |
+| `PlotBufferRequest` / `oid.plot` failure | Status-bar warning; no crash |
+| Per-buffer plot failure on stop | Warn per name; continue loop |
+| No stopped thread for inbound request | Ignore or warn "pause first" |
+| Panel not ready | `ensureReady()` opens editor split (existing) |
+
+---
+
+## 7. Testing
+
+**OID C++:** composer coalescing sends exactly one transport call with concatenated bytes.
+
+**Extension unit:**
+
+- Symbol enumerator filters scopes (Local, Arguments only).
+- Session manager: `setAvailableSymbols` called with enumerated names; poll observed; first-stop seed; one plot per observed name; `onPlotBufferRequest` plots; failures isolated.
+- Remove live-watch-specific tests (`liveNames` enroll, `reset` clears names).
+
+**Manual (original P3 §7):**
+
+1. Break in testbench `nest()` — autocomplete lists locals + arguments.
+2. Type `TestField` in viewer symbol box — plots.
+3. `oid.watchOnStop: ["TestField"]` — auto-plots first stop.
+4. Step/continue — watched buffers refresh.
+5. Remove buffer in viewer — next stop does not replot it.
+
+---
+
+## 8. Phase boundary
+
+**In this refine:**
+
+- MessageComposer coalescing + WASM refresh
+- Full P3 extension wiring
+- Remove extension-owned live set and `oid.clearWatch`
+
+**Still deferred:** P5 persistence; P4 UI parity; OBP protobuf; no-copy transfer.
+
+---
+
+## 9. Self-review
+
+- **Placeholders:** None.
+- **Consistency:** Viewer-owned decision matches stop loop, removes `liveNames`, removes `oid.clearWatch`. Coalescing fix enables inbound decode path assumed in §5.
+- **Scope:** Two repos, bounded files; single implementation plan.
+- **Ambiguity:** `oid.plot` does not maintain a separate extension set — viewer is authoritative after plot. `seeded` is per debug session only.

--- a/docs/superpowers/specs/2026-06-27-oid-vscode-p5-full-parity-design.md
+++ b/docs/superpowers/specs/2026-06-27-oid-vscode-p5-full-parity-design.md
@@ -1,0 +1,300 @@
+# OID VS Code P5: Export, session persistence, full type parity — Design
+
+**Date:** 2026-06-27  
+**Status:** Approved  
+**Parent spec:** `docs/superpowers/specs/2026-06-23-oid-wasm-vscode-design.md` (phase P5)  
+**Builds on:** P3 session loop, P4 UI parity (WASM viewer), editor-split panel (`2026-06-27-oid-editor-split-view-design.md`), export IPC stub (`2845018` / `0372e75`)
+
+**Goal:** Reach desktop OID parity for export (PNG/Octave), cross-restart session persistence, and all built-in type inspectors plus user-defined custom types — using extended legacy IPC (Approach 1), not OBP migration.
+
+---
+
+## 1. Decisions
+
+| Topic | Choice | Rationale |
+|-------|--------|-----------|
+| Wire format | **Extend legacy IPC** (types 0–8) | P3 loop already proven; OBP deferred |
+| Persistence owner | **Extension** (`globalState` + `workspaceState`) | WASM `QSettings` unreliable |
+| Persistence scope | **Full desktop parity** | Watched buffers (1-day expiry), UI prefs, splitter, framerate, export suffix; not window pos/size |
+| Export UX | **Hybrid** | WASM context menu + `oid.export` command, shared extension path |
+| Export pixels | **Always re-fetch** via DAP at export time | Fresh debugger memory, not WASM texture |
+| Export contrast | **From WASM at request time** | 8-float `auto_buffer_contrast_brightness` in IPC; extension applies during PNG encode |
+| Types | **Full parity** | Eigen, CvMat, IplImage, pluggable `oid.customTypes` |
+| `oid.watchOnStop` | **One-time migration seed** | Merged into persisted watch list on first run; extension list is authoritative thereafter |
+
+### Approaches considered
+
+1. **Extend legacy IPC (chosen)** — add messages 5–8; minimal regression risk.
+2. **Full OBP v1** — rejected; large blast radius on working P3 path.
+3. **Hybrid wire (legacy + OBP export only)** — rejected; two encoders in one webview.
+
+---
+
+## 2. Architecture
+
+```mermaid
+flowchart TB
+    subgraph ext["Extension (source of truth)"]
+        PM["session/persistence.ts"]
+        EX["export/buffer-exporter.ts"]
+        TB["typebridge/"]
+        SM["session-manager.ts"]
+        VC["webview/panel.ts"]
+    end
+
+    subgraph wasm["OID WASM"]
+        MH["MessageHandler"]
+        MW["MainWindow"]
+    end
+
+    PM -->|"ApplySessionState (6)"| MH
+    MH --> MW
+    MW -->|"SessionStateChanged (7)"| VC
+    VC --> PM
+    MW -->|"ExportBufferRequest (5)"| VC
+    VC --> EX
+    EX --> TB
+    TB --> SM
+```
+
+| Concern | Owner |
+|---------|-------|
+| Watched buffers + UI prefs | Extension storage |
+| Restore on viewer ready | `ApplySessionState` after `viewer-ready` |
+| Persist UI changes | Debounced `SessionStateChanged` (~100 ms) |
+| Export file I/O | Extension (`showSaveDialog` + write) |
+| Type parsing | Extension TypeBridge |
+
+**Not persisted on WASM:** window position/size (VS Code owns panel geometry).
+
+**WASM `QSettings`:** disabled under `__EMSCRIPTEN__`; replaced by IPC sync.
+
+---
+
+## 3. Legacy IPC wire format
+
+Extend `MessageType` in `src/ipc/message_exchange.h` and `openimagedebugger-vscode/src/ipc/message-exchange.ts`:
+
+| ID | Name | Direction | Payload |
+|----|------|-----------|---------|
+| 0–4 | *(existing)* | | |
+| 5 | `ExportBufferRequest` | WASM → ext | `string` variableName · `int32` format · `float32[8]` contrastBrightness |
+| 6 | `ApplySessionState` | ext → WASM | `string` JSON (UTF-8, u32 length) |
+| 7 | `SessionStateChanged` | WASM → ext | `string` JSON (partial or full) |
+| 8 | `ExportSelectedBuffer` | ext → WASM | *(empty)* — WASM replies with type 5 for selected list item |
+
+**Format enum** (matches desktop `BufferExporter::OutputType`): `0` = PNG (auto-contrast applied), `1` = Octave raw matrix.
+
+**Note:** Type 5 exists today as variable name only (crash-fix stub). P5 extends the payload with format + contrast; extension must accept both shapes during rollout or bump media atomically.
+
+Add `float` to the C++ `PrimitiveType` concept in `message_exchange.h`.
+
+### Session JSON schema (`version: 1`)
+
+```typescript
+interface OidSessionState {
+  version: 1;
+  rendering: { framerate: number };
+  export: { defaultSuffix: string };
+  ui: {
+    splitterSizes: number[];
+    listPosition?: string;
+    minmaxVisible: boolean;
+    minmaxCompact?: boolean;
+    contrastEnabled: boolean;
+    linkViewsEnabled: boolean;
+    colorspace?: string; // up to 4 chars: b/g/r/a
+  };
+  buffers: {
+    watched: Array<{ name: string; expiresAt: number }>; // unix ms
+    removed: string[];
+  };
+  selectedBuffer?: string;
+}
+```
+
+- `ApplySessionState`: full snapshot on viewer ready.
+- `SessionStateChanged`: partial deep-merge on extension side.
+
+**Storage keys:**
+
+- `globalState` key `oid.session.global`: rendering, export, ui prefs.
+- `workspaceState` key `oid.session.workspace`: `buffers` (per-workspace watch list).
+
+---
+
+## 4. Export
+
+### Shared path (`export/buffer-exporter.ts`)
+
+1. Receive export intent (IPC type 5 or `oid.export` → type 8 → type 5).
+2. `vscode.window.showSaveDialog` with PNG / Octave filters; default from persisted `export.defaultSuffix`.
+3. `CodeLldbBridge.getBufferMetadata(variable, frameId)` — fresh DAP read.
+4. Encode file:
+   - **PNG:** port `BufferExporter::export_bitmap` in TypeScript (`pngjs`).
+   - **Octave:** port `export_binary` (type descriptor + dimensions + raw rows).
+5. Apply `contrastBrightness` during PNG encode (same math as `src/io/buffer_exporter.cpp`).
+6. Update persisted `defaultSuffix`; show error notification on failure.
+
+### Triggers
+
+| Trigger | Flow |
+|---------|------|
+| Context menu “Export buffer” | WASM → `ExportBufferRequest` |
+| `oid.export` command | ext → `ExportSelectedBuffer` → WASM → `ExportBufferRequest` |
+
+### OID WASM
+
+- `UIEventHandler::export_buffer()` under `__EMSCRIPTEN__`: gather contrast from `Buffer` component, send extended type 5 (no `QFileDialog`).
+- `show_context_menu()`: `QMenu::popup()` (never `exec()` on WASM).
+- `MessageHandler`: decode type 8, emit export for selected buffer.
+
+Desktop path unchanged (`QFileDialog` + in-process `BufferExporter`).
+
+---
+
+## 5. Session persistence
+
+### Extension `session/persistence.ts`
+
+- `load(context): OidSessionState` — merge global + workspace; apply defaults matching `SettingsConstants` in `settings_manager.h`.
+- `save(context, state)` — debounced 100 ms.
+- `mergeDelta(state, partial): OidSessionState`.
+- `migrateWatchOnStop(state, configNames: string[])` — append config names with fresh 24 h expiry if not present.
+
+### Lifecycle
+
+1. Viewer ready → extension sends `ApplySessionState`.
+2. WASM `MessageHandler::decode_apply_session_state()` invokes existing `SettingsApplier` paths (same signals as `SettingsManager::load_*`).
+3. User changes UI or watch list → WASM `MainWindow::persist_settings()` under `__EMSCRIPTEN__` serializes callbacks to JSON → `SessionStateChanged`.
+4. Extension merges + saves.
+5. Watched-buffer expiry: same 1-day semantics as desktop `SettingsManager::persist_settings`.
+6. Debug session end disposes panel; **persisted state survives** VS Code restart.
+
+### OID WASM
+
+- `#ifdef __EMSCRIPTEN__` in `MainWindow::persist_settings()`: emit JSON over transport instead of `QSettings`.
+- Skip `settings_manager_->load_settings()` on WASM startup; wait for `ApplySessionState`.
+- `previous_session_buffers` in WASM still drives auto-plot on `SetAvailableSymbols` (existing behavior).
+
+---
+
+## 6. TypeBridge full parity
+
+### Extension modules
+
+| Module | Python source |
+|--------|---------------|
+| `typebridge/index.ts` | `typebridge.py` — router, first match wins |
+| `typebridge/opencv-mat.ts` | `opencv.Mat` (exists) |
+| `typebridge/opencv-cvmat.ts` | `opencv.CvMat` |
+| `typebridge/opencv-iplimage.ts` | `opencv.IplImage` |
+| `typebridge/eigen-matrix.ts` | `eigen3.EigenXX` |
+| `typebridge/custom-type.ts` | workspace `oid.customTypes` |
+
+Refactor `debugger/codelldb-bridge.ts` to delegate to `TypeBridge.resolve(name, typeString, frameId)`.
+
+Custom inspectors run **before** built-ins. Extend `symbol-observable.ts` with custom `typePattern`s.
+
+### `oid.customTypes` (workspace setting)
+
+```json
+[{
+  "id": "example",
+  "typePattern": "^MyImageBuffer$",
+  "pointerExpr": "pixels",
+  "widthExpr": "width",
+  "heightExpr": "height",
+  "channels": 1,
+  "bufferType": "uint8",
+  "strideExpr": "stride",
+  "pixelLayout": "rgba",
+  "transpose": false
+}]
+```
+
+Expressions are evaluated as `${variable}.${expr}` via DAP. `bufferType` is one of: `uint8`, `uint16`, `int16`, `int32`, `float32`, `float64`.
+
+### Eigen note
+
+CodeLLDB exposes types via evaluate strings, not Python LLDB `template_argument()`. Port uses evaluate + regex on type name (patterns from `eigen3.py`), with unit tests from recorded LLDB fixture JSON.
+
+---
+
+## 7. Components
+
+### OID repo
+
+| File | Change |
+|------|--------|
+| `src/ipc/message_exchange.h` | Types 6–8; `float` in `PrimitiveType` |
+| `src/ui/messaging/message_handler.cpp` | Decode 6, 8; send 7; extend 5 |
+| `src/ui/events/event_handler.cpp` | Extended export IPC; `popup()` on WASM |
+| `src/ui/main_window/main_window.cpp` | EMSCRIPTEN persist → IPC; skip QSettings load |
+| `tests/test_message_exchange.cpp` | Round-trip for types 5–8 |
+
+### Extension repo
+
+| File | Change |
+|------|--------|
+| `src/session/persistence.ts` | **new** |
+| `src/export/buffer-exporter.ts` | **new** |
+| `src/typebridge/*.ts` | extend |
+| `src/ipc/message-exchange.ts` | types 6–8 codecs |
+| `src/webview/panel.ts` | send 6/8; decode 7; export handler |
+| `src/extension.ts` | persistence load on ready; `oid.export` |
+| `package.json` | `oid.export` command; `oid.customTypes` schema; add `pngjs` |
+
+---
+
+## 8. Error handling
+
+| Failure | Behavior |
+|---------|----------|
+| Save dialog cancelled | Silent return |
+| Variable not plottable at export | Warning notification; no file written |
+| `readMemory` fails | Retry once; then error with variable name |
+| Invalid session JSON | Log warning; apply defaults |
+| Custom type misconfigured | Warning on plot; skip that inspector |
+
+---
+
+## 9. Testing
+
+### Extension unit tests
+
+- Persistence merge, expiry, removal, watchOnStop migration
+- IPC encode/decode types 5–8
+- TypeBridge: Mat, CvMat, IplImage, Eigen fixtures, custom type config
+- Buffer exporter: PNG + Octave golden samples vs desktop output
+
+### OID unit tests
+
+- `ApplySessionState` JSON → applier invocation (mock deps)
+- Export IPC payload includes 8 contrast floats
+
+### Manual matrix
+
+- macOS + Linux, CodeLLDB, each built-in type
+- Export PNG + Octave from context menu and `oid.export`
+- Restart VS Code → watched buffers + UI toggles restored
+- Custom type via workspace config
+
+---
+
+## 10. Success criteria
+
+- User can export a plotted buffer to PNG (with viewer auto-contrast) or Octave from the WASM context menu or `oid.export`.
+- Watched buffers and UI preferences persist across VS Code restarts (per workspace for buffer names).
+- OpenCV `Mat`, `CvMat`, `IplImage`, and Eigen matrix types plot via the extension TypeBridge.
+- User-defined types work via `oid.customTypes` without extension code changes.
+- Desktop GDB/LLDB workflow unchanged.
+
+---
+
+## Self-review (spec)
+
+- **Placeholder scan:** No TBD sections.
+- **Internal consistency:** IPC types, JSON schema, export re-fetch + contrast-from-WASM, and persistence owner align across sections.
+- **Scope check:** Single plan scope; OBP migration explicitly out of scope.
+- **Ambiguity check:** Type 5 stub vs extended payload noted; window geometry explicitly excluded from persistence.

--- a/docs/superpowers/specs/2026-06-27-oid-wasm-session-persistence-design.md
+++ b/docs/superpowers/specs/2026-06-27-oid-wasm-session-persistence-design.md
@@ -1,0 +1,262 @@
+# OID WASM Session Persistence — Design
+
+**Date:** 2026-06-27  
+**Status:** Approved (brainstorming)  
+**Parent spec:** `docs/superpowers/specs/2026-06-27-oid-vscode-p5-full-parity-design.md` (§5 subset)  
+**Related:** P3 session loop (`2026-06-24-oid-vscode-p3-session-design.md`)
+
+**Goal:** Persist OID viewer session state across VS Code restarts with behavioral parity to desktop C++ `SettingsManager`, using extension-owned storage and IPC sync — not a shared QSettings INI file.
+
+---
+
+## 1. Decisions
+
+| Topic | Choice | Rationale |
+|-------|--------|-----------|
+| Storage owner | **Extension** (`globalState` + `workspaceState`) | QSettings unreliable on WASM; VS Code owns panel geometry |
+| Desktop INI sharing | **No** | VS Code session is independent; behavioral parity is sufficient |
+| Sync transport | **Legacy IPC types 6–7** | Already declared in `message_exchange.h`; proven P3 wire format |
+| C++ apply path | **Reuse `SettingsApplier`** | Same signals as `SettingsManager::load_*`; minimal behavior drift |
+| C++ persist path | **Reuse `MainWindow::persist_settings()` callbacks** | Same triggers and 100 ms debounce; only sink changes on WASM |
+| Window geometry | **Not persisted** | VS Code owns panel layout |
+| Selected buffer | **Not persisted** | Desktop C++ does not restore list selection across restarts |
+| Load-only C++ fields | **Persist on WASM** | `listPosition`, `minmaxCompact`, `colorspace` are loaded on desktop but never written back — WASM path persists them |
+
+### Approaches considered
+
+1. **Extension-owned JSON + C++ apply path (chosen)** — behavioral parity, testable, no Qt INI in extension.
+2. **Shared QSettings INI with desktop** — rejected; user chose independent VS Code storage.
+3. **Emscripten IDBFS + unchanged QSettings** — rejected; QSettings on WASM already unreliable; cross-restart still needs extension bridge.
+
+---
+
+## 2. Architecture
+
+```mermaid
+flowchart TB
+    subgraph ext["Extension (source of truth)"]
+        PM["session/persistence.ts"]
+        VC["webview/panel.ts"]
+    end
+
+    subgraph wasm["OID WASM"]
+        MH["MessageHandler"]
+        MW["MainWindow"]
+        SA["SettingsApplier"]
+        SC["session_state_codec"]
+    end
+
+    PM -->|"ApplySessionState (6)"| VC
+    VC --> MH
+    MH --> SC
+    SC --> SA
+    MW -->|"SessionStateChanged (7)"| VC
+    VC --> PM
+```
+
+| Concern | Owner |
+|---------|-------|
+| Watched buffers + UI prefs | Extension storage |
+| Restore on viewer ready | `ApplySessionState` after `viewer-ready` |
+| Persist UI/buffer changes | Debounced `SessionStateChanged` (~100 ms) |
+| Auto-plot on stop | WASM `previous_session_buffers` + existing `SetAvailableSymbols` path |
+| Buffer merge algorithm | Extension (port of `SettingsManager::persist_settings`) |
+
+**WASM `QSettings`:** disabled under `__EMSCRIPTEN__` for load and persist; replaced by IPC sync.
+
+---
+
+## 3. Session JSON schema (`version: 1`)
+
+```typescript
+interface OidSessionState {
+  version: 1;
+  rendering: { framerate: number };           // default 60, min 1
+  export: { defaultSuffix: string };        // default "Image File (*.png)"
+  ui: {
+    splitterSizes: number[];
+    listPosition?: string;                    // "left" | "right" | "top" | "bottom"
+    minmaxVisible: boolean;
+    minmaxCompact?: boolean;
+    contrastEnabled: boolean;
+    linkViewsEnabled: boolean;
+    colorspace?: string;                      // up to 4 chars: b/g/r/a
+  };
+  buffers: {
+    watched: Array<{ name: string; expiresAt: number }>;  // unix ms
+    removed: string[];                        // transient; cleared after persist
+  };
+}
+```
+
+### C++ field mapping
+
+| JSON path | QSettings key / constant |
+|-----------|--------------------------|
+| `rendering.framerate` | `Rendering/maximum_framerate` |
+| `export.defaultSuffix` | `Export/default_export_suffix` |
+| `ui.splitterSizes` | `UI/splitter` |
+| `ui.listPosition` | `UI/list_position` |
+| `ui.minmaxVisible` | `UI/minmax_visible` |
+| `ui.minmaxCompact` | `UI/minmax_compact` |
+| `ui.contrastEnabled` | `UI/contrast_enabled` |
+| `ui.linkViewsEnabled` | `UI/link_views_enabled` |
+| `ui.colorspace` | `UI/colorspace` |
+| `buffers.watched` | `PreviousSession/buffers` |
+
+Defaults match `SettingsConstants` in `settings_manager.h`.
+
+### Storage keys
+
+- `globalState` key `oid.session.global`: `rendering`, `export`, `ui`
+- `workspaceState` key `oid.session.workspace`: `buffers`
+
+---
+
+## 4. IPC wire format
+
+Types declared in `src/ipc/message_exchange.h` and `openimagedebugger-vscode/src/ipc/message-exchange.ts`:
+
+| ID | Name | Direction | Payload |
+|----|------|-----------|---------|
+| 6 | `ApplySessionState` | ext → WASM | UTF-8 JSON string (u32 length prefix) |
+| 7 | `SessionStateChanged` | WASM → ext | UTF-8 JSON string (partial or full) |
+
+- `ApplySessionState`: full snapshot on viewer ready.
+- `SessionStateChanged`: partial deep-merge on extension side before buffer merge.
+
+---
+
+## 5. Buffer semantics
+
+Port of `SettingsManager::persist_settings` buffer logic:
+
+1. Load existing `buffers.watched` from workspace storage.
+2. For each stored entry: keep if **not** in `removed`, **not** currently held (from WASM delta), and `expiresAt >= now`.
+3. For each currently held buffer: append with `expiresAt = now + 1 day` (`BUFFER_EXPIRATION_DAYS = 1`).
+4. Clear `buffers.removed` after persist (matches `clearRemovedBufferNames()` in C++).
+
+On restore:
+
+1. Extension sends non-expired watched names in `ApplySessionState`.
+2. WASM `SettingsApplier::apply_previous_session_buffers()` fills `buffer_data.previous_session_buffers`.
+3. On `SetAvailableSymbols`, WASM auto-plots matching names (existing `decode_set_available_symbols()` — unchanged).
+
+### `oid.watchOnStop` migration
+
+One-time seed on first viewer ready per debug session: append config names to `watched` with fresh 24 h expiry if not already present. Extension list is authoritative thereafter.
+
+---
+
+## 6. Lifecycle
+
+```mermaid
+sequenceDiagram
+    participant Ext as Extension
+    participant PM as persistence.ts
+    participant VC as webview/panel.ts
+    participant WASM as OID WASM
+
+    Ext->>PM: loadSession(context)
+    Ext->>WASM: open webview
+    WASM->>VC: viewer-ready
+    Ext->>PM: migrateWatchOnStop(state, config)
+    VC->>WASM: ApplySessionState (type 6)
+    WASM->>WASM: SettingsApplier applies fields
+
+    Note over Ext,WASM: Debugger stop
+    Ext->>WASM: SetAvailableSymbols
+    WASM->>WASM: auto-plot previous_session_buffers
+
+    Note over Ext,WASM: User changes UI / watch list
+    WASM->>WASM: settingsPersistenceRequested, debounce 100ms
+    WASM->>VC: SessionStateChanged (type 7)
+    VC->>PM: mergeSessionDelta + saveSession
+```
+
+**Rules:**
+
+1. Skip `settings_manager_->load_settings()` on WASM startup; wait for `ApplySessionState`.
+2. Send type 6 only after `viewer-ready`.
+3. Persist triggers unchanged from desktop: splitter moved, acEdit/acToggle/linkViewsToggle, buffer add/remove/plot, export suffix change — all via `settingsPersistenceRequested` → 100 ms timer.
+4. Debug session end disposes panel; persisted state survives in extension storage.
+
+---
+
+## 7. Components
+
+### OID repo
+
+| File | Change |
+|------|--------|
+| `src/ui/messaging/session_state_codec.{h,cpp}` | **new** — JSON parse/serialize; invoke `SettingsApplier` on apply |
+| `src/ui/messaging/message_handler.cpp` | Decode type 6; helper to send type 7 |
+| `src/ui/main_window/main_window.cpp` | EMSCRIPTEN: persist → JSON type 7; skip QSettings load |
+| `tests/test_session_state_codec.cpp` | **new** — JSON → applier field mapping |
+
+WASM `persist_settings()` keeps existing `DataCallbacks` lambdas; only the sink differs from `SettingsManager::persist_settings()`.
+
+### Extension repo
+
+| File | Change |
+|------|--------|
+| `src/session/persistence.ts` | **new** — `loadSession`, `saveSession`, `mergeSessionDelta`, `migrateWatchOnStop` |
+| `src/ipc/message-exchange.ts` | Codecs for types 6–7 |
+| `src/webview/panel.ts` | Send type 6 on ready; decode type 7 → persistence |
+| `src/extension.ts` | Wire lifecycle |
+| `test/persistence.test.ts` | **new** — merge, expiry, removed clearing, migration |
+
+---
+
+## 8. Error handling
+
+| Failure | Behavior |
+|---------|----------|
+| Invalid session JSON on apply | Log warning; apply defaults for missing fields |
+| Invalid partial delta on persist | Log warning; ignore unknown keys |
+| Expired watched buffers | Filtered on load and merge; never sent to WASM |
+| WASM not ready when restore queued | Wait for `viewer-ready` before sending type 6 |
+
+---
+
+## 9. Testing
+
+### Extension unit tests
+
+- Defaults match `SettingsConstants`
+- Buffer merge: expiry, removed names, currently-held refresh
+- Deep-merge of partial deltas
+- `migrateWatchOnStop` one-time seed
+- IPC encode/decode types 6–7
+
+### OID unit tests
+
+- `session_state_codec`: JSON fields map to correct `SettingsApplier` invocations
+- Colorspace char encoding (`b/g/r/a` ↔ channel names)
+- Partial JSON apply does not clobber unspecified fields
+
+### Manual matrix
+
+- Toggle contrast, move splitter, restart VS Code → restored
+- Add watched buffer, restart → auto-plotted on next stop when symbol in scope
+- Remove buffer → not restored after restart
+- Watch list expires after 24 h
+
+---
+
+## 10. Success criteria
+
+- Watched buffers and UI preferences persist across VS Code restarts (workspace-scoped for buffer names).
+- Buffer expiry, removed-buffer tracking, and auto-plot behavior match desktop C++.
+- Same debounce interval and persist triggers as desktop.
+- Desktop GDB/LLDB workflow and QSettings file unchanged.
+- No shared INI file between VS Code and desktop OID.
+
+---
+
+## Self-review
+
+- **Placeholder scan:** No TBD sections.
+- **Internal consistency:** JSON schema, storage split, IPC types, and C++ apply/persist paths align across sections.
+- **Scope check:** Single implementation plan scope; export and TypeBridge remain in parent P5 spec.
+- **Ambiguity check:** `selectedBuffer` explicitly excluded; window geometry explicitly excluded; load-only C++ fields explicitly included in WASM persist.

--- a/docs/superpowers/specs/2026-06-28-oid-persistence-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-28-oid-persistence-redesign-design.md
@@ -1,0 +1,240 @@
+# OID VS Code Persistence Redesign — Design
+
+**Date:** 2026-06-28
+**Status:** Approved (brainstorming)
+**Supersedes:** `2026-06-27-oid-wasm-session-persistence-design.md`, P5 §5 of `2026-06-27-oid-vscode-p5-full-parity-design.md`
+**Related:** P3 session loop (`2026-06-24-oid-vscode-p3-session-design.md`)
+
+**Goal:** Persist OID viewer state across VS Code restarts with **behavioral parity** to the desktop C++ `SettingsManager` — UI preferences and an auto-captured, 1-day-expiring set of plotted buffers that auto-replot when back in scope — while guaranteeing **no regression** to autocompletion or plotting. Clean-slate replacement of the current `persistence.ts`.
+
+---
+
+## 1. Decisions
+
+| Topic | Choice | Rationale |
+|-------|--------|-----------|
+| Parity meaning | **Behavioral** parity, implementation free to fit the VS Code/WASM split | Desktop QSettings/IDBFS can't satisfy per-workspace or reliable webview storage |
+| Storage owner | **Extension** (`globalState` + `workspaceState`) | Reliable, VS Code-managed; enables per-workspace scope |
+| Storage scope | **Split:** UI prefs global; buffer set per-workspace | Buffer names belong to a project; prefs are general |
+| Auto-replot model | **Auto-capture** plotted buffers with 1-day expiry; `oid.watchOnStop` = one-time seed | Matches desktop `previous_session_buffers` behavior |
+| Replot decision owner | **Extension** (never the viewer's `previous_session_buffers`) | Decouples replot from IPC ordering → no auto-plot race |
+| Buffer sync | **Existing** IPC only: `GetObservedSymbols` (0/1) + DAP plot (3) | No new IPC, no C++ change for the regression-prone path |
+| Pref sync | **New** IPC: `ApplySessionState` (6), `SessionStateChanged` (7) | Prefs live in the viewer UI; need bidirectional sync |
+| Buffer removal timing | **Next-stop convergence** via held-set diff (no removal IPC) | Held is monotonic within a session except explicit removal |
+| Window geometry | **Not persisted** | VS Code owns panel layout |
+| `ui.minmaxCompact` | **Omitted in v1** (no readable runtime state) | Degrades gracefully; follow-up |
+
+### Approaches considered
+
+1. **Split responsibilities (chosen)** — extension owns buffer replot via existing IPC (no C++ change there); UI prefs via new types 6/7. Lowest regression risk; replot independent of IPC ordering.
+2. **Unified IPC parity** — both prefs and buffers flow through types 6/7; the viewer's `previous_session_buffers` drives replot like desktop. Rejected: auto-replot then races `SetAvailableSymbols`; larger C++ surface.
+3. **WASM-native QSettings via Emscripten IDBFS** — rejected: IndexedDB is per-origin (can't do per-workspace buffers) and webview persistence across restarts is unreliable.
+
+---
+
+## 2. Architecture
+
+The extension is the single source of truth. Two independent subsystems, separate sync mechanisms.
+
+```mermaid
+flowchart TB
+    subgraph ext["VS Code Extension (source of truth)"]
+        BS["session/buffer-store.ts<br/>(per-workspace wanted set)"]
+        PS["session/pref-store.ts<br/>(global prefs)"]
+        SM["session/session-manager.ts"]
+        VC["webview/panel.ts"]
+    end
+    subgraph wasm["OID WASM viewer"]
+        MH["MessageHandler"]
+        MW["MainWindow / SettingsApplier"]
+    end
+
+    SM -->|"GetObservedSymbols (0/1) + PlotBufferContents (3)"| MH
+    SM <--> BS
+    PS -->|"ApplySessionState (6)"| MH --> MW
+    MW -->|"SessionStateChanged (7)"| VC --> PS
+```
+
+| Concern | Owner | Sync | C++ change |
+|---------|-------|------|------------|
+| Buffer auto-replot set (per-workspace, 1-day) | `buffer-store` + `session-manager` | existing IPC 0/1 + 3 | **none** |
+| UI prefs (global) | `pref-store` | new IPC 6/7 | small, prefs-only |
+| Desktop QSettings | unchanged | n/a | none |
+
+**Invariant:** the replot decision is made entirely from the extension's own `wanted` set; it never reads the viewer's `previous_session_buffers`. Therefore `ApplySessionState` timing cannot affect plotting or autocompletion.
+
+---
+
+## 3. Buffer persistence (per-workspace)
+
+Mirrors desktop `previous_session_buffers` semantics with no new IPC and no C++ change.
+
+### State
+
+```ts
+type WantedBuffer = { name: string; expiresAt: number }; // unix ms
+// workspaceState["oid.session.buffers.v1"] = WantedBuffer[]
+```
+
+Held in memory during a session as `Map<name, expiresAt>`, mirrored to `workspaceState` debounced ~100 ms (matches desktop `SETTINGS_PERSIST_DELAY_MS`). Expiry window = 1 day (`BUFFER_EXPIRATION_DAYS = 1`).
+
+### Lifecycle (extends `session-manager`)
+
+1. **Session start:** load persisted set → prune expired → seed in-memory `wanted`. Merge `oid.watchOnStop` names once with fresh expiry (one-time seed; extension set authoritative thereafter).
+2. **On each stop** (after the existing replot loop):
+   - `held = getObservedSymbols()` (existing IPC 0/1).
+   - Replot target = `wanted` ∪ `held`; plot via existing DAP path. Out-of-scope names fail silently, as today.
+   - **Refresh:** each name in `held` → `expiresAt = now + 1 day`.
+   - **Removal detection:** names present in the previous stop's `held` snapshot but absent now → user closed them → delete from `wanted`. (Held is monotonic within a session except explicit removal — out-of-scope buffers remain held — so the diff is unambiguous.)
+   - Persist `wanted` (debounced). Record `prevHeld = held`.
+3. **Session end:** no snapshot/diff (held reads empty); the last persisted set is the durable record.
+
+This is desktop's merge algorithm restated: keep unexpired entries not currently held, refresh held with fresh expiry, drop removed.
+
+### Known nuance
+
+A closed buffer is dropped from `wanted` at the **next stop**, not the instant of removal (desktop drops on a 100 ms debounce). The set still converges; only the timing differs. Exact-instant parity would require a small "buffer removed" IPC signal — explicitly out of scope for v1.
+
+---
+
+## 4. UI-pref persistence (global)
+
+Desktop parity for viewer UI settings; the only subsystem touching C++, isolated to prefs.
+
+### Fields
+
+| Field | Source on WASM | Notes |
+|-------|----------------|-------|
+| `framerate` | direct | drives render timer; default 60, min 1 |
+| `export.defaultSuffix` | direct | default `"Image File (*.png)"`; also feeds export dialog default |
+| `ui.splitterSizes` | direct | |
+| `ui.minmaxVisible` | direct | |
+| `ui.contrastEnabled` | direct | |
+| `ui.linkViewsEnabled` | direct | |
+| `ui.listPosition` | derived | splitter orientation + list child index → `left/right/top/bottom` |
+| `ui.colorspace` | derived | `channel_names_` → up-to-4-char `b/g/r/a` string |
+| `ui.minmaxCompact` | — | no readable runtime state; **omitted v1**; applier applies `minmaxVisible` alone when absent |
+
+### Flow
+
+- **Restore:** on `viewer-ready`, extension sends `ApplySessionState` (type 6) = full prefs JSON. Viewer parses (`session_state_codec`, `QJsonDocument`) and applies through the **existing `SettingsApplier` slots** — identical code paths to `SettingsManager::load_*`.
+- **Persist:** `MainWindow::persist_settings()` under `__EMSCRIPTEN__` serializes prefs (not buffers) and emits `SessionStateChanged` (type 7), reusing the existing 100 ms debounce. Extension deep-merges into `globalState`.
+- **C++ change:** skip `settings_manager_->load_settings()` under `__EMSCRIPTEN__` (prefs arrive via type 6). `MessageHandler` gains a null-guarded `SettingsApplier*` dependency to apply type 6. Desktop path unchanged.
+
+The type 6/7 payload is **prefs-only**; buffers are the Section 3 subsystem.
+
+---
+
+## 5. Data model, storage keys & wire format
+
+### Extension storage
+
+```ts
+// globalState — UI prefs (all workspaces)
+"oid.session.prefs.v1": {
+  framerate: number;
+  export: { defaultSuffix: string };
+  ui: {
+    splitterSizes: number[];
+    minmaxVisible: boolean;
+    contrastEnabled: boolean;
+    linkViewsEnabled: boolean;
+    listPosition?: string;   // left|right|top|bottom
+    colorspace?: string;     // up to 4 chars b/g/r/a
+  };
+}
+
+// workspaceState — per-workspace buffer set
+"oid.session.buffers.v1": Array<{ name: string; expiresAt: number }>;
+```
+
+Versioned keys (`.v1`) allow clean future migration. Missing/unknown fields fall back to defaults matching `SettingsConstants`.
+
+### Wire format
+
+Extends the legacy IPC (little-endian u32 headers/lengths; UTF-8 length-prefixed strings).
+
+| ID | Name | Direction | Payload |
+|----|------|-----------|---------|
+| 6 | `ApplySessionState` | ext → viewer | `string` prefs-JSON |
+| 7 | `SessionStateChanged` | viewer → ext | `string` prefs-JSON (partial deep-merged) |
+
+Types 6/7 are already declared in `message_exchange.h` and `message-exchange.ts`.
+
+### Module layout
+
+| Module | Repo | Responsibility |
+|--------|------|----------------|
+| `src/session/pref-store.ts` | ext | **new** — load/merge/save prefs (globalState), debounce, defaults |
+| `src/session/buffer-store.ts` | ext | **new** — `wanted` set: seed, refresh, removal-diff, expiry, persist (workspaceState) |
+| `src/session/session-manager.ts` | ext | wire to `buffer-store` (replot ∪ wanted; capture held + diff) |
+| `src/webview/panel.ts` | ext | send type 6 on ready; route type 7 → pref-store |
+| `src/extension.ts` | ext | lifecycle wiring |
+| `src/ipc/message-exchange.ts` | ext | codecs for 6/7 |
+| `src/session/persistence.ts` | ext | **removed** — replaced by pref-store + buffer-store |
+| `src/ui/messaging/session_state_codec.{h,cpp}` | OID | prefs JSON ↔ `SettingsApplier` (parse + serialize, prefs-only) |
+| `src/ui/messaging/message_handler.{h,cpp}` | OID | decode type 6 → applier; null-guarded `SettingsApplier*` dep |
+| `src/ui/main_window/main_window.cpp` | OID | `__EMSCRIPTEN__`: persist→type 7, skip QSettings load |
+
+---
+
+## 6. Regression safeguards
+
+| Risk | Mitigation |
+|------|------------|
+| Autocompletion | Untouched — driven by `available_vars`/`completer_updated` from `SetAvailableSymbols` (IPC 2); no persistence code touches it |
+| Auto-plot ordering race | Replot decided extension-side from `wanted`; never reads viewer `previous_session_buffers`; type 6 timing irrelevant |
+| Skipping QSettings on WASM | Affects prefs only (now via type 6); `previous_session_buffers` going unused on WASM is fine (replot is extension-driven) |
+| Desktop GDB/LLDB | All C++ changes `#ifdef __EMSCRIPTEN__` or null-guarded; desktop QSettings path byte-for-byte unchanged |
+| Within-session replot | `session-manager` keeps `getObservedSymbols ∪ watchOnStop`; buffer-store only adds the persisted set and captures held |
+
+---
+
+## 7. Error handling
+
+| Failure | Behavior |
+|---------|----------|
+| Invalid type-7 JSON | log warning; keep last good prefs |
+| Invalid persisted JSON on load | apply defaults |
+| Expired buffers | pruned on load; never sent for replot |
+| Out-of-scope persisted buffer | plot fails silently (as today) |
+| `getObservedSymbols` times out | skip capture/diff this stop; `wanted` unchanged |
+
+---
+
+## 8. Testing
+
+### Extension unit (`node:test`)
+- `buffer-store`: expiry prune, held refresh, removal-diff (drop on disappearance), watchOnStop one-time seed, session-start seeding.
+- `pref-store`: deep-merge, defaults, debounce.
+- IPC codecs: build type 6, decode type 7.
+
+### OID native (`ctest`)
+- `session_state_codec`: prefs JSON → applier field mapping (framerate, contrast, colorspace, list position…); serialize round-trip asserts **no buffer keys** present.
+
+### Manual matrix
+- Toggle contrast / move splitter → reload window → restored.
+- Plot buffers → restart VS Code → auto-replot on next stop when in scope.
+- Remove buffer → not back after next stop.
+- Watched buffer expires after 24 h.
+- Desktop OID QSettings file unchanged after a WASM session.
+- Autocomplete and manual plot still work.
+
+---
+
+## 9. Success criteria
+
+- UI prefs persist globally across VS Code restarts.
+- Plotted buffers persist per-workspace, auto-replot when in scope, expire after 1 day, and stop returning once removed (by next stop).
+- `oid.watchOnStop` still seeds the set on first run.
+- Autocompletion and plotting are unchanged in behavior.
+- Desktop GDB/LLDB workflow and its QSettings file are untouched.
+
+---
+
+## Self-review
+
+- **Placeholder scan:** none.
+- **Internal consistency:** buffer subsystem uses only existing IPC; prefs use 6/7; storage split (global prefs / workspace buffers) consistent across §1–5; `minmaxCompact` omission stated once and reflected in fields + tests.
+- **Scope check:** single implementation plan; removal-notification IPC and `minmaxCompact` readback explicitly deferred.
+- **Ambiguity check:** "currently held" = `getObservedSymbols()`; removal = held-set diff between stops; replot target = `wanted ∪ held`; type 6/7 payload = prefs-only (no buffer keys).

--- a/docs/superpowers/specs/2026-06-28-oid-persistence-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-28-oid-persistence-redesign-design.md
@@ -238,3 +238,23 @@ Types 6/7 are already declared in `message_exchange.h` and `message-exchange.ts`
 - **Internal consistency:** buffer subsystem uses only existing IPC; prefs use 6/7; storage split (global prefs / workspace buffers) consistent across §1–5; `minmaxCompact` omission stated once and reflected in fields + tests.
 - **Scope check:** single implementation plan; removal-notification IPC and `minmaxCompact` readback explicitly deferred.
 - **Ambiguity check:** "currently held" = `getObservedSymbols()`; removal = held-set diff between stops; replot target = `wanted ∪ held`; type 6/7 payload = prefs-only (no buffer keys).
+
+---
+
+## Addendum (2026-06-29): immediate buffer capture/removal
+
+The original §3 captured the watched set only at debugger stops (`captureHeld` from
+`onStopped`). Two refinements bring it to true desktop parity (persist on add/remove):
+
+- **Persist on plot:** when the user plots a buffer (`onPlotBufferRequest` /
+  `oid.plot`), the extension immediately adds it to the per-workspace set
+  (`BufferStore.add`). Previously a buffer plotted with no *subsequent* stop was
+  never persisted.
+- **Immediate removal (IPC type 9 `BufferRemoved`, viewer → ext):** when the user
+  removes a buffer, the viewer emits `bufferRemoved` →
+  `MessageHandler::notify_buffer_removed` sends type 9; the extension calls
+  `BufferStore.remove`, dropping it from the set at once. This is required because,
+  with persist-on-plot, a plotted-then-removed buffer would otherwise be replotted
+  every stop until expiry (the stop-diff only drops buffers seen in a prior stop's
+  `observed`). The desktop INI/QSettings path is unchanged; type 9 is wired only
+  under `__EMSCRIPTEN__`.

--- a/docs/superpowers/specs/2026-06-29-ifdef-consolidation-design.md
+++ b/docs/superpowers/specs/2026-06-29-ifdef-consolidation-design.md
@@ -1,0 +1,302 @@
+# Platform `#ifdef` Consolidation Design
+
+**Date:** 2026-06-29
+**Branch:** feat/wasm-vscode
+**Goal:** Eliminate scattered `#ifdef __EMSCRIPTEN__` from the codebase by consolidating
+all platform divergence behind a thin, well-named boundary. Compile-time separation is
+preferred over runtime polymorphism. The goal is *consolidate, not eliminate*: a single
+permitted ifdef remains in one platform-config header (and the `GLCanvas` base-class
+declaration), and everything else moves to per-platform translation units or injected
+strategy objects.
+
+## Background
+
+The WASM/VS Code port (`feat/wasm-vscode`) introduced `#ifdef __EMSCRIPTEN__` across ~13
+non-thirdparty source files. The build already branches on
+`CMAKE_SYSTEM_NAME STREQUAL "Emscripten"` in `src/CMakeLists.txt`, which is the enabler for
+compile-time separation: CMake can select which translation unit to compile per platform.
+
+The divergence falls into 6 concern-domains:
+
+1. **Transport/IPC** — `PostMessageTransport` (WASM) vs `TcpTransport` (native).
+   Files: `main_window.cpp` (transport member + `loop()` socket-disconnect guard),
+   `postmessage_transport.*`, `oid_window.cpp`. A `Transport` interface already exists;
+   selection is still done with an ifdef.
+2. **GL backend & render lifecycle** — `QRhiWidget` + deferred GL queue (WASM) vs
+   `QOpenGLWidget` + immediate GL (native). Files: `gl_canvas.{h,cpp}`,
+   `message_handler.cpp`, `main_window.cpp` (`prepare_gl_draw()` is a WASM-only render hook).
+   This is the only type-level divergence (the base class differs).
+3. **GL dialect & capabilities** — GLSL ES 3.00 vs GLSL 1.20, RGBA vs RGB readback,
+   per-format texture internal-format selection (WASM) vs fixed `RGBA32F` (native), and
+   capability gaps (`GL_TEXTURE_WRAP_R` absent in WebGL). Files: `shader.cpp`,
+   `gl_text_renderer.cpp`, `buffer.cpp`, `gl_canvas.cpp`, `message_handler.cpp`.
+4. **App bootstrap & lifecycle hooks** — OpenGLES surface format, CLI parsing, JS inbound
+   hooks, the WASM-only `oid_notify_viewer_ready()` in `loop()`. Files: `oid_window.cpp`,
+   `main_window.cpp` (`loop()`), `main_window_initializer.cpp`.
+5. **Persistence** — VS Code session streaming vs `SettingsManager`; on WASM the local
+   `load_settings()` is also skipped. File: `main_window.cpp`.
+6. **UI event-loop / dialog semantics** — WASM forbids nested event loops, so blocking
+   `QFileDialog::exec()` / `QMenu::exec()` become async `popup()` + signal round-trips to the
+   extension. Files: `event_handler.cpp` (`export_buffer`, context menu),
+   `main_window.cpp` (WASM-only async-export signal/slot wiring).
+
+## Chosen strategy — Hybrid (right tool per domain)
+
+Two alternatives were rejected:
+
+- **A: build-selected translation units everywhere.** Splitting every divergent `.cpp` into
+  `_native`/`_wasm` pairs duplicates the *shared* logic interleaved with the divergent bits
+  (`message_handler.cpp` especially). Rejected for the duplication it forces.
+- **B: a uniform interface for every domain.** Over-engineers the thin cases (a 2-line
+  surface-format difference does not warrant an interface). Rejected for needless indirection.
+
+**Hybrid (chosen):** inject strategy objects where shared and divergent logic are tangled
+(highest payoff), and split translation units where method bodies are wholly disjoint. Thin
+value differences become a selected constants struct or `if constexpr (kIsWasm)`.
+
+### Invariant
+
+After this work, `#ifdef __EMSCRIPTEN__` may appear **only**:
+- inside `src/platform/`, and
+- in the `GLCanvas` base-class declaration in `gl_canvas.h` (unavoidable: the base type is
+  part of the class declaration, and Qt's moc cannot template a `QObject`-derived class).
+
+A grep gate verifies this.
+
+## The platform boundary
+
+New directory `src/platform/`:
+
+```
+src/platform/
+  platform_config.h              # constexpr bool kIsWasm; shared platform constants
+  transport_factory.h            # make_transport(deps) -> std::unique_ptr<Transport>
+  transport_factory_native.cpp   #   TcpTransport
+  transport_factory_wasm.cpp     #   PostMessageTransport + oid_set_postmessage_transport
+  render_scheduler.h             # RenderScheduler interface
+  render_scheduler_native.cpp    #   ImmediateScheduler (runs task now)
+  render_scheduler_wasm.cpp      #   DeferredScheduler (canvas->schedule_gl)
+  gl_dialect.h                   # GlDialect struct (shader + texture + caps) + the_dialect()
+  gl_dialect_native.cpp          #   GLSL 1.20, fixed RGBA32F, WRAP_R available
+  gl_dialect_wasm.cpp            #   GLSL ES 3.00, per-format internal format, no WRAP_R
+  app_platform.h                 # configure_surface_format / parse_connection_settings /
+                                 #   install_inbound_hooks / notify_viewer_ready
+  app_platform_native.cpp
+  app_platform_wasm.cpp
+  session_persistence.h          # persist_session / load_settings_if_local
+  session_persistence_native.cpp #   SettingsManager::persist_settings + load_settings
+  session_persistence_wasm.cpp   #   serialize delta + stream SessionStateChanged; load = no-op
+  ui_dialogs.h                   # request_buffer_export / show_buffer_context_menu /
+                                 #   wire_async_export_signals
+  ui_dialogs_native.cpp          #   QFileDialog::exec / QMenu::exec; wiring = no-op
+  ui_dialogs_wasm.cpp            #   emit signals / QMenu::popup; wiring = connect()s
+```
+
+`platform_config.h`:
+
+```cpp
+namespace oid::platform {
+#ifdef __EMSCRIPTEN__
+inline constexpr bool kIsWasm = true;
+#else
+inline constexpr bool kIsWasm = false;
+#endif
+}
+```
+
+`src/CMakeLists.txt` gains a platform-selected source list appended to `SOURCES`:
+
+```cmake
+if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  list(APPEND SOURCES
+    platform/transport_factory_wasm.cpp
+    platform/render_scheduler_wasm.cpp
+    platform/gl_dialect_wasm.cpp
+    platform/app_platform_wasm.cpp
+    platform/session_persistence_wasm.cpp
+    platform/ui_dialogs_wasm.cpp
+    ui/gl_canvas_wasm.cpp)
+else()
+  list(APPEND SOURCES
+    platform/transport_factory_native.cpp
+    platform/render_scheduler_native.cpp
+    platform/gl_dialect_native.cpp
+    platform/app_platform_native.cpp
+    platform/session_persistence_native.cpp
+    platform/ui_dialogs_native.cpp
+    ui/gl_canvas_native.cpp)
+endif()
+```
+
+## Domain designs
+
+These are design units, not a 1:1 map of the 6 concern-domains: the GL backend concern is
+split into render scheduling (2) and the type-level backend (3) because they use different
+techniques (strategy injection vs translation-unit split).
+
+### 1. Transport
+
+`main_window.cpp:158-191` loses its ifdef. The branches differ only in which transport is
+constructed plus one `oid_set_postmessage_transport()` call (WASM). Replace with:
+
+```cpp
+transport_ = platform::make_transport({socket_});
+message_handler_ = std::make_unique<MessageHandler>(
+    MessageHandler::Dependencies{..., *transport_, ...}, this);
+```
+
+`make_transport` is implemented per platform. The WASM impl performs the
+`oid_set_postmessage_transport` wiring internally. `main_window.h` stores a single
+`std::unique_ptr<Transport> transport_` rather than the two platform-specific members.
+
+### 2. Render scheduling (highest payoff)
+
+`message_handler.cpp` branches 5× between "schedule GL work on the canvas queue" (WASM) and
+"run it now" (native). Introduce:
+
+```cpp
+struct RenderScheduler {
+    virtual ~RenderScheduler() = default;
+    virtual void run_gl(std::function<void()> task) = 0;       // stage GL init/update
+    virtual void run_icon_gl(std::function<void()> task) = 0;  // icon paint
+};
+```
+
+- `ImmediateScheduler::run_gl(t) { t(); }` (native)
+- `DeferredScheduler` holds a `GLCanvas&` and forwards to `schedule_gl` / `schedule_icon_gl`.
+
+`MessageHandler::Dependencies` gains a `RenderScheduler&`. Each ifdef site becomes
+`deps_.scheduler.run_gl(...)`. The deferred and immediate paths were already structurally
+identical (the same lambda body, only "now vs later" differs), so the lambda is written once
+— **no logic duplicated**. The RGBA/RGB `QImage` format difference in the icon path
+(`message_handler.cpp:112-126`) is handled via `the_dialect()` (domain 3).
+
+### 3. GL backend (type-level)
+
+`gl_canvas.h` keeps the single base-class ifdef. Diverging method bodies move out:
+
+- `gl_canvas_wasm.cpp`: `initialize`, `render`, `releaseResources`, `resizeEvent`,
+  `schedule_gl`, `schedule_icon_gl`, `drain_gl_queue`, `drain_icon_gl_queue`,
+  `init_gl_state`, the QRhi `render_width/height`.
+- `gl_canvas_native.cpp`: `initializeGL`, `paintGL`, `resizeGL`, the native
+  `render_width/height`.
+- `gl_canvas.cpp` (shared): ctor/dtor common parts, mouse/wheel events,
+  `render_buffer_icon`, icon framebuffer create/destroy, accessors.
+
+The header declares each platform's overrides inside the single existing ifdef block
+(declarations only, no logic). The ctor body differs (QRhiWidget setApi + renderFailed
+connect vs none) — the platform-specific ctor tail moves to a `platform_ctor_init()` helper
+defined in each `gl_canvas_<platform>.cpp`, called from the shared ctor.
+
+`MainWindow::prepare_gl_draw()` (`main_window.cpp:320-343`) is a WASM-only render hook driven
+by the QRhi lifecycle. Its declaration stays under the one base-class-aligned ifdef in
+`main_window.h`; alternatively, since its body type-checks on both platforms, it can be
+declared unconditionally and simply left uncalled on native. Decided per-site; default is to
+keep it WASM-only to avoid dead native code.
+
+### 4. GL dialect & capabilities
+
+```cpp
+struct GlDialect {
+    std::string_view version_directive;   // "#version 300 es\n" | "#version 120\n"
+    std::string_view fragment_preamble;   // precision + out decl | ""
+    bool uses_out_color;                  // gates GLES in/out adaptation
+    QImage::Format icon_image_format;     // RGBA8888 | RGB888
+    int icon_bytes_per_pixel;             // 4 | 3
+    bool has_texture_wrap_r;              // true native, false WebGL
+    GLuint texture_internal_format(GLenum tex_type, GLenum tex_format) const;
+};
+const GlDialect& the_dialect();
+```
+
+`shader.cpp::compile()` assembles its source from `the_dialect()` fields; the GLES source
+adaptation (`adapt_shader_source_for_gles`) stays callable but is gated by
+`dialect.uses_out_color` (a value, not an ifdef). `gl_text_renderer.cpp` reads the same
+struct. `buffer.cpp` uses `texture_internal_format()` (native returns `GL_RGBA32F`
+unconditionally; WASM does the per-format `R32F/RG32F/...` selection) and guards `WRAP_R`
+with `if (dialect.has_texture_wrap_r)`. Where a difference is a pure value with both branches
+type-valid on both platforms, `if constexpr (kIsWasm)` is acceptable instead of a struct
+field.
+
+### 5. Bootstrap & lifecycle hooks
+
+`oid_window.cpp main()`:
+
+```cpp
+platform::configure_surface_format();                              // no-op native, GLES3 wasm
+auto settings = platform::parse_connection_settings(argc, argv);   // CLI native, {} wasm
+platform::install_inbound_hooks();                                 // no-op native, EM_JS wasm
+auto window = oid::MainWindow{settings};
+window.showWindow();
+```
+
+The `EM_JS` block and `emscripten.h` include move into `app_platform_wasm.cpp`.
+
+`MainWindow::loop()` carries two opposite hooks: a native-only socket-disconnect guard
+(domain 1) and a WASM-only viewer-ready notification. Both become platform calls:
+`platform::should_quit_on_disconnect(socket_)` (native checks the socket; WASM returns false)
+and `platform::notify_viewer_ready_once(...)` (WASM emits `oid_notify_viewer_ready`; native is
+a no-op). `main_window_initializer.cpp`'s two small ifdefs fold into a `platform::` helper or
+`if constexpr (kIsWasm)`, decided per-site.
+
+### 6. Persistence
+
+`main_window.cpp:479-526` calls
+`platform::persist_session(callbacks, {transport_.get(), channel_names_, ui_components_})`.
+Native impl calls `SettingsManager::persist_settings`; WASM impl performs the
+colorspace/list-position serialization and streams `SessionStateChanged`. The startup
+`load_settings()` (skipped on WASM, `main_window.cpp:292-294`) becomes
+`platform::load_settings_if_local(*settings_manager_)` — native loads, WASM is a no-op.
+
+### 7. UI event-loop / dialog semantics
+
+WASM has no nested event loops, so blocking dialogs are replaced by async flows. Behind
+`ui_dialogs.h`:
+
+- `platform::request_buffer_export(stage, buffer_name, deps)` — native opens
+  `QFileDialog::exec()` and exports synchronously; WASM gathers contrast and emits
+  `exportBufferRequested` for the extension to handle. `event_handler.cpp::export_buffer`
+  reduces to one call.
+- `platform::show_buffer_context_menu(parent, global_pos, actions)` — native uses a stack
+  `QMenu` + `exec()`; WASM uses a heap `QMenu{WA_DeleteOnClose}` + `popup()`.
+- `platform::wire_async_export_signals(event_handler, message_handler)` — native is a no-op;
+  WASM performs the `connect()` calls currently at `main_window.cpp:260-273`.
+
+The signals/slots involved (`exportBufferRequested`, `request_export_buffer`, etc.) are
+declared unconditionally in their headers so both platforms compile; only the wiring differs.
+If any are currently ifdef-guarded in the header, they are made unconditional as part of this
+domain (declaring an unused signal is harmless).
+
+## Verification
+
+- **Both builds compile** — native preset and Emscripten/WASM preset. This is the primary
+  safety net, since most divergence is now compile-selected.
+- **Existing native tests pass** (`tests/`).
+- **Behavioral equivalence** — pure restructuring, no behavior change intended. Moved bodies
+  are diffed against originals to confirm equivalence (especially the scheduler lambdas and
+  the shader-source assembly).
+- **Grep gate** — `grep -rn __EMSCRIPTEN__ src --include=*.cpp` outside `src/platform/`
+  returns nothing; including headers, the only hit is the `gl_canvas.h` base-class line and
+  `platform_config.h`.
+
+## Rollout
+
+Mechanical but broad (~13 edited files, ~20 new small platform files). Land domain-by-domain,
+one commit per domain, each independently buildable and reviewable:
+
+1. `src/platform/` scaffold + `platform_config.h` + CMake wiring.
+2. Transport factory (incl. `loop()` disconnect guard).
+3. Render scheduler.
+4. GL backend split (`gl_canvas`, `prepare_gl_draw`).
+5. GL dialect & capabilities (`shader.cpp`, `gl_text_renderer.cpp`, `buffer.cpp`).
+6. Bootstrap & lifecycle hooks (surface format, CLI, JS hooks, viewer-ready).
+7. Persistence (`persist_session`, `load_settings_if_local`).
+8. UI event-loop / dialog semantics (`event_handler.cpp`, async-export wiring).
+9. Grep gate / cleanup sweep.
+
+## Out of scope
+
+- Non-Emscripten ifdefs (`Q_OS_DARWIN` in `event_handler.cpp:78`, Python-version guards in
+  `python_native_interface.*`, thirdparty Eigen). These are unrelated to the WASM/native
+  split and are left untouched.
+- Any behavior change, feature addition, or unrelated refactoring.

--- a/docs/superpowers/specs/2026-06-29-wasm-large-buffer-tiling-design.md
+++ b/docs/superpowers/specs/2026-06-29-wasm-large-buffer-tiling-design.md
@@ -1,0 +1,154 @@
+# WASM Large-Buffer Tiling — Design
+
+**Date:** 2026-06-29
+**Status:** Approved (brainstorming)
+**Repos:** `OpenImageDebugger` (C++ WASM viewer), `openimagedebugger-vscode` (extension)
+
+## Problem
+
+Plotting a large buffer (e.g. 40000×2160, any dtype) into the WASM viewer
+renders **blank** — autocomplete and the rest of the UI work, but no image
+appears. The C++ dimension/size limits are generous (`MAX_BUFFER_DIMENSION =
+131072`, `MAX_BUFFER_SIZE = 16 GB`), so a 40000×2160 buffer would be accepted
+*if the bytes arrived*. The failure is in the **transport**, not the renderer.
+
+A single `PlotBufferContents` frame carrying the full pixel payload hits three
+walls at once on the extension→webview hop:
+
+1. **`Array.from(bytes)`** in `panel.ts` (lines 249, 295) boxes every byte into
+   a JS array — an ~8–16× memory blow-up plus a giant structured clone.
+2. **~64 MB postMessage ceiling** in Chromium (noted in the
+   `2026-06-24-oid-wasm-vscode-qt611-design.md`).
+3. **`int` length overflow** at 2 GB in the EM_JS transport bindings
+   (`oid_send_to_js(ptr, int len)`, `oidEnqueueInbound(ptr, int len)`). Worst
+   case (float64×4 at 40000×2160 ≈ 2.76 GB) overflows.
+
+GL texture tiling into 2048² tiles **already exists** in `Buffer::setup_gl_buffer`
+and is not the problem. The original design always intended extension-side
+tiling (`2026-06-23-oid-wasm-vscode-design.md`, line 117: "Extension tiles large
+buffers"); it was deferred and never built.
+
+## Goal
+
+Send large buffers as a sequence of size-bounded chunks so no single message
+exceeds the postMessage/​`int` limits, while preserving every viewer feature
+(GL tiling, contrast min/max, pixel-value hover). Out of scope: streaming that
+avoids ever holding the full buffer (Approach B below) and source-side
+downsampling (Approach C). Both are noted as possible future work.
+
+## Approach chosen: A — reassemble in C++
+
+Chunk only the **transport**. The viewer concatenates chunks into one
+contiguous buffer in the same owned storage the renderer already uses
+(`deps_.buffer_data.held_buffers[name]`), then runs **today's pipeline
+unchanged**. The only thing that changes is how bytes get from the extension to
+that storage.
+
+- ✅ Directly fixes the blank-render (a transport failure).
+- ✅ Minimal C++ logic change; GL tiling, contrast scan, and pixel-hover readout
+  are untouched because the assembled buffer is byte-identical to today's.
+- ✅ Handles the realistic cases: uint8/uint16/float32 up to ~1–2 GB.
+- ⚠️ Bounded by the 32-bit WASM heap, so a ~2.7 GB float64×4 buffer still won't
+  fit. Only streaming (B) would fix that; it is the rare case.
+
+### Rejected alternatives
+
+- **B — stream tiles straight to GL, never hold the full buffer.** Scales past
+  the heap ceiling, but pixel-value hover (a core OID feature) needs the bytes
+  and would require round-tripping reads to the extension; contrast min/max must
+  become incremental. Much larger, riskier change. Deferred.
+- **C — downsample huge buffers at the source.** Trivial payloads but destroys
+  pixel-exact inspection, the whole point of OID. Only viable as an optional
+  mode, not the core fix.
+
+## Wire protocol
+
+The extension chooses per buffer based on serialized pixel size vs a shared
+`CHUNK_BUDGET` (~16 MB, safely below the 64 MB postMessage ceiling and far from
+the 2 GB `int` boundary):
+
+- **Small buffers (≤ budget):** unchanged single `PlotBufferContents` (type 3).
+  Desktop/TCP path also untouched.
+- **Large buffers (> budget):** a three-message sequence, all keyed by
+  `variable_name`:
+
+| Type | Name | Payload |
+|---|---|---|
+| 10 | `PlotBufferBegin` | variable_name, display_name, pixel_layout, transpose, width, height, channels, stride, type, total_byte_size |
+| 11 | `PlotBufferChunk` | variable_name, row_offset, row_count, bytes (`row_count × stride`, tightly packed) |
+| 12 | `PlotBufferEnd` | variable_name |
+
+Chunks are **full-width row strips** (`row_count = floor(budget / stride)`), so
+each chunk is a contiguous byte range at offset `row_offset × stride` — assembly
+is a single `memcpy`, no per-tile scatter. A single 40000-wide float64×4 row is
+~1.28 MB, far under budget, so row-strip chunking always fits. New types are
+additive (10–12); the existing protocol and the desktop TCP/Python bridge are
+unaffected.
+
+## C++ assembly
+
+A small `BufferAssembler` owns in-progress transfers, keyed by name:
+
+- **Begin** → allocate the entry in `held_buffers[name]` sized to
+  `total_byte_size`; stash geometry (width/height/channels/stride/type/
+  pixel_layout/transpose/display_name).
+- **Chunk** → `memcpy` bytes to `offset = row_offset × stride`; bounds-checked
+  against `total_byte_size`. Out-of-range or overflowing chunks are rejected
+  with a logged error.
+- **End** → build `BufferParams` pointing at the now-complete owned buffer, then
+  call the **exact existing path** from `decode_plot_buffer_contents`
+  (Float64→Float32 conversion, `create_stage`/`initialize` or `buffer_update`,
+  `select_stage`, `request_render_update`, image-list + label update). Drop the
+  staging entry.
+
+Because assembly lands in the same owned storage the renderer's non-owning
+`Buffer::buffer_` span already points into, nothing downstream changes.
+
+`MessageHandler` dispatch gains three cases (10/11/12) routed to the assembler;
+everything else is untouched.
+
+## Extension side (TypeScript)
+
+1. **Stop boxing bytes.** In `panel.ts`, replace `Array.from(bytes)` on the
+   large-payload sends (lines 249, 295) with the `Uint8Array` directly; the
+   inbound bridge's `toUint8Array(...)` already accepts all forms. The small
+   viewer→host send (line 57) can switch too but is low-stakes.
+2. **Chunked encoder.** Add `buildPlotBufferBegin`, `buildPlotBufferChunk`,
+   `buildPlotBufferEnd` to `message-exchange.ts`. The plot sink branches: if
+   `pixels.byteLength > CHUNK_BUDGET`, emit Begin + N Chunks (zero-copy
+   `subarray` views) + End; else the existing single-frame path. Budget is a
+   shared constant.
+
+The DAP read in `dap-client.ts` is left as-is (single `readMemory`). If it
+proves to be a second bottleneck — the still-unverified "no console output yet"
+unknown — it is an isolated follow-up that does not affect this protocol.
+
+## Defensive cleanup
+
+Widen `oid_send_to_js` / `oidEnqueueInbound` / `PostMessageTransport::send`
+length params from `int` to `std::size_t` (`uintptr_t`/`double` across the EM_JS
+boundary). Chunk sizes keep us far from the 2 GB line regardless, but this
+removes the latent overflow.
+
+## Testing
+
+- **C++ unit — `BufferAssembler`:** Begin/Chunk×N/End reconstructs a known byte
+  pattern identical to the single-frame buffer; out-of-order/overflow chunks
+  rejected; an interleaved second buffer does not corrupt the first.
+- **C++ equivalence:** a buffer sent chunked yields the same `BufferParams`
+  (geometry + bytes) as the same buffer sent as one `PlotBufferContents`.
+- **Extension unit (`node:test`):** `buildPlotBuffer*` round-trips via the
+  existing decoder; the sink picks chunked vs single exactly at the budget
+  boundary; chunk count and total byte coverage are exact.
+- **Manual:** plot a 40000×2160 buffer of each dtype; confirm it renders, hover
+  shows correct pixel values, and contrast works.
+
+## Risks / open questions
+
+- The blank-render root cause is inferred (transport), not yet confirmed from
+  console output. If a C++ `[Error]` line *does* appear for large buffers, that
+  points at GL/validation instead and would be addressed before/with this work.
+  Reproduction + a quick console check is the recommended first implementation
+  step.
+- A single `readMemory` for hundreds of MB over DAP may be slow or capped; if so,
+  chunk the DAP read as a separate follow-up (does not change the wire protocol).

--- a/resources/matlab/oid_load.m
+++ b/resources/matlab/oid_load.m
@@ -3,23 +3,97 @@
 
 function buffer = oid_load(fname)
 
-    fid = fopen(fname, 'r');
+    known_types = {'uint8', 'uint16', 'int16', 'int32', 'float'};
+    bytes_per_elem = [1, 2, 2, 4, 4];
 
-    type = fgets(fid);
-    dimensions = fread(fid, 3, 'int32')';
+    fid = fopen(fname, 'rb');
+    if fid < 0
+        error('oid_load: cannot open file: %s', fname);
+    end
+    cleanup = onCleanup(@() fclose(fid)); %#ok<NASGU>
 
-    buffer = fread(fid, prod(dimensions), type(1:length(type)-1));
+    probe = fread(fid, 6, 'uint8=>char')';
+    type = '';
+    type_len = 0;
+    for i = 1:numel(known_types)
+        candidate = known_types{i};
+        if strncmp(probe, candidate, numel(candidate))
+            type = candidate;
+            type_len = numel(candidate);
+            break;
+        end
+    end
+    if isempty(type)
+        error('oid_load: unknown matrix type in %s', fname);
+    end
 
+    fseek(fid, type_len, 'bof');
+    next_byte = fread(fid, 1, 'uint8');
+
+    if next_byte == 10
+        dimensions = fread(fid, 3, 'int32')';
+        raw = fread(fid, inf, type);
+    else
+        % Legacy export format (OID <= 1.x regression): ASCII dimensions
+        fseek(fid, type_len, 'bof');
+        dims_str = read_digit_run(fid);
+
+        fseek(fid, 0, 'eof');
+        file_size = ftell(fid);
+        data_start = type_len + numel(dims_str);
+
+        bpp = bytes_per_elem(strcmp(known_types, type));
+        pixel_count = (file_size - data_start) / bpp;
+        dimensions = parse_dimensions(dims_str, pixel_count);
+
+        fseek(fid, data_start, 'bof');
+        raw = fread(fid, pixel_count, type);
+    end
+
+    buffer = reshape_buffer(raw, dimensions);
+end
+
+function dims_str = read_digit_run(fid)
+    dims_str = '';
+    while true
+        c = fread(fid, 1, 'uint8=>char');
+        if isempty(c) || c < '0' || c > '9'
+            if ~isempty(dims_str)
+                fseek(fid, -1, 'cof');
+            end
+            break;
+        end
+        dims_str = [dims_str, c]; %#ok<AGROW>
+    end
+end
+
+function dimensions = parse_dimensions(dims_str, pixel_count)
+    n = numel(dims_str);
+    for i = 1:(n - 2)
+        for j = (i + 1):(n - 1)
+            rows = str2double(dims_str(1:i));
+            cols = str2double(dims_str(i + 1:j));
+            channels = str2double(dims_str(j + 1:end));
+            if rows > 0 && cols > 0 && channels > 0 && ...
+                    rows * cols * channels == pixel_count
+                dimensions = [rows, cols, channels];
+                return;
+            end
+        end
+    end
+    error('oid_load: could not parse dimensions from ''%s''', dims_str);
+end
+
+function buffer = reshape_buffer(raw, dimensions)
     rows = dimensions(1);
     cols = dimensions(2);
     channels = dimensions(3);
 
-    buffer_t = reshape(reshape(buffer, channels, rows*cols)', [cols,rows,channels]);
+    buffer_t = reshape(reshape(raw, channels, rows * cols)', ...
+        [cols, rows, channels]);
 
-    buffer = zeros(dimensions);
+    buffer = zeros(dimensions, class(raw));
     for c = 1:channels
         buffer(:, :, c) = buffer_t(:, :, c)';
     end
-
-    fclose(fid);
-
+end

--- a/scripts/check_platform_ifdefs.sh
+++ b/scripts/check_platform_ifdefs.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cpp_violations=$(grep -rn "__EMSCRIPTEN__" src --include=*.cpp \
+  | grep -v "src/platform/" | grep -v "src/thirdparty/" || true)
+h_violations=$(grep -rn "__EMSCRIPTEN__" src --include=*.h \
+  | grep -v "src/platform/" | grep -v "src/thirdparty/" \
+  | grep -v "src/ui/gl_canvas.h" || true)
+
+status=0
+if [[ -n "$cpp_violations" ]]; then
+  echo "Platform ifdefs leaked outside src/platform/ (.cpp):" >&2
+  echo "$cpp_violations" >&2
+  status=1
+fi
+if [[ -n "$h_violations" ]]; then
+  echo "Platform ifdefs leaked outside src/platform/ and src/ui/gl_canvas.h (.h):" >&2
+  echo "$h_violations" >&2
+  status=1
+fi
+
+if [[ $status -eq 0 ]]; then
+  echo "OK: all __EMSCRIPTEN__ ifdefs are confined to src/platform/ (and src/ui/gl_canvas.h)"
+fi
+exit $status

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,11 +84,13 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   list(APPEND SOURCES
     platform/transport_factory_wasm.cpp
     platform/render_scheduler_wasm.cpp
+    ui/gl_canvas_wasm.cpp
   )
 else()
   list(APPEND SOURCES
     platform/transport_factory_native.cpp
     platform/render_scheduler_native.cpp
+    ui/gl_canvas_native.cpp
   )
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,6 +58,8 @@ set(SOURCES
     ui/main_window/settings_manager.cpp
     ui/main_window/ui_events.cpp
     ui/messaging/message_handler.cpp
+    ui/messaging/session_state_apply.cpp
+    ui/messaging/session_state_codec.cpp
     ui/symbol_completer.cpp
     ui/symbol_search_input.cpp
     visualization/components/background.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,10 +83,12 @@ set(SOURCES
 if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   list(APPEND SOURCES
     platform/transport_factory_wasm.cpp
+    platform/render_scheduler_wasm.cpp
   )
 else()
   list(APPEND SOURCES
     platform/transport_factory_native.cpp
+    platform/render_scheduler_native.cpp
   )
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,7 +76,7 @@ set(SOURCES
 set(QT_FORMS ui/main_window/main_window.ui)
 set(QT_RESOURCES resources/resources.qrc)
 
-add_executable(${PROJECT_NAME} ${SOURCES} ${QT_FORMS} ${QT_RESOURCES})
+qt_add_executable(${PROJECT_NAME} ${SOURCES} ${QT_FORMS} ${QT_RESOURCES})
 
 add_dependencies(${PROJECT_NAME} oidipc)
 
@@ -96,7 +96,7 @@ target_include_directories(${PROJECT_NAME} SYSTEM
 target_compile_options(${PROJECT_NAME} PUBLIC "$<$<CXX_COMPILER_ID:AppleClang,Clang,GNU>:-fvisibility=hidden>")
 
 target_link_options(${PROJECT_NAME}
-                     PUBLIC "$<$<PLATFORM_ID:Unix>:-Wl,--exclude-libs,ALL;>")
+                     PUBLIC "$<$<AND:$<PLATFORM_ID:Unix>,$<NOT:$<STREQUAL:${CMAKE_SYSTEM_NAME},Emscripten>>>:-Wl,--exclude-libs,ALL;>")
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
                       oidipc
@@ -108,6 +108,11 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   target_link_libraries(${PROJECT_NAME} PRIVATE ${OPENGL_gl_LIBRARY})
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  target_link_options(${PROJECT_NAME} PRIVATE
+    "SHELL:-s EXPORTED_FUNCTIONS=['_main','_oidEnqueueInbound','_oid_set_postmessage_transport','__embind_initialize_bindings']")
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,6 +82,7 @@ set(SOURCES
 # Platform-selected sources
 if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   list(APPEND SOURCES
+    platform/app_platform_wasm.cpp
     platform/transport_factory_wasm.cpp
     platform/render_scheduler_wasm.cpp
     platform/gl_dialect_wasm.cpp
@@ -89,6 +90,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   )
 else()
   list(APPEND SOURCES
+    platform/app_platform_native.cpp
     platform/transport_factory_native.cpp
     platform/render_scheduler_native.cpp
     platform/gl_dialect_native.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,8 +25,12 @@ cmake_minimum_required(VERSION 3.28.3)
 
 project(oidwindow CXX)
 
-set(OpenGL_GL_PREFERENCE LEGACY)
-find_package(OpenGL 2.1 REQUIRED)
+include(${CMAKE_SOURCE_DIR}/cmake/EmscriptenWasm.cmake)
+
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  set(OpenGL_GL_PREFERENCE LEGACY)
+  find_package(OpenGL 2.1 REQUIRED)
+endif()
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
@@ -100,8 +104,11 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
                       Qt6::OpenGL
                       Qt6::OpenGLWidgets
                       Qt6::Widgets
-                      Threads::Threads
-                      ${OPENGL_gl_LIBRARY})
+                      Threads::Threads)
+
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  target_link_libraries(${PROJECT_NAME} PRIVATE ${OPENGL_gl_LIBRARY})
+endif()
 
 install(TARGETS ${PROJECT_NAME}
         RUNTIME DESTINATION OpenImageDebugger)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,6 +87,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     platform/render_scheduler_wasm.cpp
     platform/gl_dialect_wasm.cpp
     platform/session_persistence_wasm.cpp
+    platform/postmessage_transport.cpp
     ui/gl_canvas_wasm.cpp
   )
 else()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,7 +32,7 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-find_package(Qt6 "6.4.2" REQUIRED COMPONENTS Core Gui OpenGL OpenGLWidgets Widgets)
+find_package(Qt6 6.11 REQUIRED COMPONENTS Core Gui OpenGL OpenGLWidgets Widgets)
 
 set(SOURCES
     oid_window.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,6 +86,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     platform/transport_factory_wasm.cpp
     platform/render_scheduler_wasm.cpp
     platform/gl_dialect_wasm.cpp
+    platform/session_persistence_wasm.cpp
     ui/gl_canvas_wasm.cpp
   )
 else()
@@ -94,6 +95,7 @@ else()
     platform/transport_factory_native.cpp
     platform/render_scheduler_native.cpp
     platform/gl_dialect_native.cpp
+    platform/session_persistence_native.cpp
     ui/gl_canvas_native.cpp
   )
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,12 +84,14 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   list(APPEND SOURCES
     platform/transport_factory_wasm.cpp
     platform/render_scheduler_wasm.cpp
+    platform/gl_dialect_wasm.cpp
     ui/gl_canvas_wasm.cpp
   )
 else()
   list(APPEND SOURCES
     platform/transport_factory_native.cpp
     platform/render_scheduler_native.cpp
+    platform/gl_dialect_native.cpp
     ui/gl_canvas_native.cpp
   )
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,11 +82,11 @@ set(SOURCES
 # Platform-selected sources
 if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   list(APPEND SOURCES
-    # WASM platform sources will be appended by platform task
+    platform/transport_factory_wasm.cpp
   )
 else()
   list(APPEND SOURCES
-    # Native platform sources will be appended by platform task
+    platform/transport_factory_native.cpp
   )
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,6 +79,17 @@ set(SOURCES
     visualization/stage.cpp
 )
 
+# Platform-selected sources
+if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  list(APPEND SOURCES
+    # WASM platform sources will be appended by platform task
+  )
+else()
+  list(APPEND SOURCES
+    # Native platform sources will be appended by platform task
+  )
+endif()
+
 set(QT_FORMS ui/main_window/main_window.ui)
 set(QT_RESOURCES resources/resources.qrc)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,10 @@ set(CMAKE_AUTOUIC ON)
 
 find_package(Qt6 6.11 REQUIRED COMPONENTS Core Gui OpenGL OpenGLWidgets Widgets)
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  find_package(Qt6 6.11 REQUIRED COMPONENTS GuiPrivate)
+endif()
+
 set(SOURCES
     oid_window.cpp
     io/buffer_exporter.cpp
@@ -106,7 +110,9 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
                       Qt6::Widgets
                       Threads::Threads)
 
-if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::GuiPrivate)
+else()
   target_link_libraries(${PROJECT_NAME} PRIVATE ${OPENGL_gl_LIBRARY})
 endif()
 

--- a/src/io/buffer_exporter.cpp
+++ b/src/io/buffer_exporter.cpp
@@ -29,6 +29,7 @@
 #include <array>
 #include <bit>
 #include <cassert>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -180,11 +181,25 @@ void export_binary(const std::string& fname, const Buffer& buffer) {
     const auto in_ptr = std::bit_cast<const T*>(buffer.buffer_.data());
 
     const auto output_path = std::filesystem::path{fname};
-    auto ofs = std::ofstream{output_path};
+    auto ofs = std::ofstream{output_path, std::ios::binary};
 
-    ofs << get_type_descriptor<T>() << height_i << width_i << buffer.channels;
+    ofs << get_type_descriptor<T>() << '\n';
+
+    const auto height  = static_cast<std::int32_t>(height_i);
+    const auto width   = static_cast<std::int32_t>(width_i);
+    const auto channels = static_cast<std::int32_t>(buffer.channels);
+
+    ofs.write(reinterpret_cast<const char*>(&height), sizeof(height));
+    ofs.write(reinterpret_cast<const char*>(&width), sizeof(width));
+    ofs.write(reinterpret_cast<const char*>(&channels), sizeof(channels));
+
+    const auto row_bytes =
+        sizeof(T) * static_cast<std::size_t>(buffer.channels) * width_i;
+
     for (std::size_t y = 0; y < height_i; ++y) {
-        ofs << in_ptr + y * buffer.step * buffer.channels;
+        ofs.write(reinterpret_cast<const char*>(
+                      in_ptr + y * buffer.step * buffer.channels),
+                  row_bytes);
     }
 }
 

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -25,7 +25,11 @@ cmake_minimum_required(VERSION 3.28.3)
 
 project(oidipc CXX)
 
-add_library(${PROJECT_NAME} SHARED
+if(NOT DEFINED OID_IPC_LIBRARY_TYPE)
+  set(OID_IPC_LIBRARY_TYPE SHARED)
+endif()
+
+add_library(${PROJECT_NAME} ${OID_IPC_LIBRARY_TYPE}
             message_exchange.cpp
             raw_data_decode.cpp
             tcp_transport.cpp

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -27,7 +27,8 @@ project(oidipc CXX)
 
 add_library(${PROJECT_NAME} SHARED
             message_exchange.cpp
-            raw_data_decode.cpp)
+            raw_data_decode.cpp
+            tcp_transport.cpp)
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
                       WINDOWS_EXPORT_ALL_SYMBOLS ON)

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -33,8 +33,7 @@ add_library(${PROJECT_NAME} ${OID_IPC_LIBRARY_TYPE}
             buffer_assembler.cpp
             message_exchange.cpp
             raw_data_decode.cpp
-            tcp_transport.cpp
-            postmessage_transport.cpp)
+            tcp_transport.cpp)
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
                       WINDOWS_EXPORT_ALL_SYMBOLS ON)

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -30,6 +30,7 @@ if(NOT DEFINED OID_IPC_LIBRARY_TYPE)
 endif()
 
 add_library(${PROJECT_NAME} ${OID_IPC_LIBRARY_TYPE}
+            buffer_assembler.cpp
             message_exchange.cpp
             raw_data_decode.cpp
             tcp_transport.cpp

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -28,7 +28,8 @@ project(oidipc CXX)
 add_library(${PROJECT_NAME} SHARED
             message_exchange.cpp
             raw_data_decode.cpp
-            tcp_transport.cpp)
+            tcp_transport.cpp
+            postmessage_transport.cpp)
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
                       WINDOWS_EXPORT_ALL_SYMBOLS ON)

--- a/src/ipc/buffer_assembler.cpp
+++ b/src/ipc/buffer_assembler.cpp
@@ -1,0 +1,80 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "buffer_assembler.h"
+
+#include <cstring>
+#include <utility>
+
+namespace oid {
+
+void BufferAssembler::begin(BeginParams params) {
+  const auto total = params.total_byte_size;
+  auto& entry = in_progress_[params.variable_name];
+  entry.params = std::move(params);
+  entry.bytes.assign(total, std::byte{});
+}
+
+bool BufferAssembler::chunk(const std::string& name,
+                            const std::size_t row_offset,
+                            const std::size_t row_count,
+                            const std::span<const std::byte> bytes) {
+  const auto it = in_progress_.find(name);
+  if (it == in_progress_.end()) {
+    return false;
+  }
+  auto& entry = it->second;
+  const auto stride = static_cast<std::size_t>(entry.params.stride);
+  const auto offset = row_offset * stride;
+  const auto expected = row_count * stride;
+  if (bytes.size() != expected ||
+      offset + bytes.size() > entry.bytes.size()) {
+    return false;
+  }
+  std::memcpy(entry.bytes.data() + offset, bytes.data(), bytes.size());
+  return true;
+}
+
+std::optional<AssembledBuffer> BufferAssembler::end(const std::string& name) {
+  const auto it = in_progress_.find(name);
+  if (it == in_progress_.end()) {
+    return std::nullopt;
+  }
+  auto& entry = it->second;
+  AssembledBuffer out{.variable_name = std::move(entry.params.variable_name),
+                      .display_name = std::move(entry.params.display_name),
+                      .pixel_layout = std::move(entry.params.pixel_layout),
+                      .transpose = entry.params.transpose,
+                      .width = entry.params.width,
+                      .height = entry.params.height,
+                      .channels = entry.params.channels,
+                      .stride = entry.params.stride,
+                      .type = entry.params.type,
+                      .bytes = std::move(entry.bytes)};
+  in_progress_.erase(it);
+  return out;
+}
+
+}  // namespace oid

--- a/src/ipc/buffer_assembler.h
+++ b/src/ipc/buffer_assembler.h
@@ -35,17 +35,17 @@
 
 namespace oid {
 
-// Geometry + completed bytes buffer reassembled row-strip chunks.
+// Geometry + completed bytes for a buffer reassembled from row-strip chunks.
 struct AssembledBuffer {
   std::string variable_name;
   std::string display_name;
   std::string pixel_layout;
-  bool transpose;
-  int width;
-  int height;
-  int channels;
-  int stride;
-  int type;
+  bool transpose{};
+  int width{};
+  int height{};
+  int channels{};
+  int stride{};
+  int type{};
   std::vector<std::byte> bytes;
 };
 
@@ -55,12 +55,12 @@ class BufferAssembler {
     std::string variable_name;
     std::string display_name;
     std::string pixel_layout;
-    bool transpose;
-    int width;
-    int height;
-    int channels;
-    int stride;
-    int type;
+    bool transpose{};
+    int width{};
+    int height{};
+    int channels{};
+    int stride{};
+    int type{};
     std::size_t total_byte_size;
   };
 
@@ -69,10 +69,10 @@ class BufferAssembler {
 
   // Append row-strip chunk. Returns false if name unknown, size mismatch, or
   // out of bounds.
-  bool chunk(const std::string& name,
-             std::size_t row_offset,
-             std::size_t row_count,
-             std::span<const std::byte> bytes);
+  [[nodiscard]] bool chunk(const std::string& name,
+                           std::size_t row_offset,
+                           std::size_t row_count,
+                           std::span<const std::byte> bytes);
 
   // Finish transfer, moving bytes out dropping entry. Returns
   // nullopt if name unknown.

--- a/src/ipc/buffer_assembler.h
+++ b/src/ipc/buffer_assembler.h
@@ -1,0 +1,91 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef IPC_BUFFER_ASSEMBLER_H_
+#define IPC_BUFFER_ASSEMBLER_H_
+
+#include <cstddef>
+#include <map>
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace oid {
+
+// Geometry + completed bytes buffer reassembled row-strip chunks.
+struct AssembledBuffer {
+  std::string variable_name;
+  std::string display_name;
+  std::string pixel_layout;
+  bool transpose;
+  int width;
+  int height;
+  int channels;
+  int stride;
+  int type;
+  std::vector<std::byte> bytes;
+};
+
+class BufferAssembler {
+ public:
+  struct BeginParams {
+    std::string variable_name;
+    std::string display_name;
+    std::string pixel_layout;
+    bool transpose;
+    int width;
+    int height;
+    int channels;
+    int stride;
+    int type;
+    std::size_t total_byte_size;
+  };
+
+  // Start transfer for buffer `name`.
+  void begin(BeginParams params);
+
+  // Append row-strip chunk. Returns false if name unknown, size mismatch, or
+  // out of bounds.
+  bool chunk(const std::string& name,
+             std::size_t row_offset,
+             std::size_t row_count,
+             std::span<const std::byte> bytes);
+
+  // Finish transfer, moving bytes out dropping entry. Returns
+  // nullopt if name unknown.
+  [[nodiscard]] std::optional<AssembledBuffer> end(const std::string& name);
+
+ private:
+  struct InProgress {
+    BeginParams params;
+    std::vector<std::byte> bytes;
+  };
+  std::map<std::string, InProgress, std::less<>> in_progress_{};
+};
+
+}  // namespace oid
+
+#endif  // IPC_BUFFER_ASSEMBLER_H_

--- a/src/ipc/message_exchange.cpp
+++ b/src/ipc/message_exchange.cpp
@@ -27,6 +27,10 @@
 
 #include <utility>
 
+#include <QTcpSocket>
+
+#include "tcp_transport.h"
+
 namespace oid {
 
 MessageBlock::~MessageBlock() noexcept = default;
@@ -45,5 +49,17 @@ size_t StringBlock::size() const noexcept {
     // that this is raw byte storage.
     return reinterpret_cast<const std::byte*>(data_.data());
 }
+
+void MessageComposer::send(QTcpSocket* socket) const {
+    TcpTransport transport{*socket};
+    send(transport);
+}
+
+MessageDecoder::MessageDecoder(ITransport& transport)
+    : transport_{transport} {}
+
+MessageDecoder::MessageDecoder(QTcpSocket* socket)
+    : owned_tcp_transport_{std::make_unique<TcpTransport>(*socket)},
+      transport_{*owned_tcp_transport_} {}
 
 } // namespace oid

--- a/src/ipc/message_exchange.h
+++ b/src/ipc/message_exchange.h
@@ -57,7 +57,10 @@ enum class MessageType {
     ApplySessionState = 6,
     SessionStateChanged = 7,
     ExportSelectedBuffer = 8,
-    BufferRemoved = 9
+    BufferRemoved = 9,
+    PlotBufferBegin = 10,
+    PlotBufferChunk = 11,
+    PlotBufferEnd = 12
 };
 
 // C++20 concept to replace SFINAE for primitive type checking

--- a/src/ipc/message_exchange.h
+++ b/src/ipc/message_exchange.h
@@ -36,11 +36,13 @@
 #include <string>
 #include <type_traits>
 
-#include <QPointer>
 #include <QString>
-#include <QTcpSocket>
 
+#include "transport.h"
+#include "tcp_transport.h"
 #include "raw_data_decode.h"
+
+class QTcpSocket;
 
 namespace oid {
 
@@ -166,27 +168,13 @@ class MessageComposer {
         return *this;
     }
 
-    void send(QTcpSocket* socket) const {
+    void send(ITransport& transport) const {
         for (const auto& block : message_blocks_) {
-            auto offset = qint64{0};
-            do {
-                // Convert std::byte* to const char* for Qt API (safe: same
-                // size/alignment)
-                offset +=
-                    socket->write(std::bit_cast<const char*>(block->data()),
-                                  static_cast<qint64>(block->size()));
-
-                if (offset < static_cast<qint64>(block->size()) &&
-                    !socket->waitForBytesWritten(5000)) [[unlikely]] {
-                    throw_socket_timeout_error("write");
-                }
-            } while (offset < static_cast<qint64>(block->size()));
-        }
-
-        if (!socket->waitForBytesWritten(5000)) [[unlikely]] {
-            throw_socket_timeout_error("write");
+            transport.send(std::span{block->data(), block->size()});
         }
     }
+
+    void send(QTcpSocket* socket) const;
 
     void clear() {
         message_blocks_.clear();
@@ -213,7 +201,9 @@ class MessageComposer {
 
 class MessageDecoder {
   public:
-    explicit MessageDecoder(QTcpSocket* socket) : socket_{socket} {}
+    explicit MessageDecoder(ITransport& transport);
+
+    explicit MessageDecoder(QTcpSocket* socket);
 
     template <PrimitiveType T> MessageDecoder& read(T& value) {
         // Safe mutable byte access to object representation
@@ -295,23 +285,19 @@ class MessageDecoder {
     }
 
   private:
-    QPointer<QTcpSocket> socket_{};
+    std::unique_ptr<TcpTransport> owned_tcp_transport_;
+    ITransport& transport_;
 
     void read_impl(std::span<std::byte> dst) const {
-        assert(!socket_.isNull() && "socket_ must be valid");
         auto offset = std::size_t{0};
         const auto read_length = dst.size();
-        do {
-            // Convert std::byte* to char* for Qt API (safe: same
-            // size/alignment)
-            offset += socket_->read(std::bit_cast<char*>(dst.data() + offset),
-                                    static_cast<qint64>(read_length - offset));
-
-            if (offset < read_length && !socket_->waitForReadyRead(5000))
-                [[unlikely]] {
+        while (offset < read_length) {
+            const auto n = transport_.receive(dst.subspan(offset));
+            if (n == 0) {
                 throw_socket_timeout_error("read");
             }
-        } while (offset < read_length);
+            offset += n;
+        }
     }
 };
 

--- a/src/ipc/message_exchange.h
+++ b/src/ipc/message_exchange.h
@@ -56,7 +56,8 @@ enum class MessageType {
     ExportBufferRequest = 5,
     ApplySessionState = 6,
     SessionStateChanged = 7,
-    ExportSelectedBuffer = 8
+    ExportSelectedBuffer = 8,
+    BufferRemoved = 9
 };
 
 // C++20 concept to replace SFINAE for primitive type checking

--- a/src/ipc/message_exchange.h
+++ b/src/ipc/message_exchange.h
@@ -60,8 +60,9 @@ enum class MessageType {
 template <typename T>
 concept PrimitiveType =
     std::is_same_v<T, MessageType> || std::is_same_v<T, int> ||
-    std::is_same_v<T, unsigned char> || std::is_same_v<T, BufferType> ||
-    std::is_same_v<T, bool> || std::is_same_v<T, std::size_t>;
+    std::is_same_v<T, float> || std::is_same_v<T, unsigned char> ||
+    std::is_same_v<T, BufferType> || std::is_same_v<T, bool> ||
+    std::is_same_v<T, std::size_t>;
 
 // Dedicated exception for socket timeout errors
 class SocketTimeoutError final : public std::runtime_error {

--- a/src/ipc/message_exchange.h
+++ b/src/ipc/message_exchange.h
@@ -52,7 +52,8 @@ enum class MessageType {
     GetObservedSymbolsResponse = 1,
     SetAvailableSymbols = 2,
     PlotBufferContents = 3,
-    PlotBufferRequest = 4
+    PlotBufferRequest = 4,
+    ExportBufferRequest = 5
 };
 
 // C++20 concept to replace SFINAE for primitive type checking

--- a/src/ipc/message_exchange.h
+++ b/src/ipc/message_exchange.h
@@ -53,7 +53,10 @@ enum class MessageType {
     SetAvailableSymbols = 2,
     PlotBufferContents = 3,
     PlotBufferRequest = 4,
-    ExportBufferRequest = 5
+    ExportBufferRequest = 5,
+    ApplySessionState = 6,
+    SessionStateChanged = 7,
+    ExportSelectedBuffer = 8
 };
 
 // C++20 concept to replace SFINAE for primitive type checking

--- a/src/ipc/message_exchange.h
+++ b/src/ipc/message_exchange.h
@@ -35,6 +35,7 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+#include <vector>
 
 #include <QString>
 
@@ -169,8 +170,18 @@ class MessageComposer {
     }
 
     void send(ITransport& transport) const {
+        std::size_t total = 0;
         for (const auto& block : message_blocks_) {
-            transport.send(std::span{block->data(), block->size()});
+            total += block->size();
+        }
+        std::vector<std::byte> frame;
+        frame.reserve(total);
+        for (const auto& block : message_blocks_) {
+            const auto* data = block->data();
+            frame.insert(frame.end(), data, data + block->size());
+        }
+        if (!frame.empty()) {
+            transport.send(frame);
         }
     }
 

--- a/src/ipc/postmessage_transport.cpp
+++ b/src/ipc/postmessage_transport.cpp
@@ -61,4 +61,22 @@ void PostMessageTransport::enqueue_inbound(std::vector<std::byte> data) {
     inbound_.insert(inbound_.end(), data.begin(), data.end());
 }
 
+#ifdef __EMSCRIPTEN__
+namespace {
+PostMessageTransport* g_transport = nullptr;
+}
+
+extern "C" void oid_set_postmessage_transport(PostMessageTransport* transport) {
+    g_transport = transport;
+}
+
+extern "C" void oidEnqueueInbound(const std::uintptr_t ptr, const int len) {
+    if (g_transport == nullptr || len <= 0) {
+        return;
+    }
+    const auto* data = reinterpret_cast<const std::byte*>(ptr);
+    g_transport->enqueue_inbound({data, data + len});
+}
+#endif
+
 } // namespace oid

--- a/src/ipc/postmessage_transport.cpp
+++ b/src/ipc/postmessage_transport.cpp
@@ -28,7 +28,7 @@
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 
-EM_JS(void, oid_send_to_js, (const void* ptr, int len), {
+EM_JS(void, oid_send_to_js, (const void* ptr, unsigned len), {
   window.oidSend(HEAPU8.slice(ptr, ptr + len));
 });
 #endif
@@ -37,7 +37,7 @@ namespace oid {
 
 void PostMessageTransport::send(std::span<const std::byte> data) {
 #ifdef __EMSCRIPTEN__
-    oid_send_to_js(data.data(), static_cast<int>(data.size()));
+    oid_send_to_js(data.data(), static_cast<unsigned>(data.size()));
 #else
     (void)data;
 #endif
@@ -72,8 +72,8 @@ extern "C" void oid_set_postmessage_transport(PostMessageTransport* transport) {
     g_transport = transport;
 }
 
-extern "C" void oidEnqueueInbound(const std::uintptr_t ptr, const int len) {
-    if (g_transport == nullptr || len <= 0) {
+extern "C" void oidEnqueueInbound(const std::uintptr_t ptr, const unsigned len) {
+    if (g_transport == nullptr || len == 0) {
         return;
     }
     const auto* data = reinterpret_cast<const std::byte*>(ptr);

--- a/src/ipc/postmessage_transport.cpp
+++ b/src/ipc/postmessage_transport.cpp
@@ -27,15 +27,17 @@
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
+
+EM_JS(void, oid_send_to_js, (const void* ptr, int len), {
+  window.oidSend(HEAPU8.slice(ptr, ptr + len));
+});
 #endif
 
 namespace oid {
 
 void PostMessageTransport::send(std::span<const std::byte> data) {
 #ifdef __EMSCRIPTEN__
-    EM_ASM({ window.oidSend(HEAPU8.slice($0, $0 + $1)); },
-           data.data(),
-           data.size());
+    oid_send_to_js(data.data(), static_cast<int>(data.size()));
 #else
     (void)data;
 #endif

--- a/src/ipc/postmessage_transport.cpp
+++ b/src/ipc/postmessage_transport.cpp
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "postmessage_transport.h"
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
+namespace oid {
+
+void PostMessageTransport::send(std::span<const std::byte> data) {
+#ifdef __EMSCRIPTEN__
+    EM_ASM({ window.oidSend(HEAPU8.slice($0, $0 + $1)); },
+           data.data(),
+           data.size());
+#else
+    (void)data;
+#endif
+}
+
+std::size_t PostMessageTransport::receive(std::span<std::byte> dst) {
+    const std::scoped_lock lock{mutex_};
+    std::size_t n = 0;
+    while (n < dst.size() && !inbound_.empty()) {
+        dst[n++] = inbound_.front();
+        inbound_.pop_front();
+    }
+    return n;
+}
+
+bool PostMessageTransport::has_data() const {
+    const std::scoped_lock lock{mutex_};
+    return !inbound_.empty();
+}
+
+void PostMessageTransport::enqueue_inbound(std::vector<std::byte> data) {
+    const std::scoped_lock lock{mutex_};
+    inbound_.insert(inbound_.end(), data.begin(), data.end());
+}
+
+} // namespace oid

--- a/src/ipc/postmessage_transport.h
+++ b/src/ipc/postmessage_transport.h
@@ -30,6 +30,10 @@
 #include <mutex>
 #include <vector>
 
+#ifdef __EMSCRIPTEN__
+#include <cstdint>
+#endif
+
 #include "transport.h"
 
 namespace oid {
@@ -46,6 +50,13 @@ class PostMessageTransport final : public ITransport {
     mutable std::mutex mutex_;
     std::deque<std::byte> inbound_;
 };
+
+#ifdef __EMSCRIPTEN__
+extern "C" {
+void oid_set_postmessage_transport(PostMessageTransport* transport);
+void oidEnqueueInbound(std::uintptr_t ptr, int len);
+}
+#endif
 
 } // namespace oid
 

--- a/src/ipc/postmessage_transport.h
+++ b/src/ipc/postmessage_transport.h
@@ -32,6 +32,7 @@
 
 #ifdef __EMSCRIPTEN__
 #include <cstdint>
+#include <emscripten.h>
 #endif
 
 #include "transport.h"
@@ -54,7 +55,7 @@ class PostMessageTransport final : public ITransport {
 #ifdef __EMSCRIPTEN__
 extern "C" {
 void oid_set_postmessage_transport(PostMessageTransport* transport);
-void oidEnqueueInbound(std::uintptr_t ptr, int len);
+EMSCRIPTEN_KEEPALIVE void oidEnqueueInbound(std::uintptr_t ptr, int len);
 }
 #endif
 

--- a/src/ipc/postmessage_transport.h
+++ b/src/ipc/postmessage_transport.h
@@ -55,7 +55,7 @@ class PostMessageTransport final : public ITransport {
 #ifdef __EMSCRIPTEN__
 extern "C" {
 void oid_set_postmessage_transport(PostMessageTransport* transport);
-EMSCRIPTEN_KEEPALIVE void oidEnqueueInbound(std::uintptr_t ptr, int len);
+EMSCRIPTEN_KEEPALIVE void oidEnqueueInbound(std::uintptr_t ptr, unsigned len);
 }
 #endif
 

--- a/src/ipc/postmessage_transport.h
+++ b/src/ipc/postmessage_transport.h
@@ -1,0 +1,52 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef IPC_POSTMESSAGE_TRANSPORT_H_
+#define IPC_POSTMESSAGE_TRANSPORT_H_
+
+#include <deque>
+#include <mutex>
+#include <vector>
+
+#include "transport.h"
+
+namespace oid {
+
+class PostMessageTransport final : public ITransport {
+  public:
+    void send(std::span<const std::byte> data) override;
+    std::size_t receive(std::span<std::byte> dst) override;
+    bool has_data() const override;
+
+    void enqueue_inbound(std::vector<std::byte> data);
+
+  private:
+    mutable std::mutex mutex_;
+    std::deque<std::byte> inbound_;
+};
+
+} // namespace oid
+
+#endif // IPC_POSTMESSAGE_TRANSPORT_H_

--- a/src/ipc/tcp_transport.cpp
+++ b/src/ipc/tcp_transport.cpp
@@ -1,0 +1,77 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "ipc/tcp_transport.h"
+
+#include <bit>
+
+#include <QTcpSocket>
+
+#include "ipc/message_exchange.h"
+
+namespace oid {
+
+TcpTransport::TcpTransport(QTcpSocket& socket) : socket_{socket} {}
+
+void TcpTransport::send(std::span<const std::byte> data) {
+    auto offset = qint64{0};
+    const auto total = static_cast<qint64>(data.size());
+    while (offset < total) {
+        offset += socket_.write(std::bit_cast<const char*>(data.data() + offset),
+                                total - offset);
+        if (offset < total && !socket_.waitForBytesWritten(5000)) {
+            throw_socket_timeout_error("write");
+        }
+    }
+    if (!socket_.waitForBytesWritten(5000)) {
+        throw_socket_timeout_error("write");
+    }
+}
+
+std::size_t TcpTransport::receive(std::span<std::byte> dst) {
+    auto offset = std::size_t{0};
+    while (offset < dst.size()) {
+        if (!has_data() && !socket_.waitForReadyRead(5000)) {
+            throw_socket_timeout_error("read");
+        }
+        const auto n =
+            socket_.read(std::bit_cast<char*>(dst.data() + offset),
+                         static_cast<qint64>(dst.size() - offset));
+        if (n < 0) {
+            throw_socket_timeout_error("read");
+        }
+        if (n == 0) {
+            break;
+        }
+        offset += static_cast<std::size_t>(n);
+    }
+    return offset;
+}
+
+bool TcpTransport::has_data() const {
+    return socket_.bytesAvailable() > 0;
+}
+
+} // namespace oid

--- a/src/ipc/tcp_transport.cpp
+++ b/src/ipc/tcp_transport.cpp
@@ -23,13 +23,13 @@
  * IN THE SOFTWARE.
  */
 
-#include "ipc/tcp_transport.h"
+#include "tcp_transport.h"
 
 #include <bit>
 
 #include <QTcpSocket>
 
-#include "ipc/message_exchange.h"
+#include "message_exchange.h"
 
 namespace oid {
 

--- a/src/ipc/tcp_transport.h
+++ b/src/ipc/tcp_transport.h
@@ -1,0 +1,49 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef IPC_TCP_TRANSPORT_H_
+#define IPC_TCP_TRANSPORT_H_
+
+#include "ipc/transport.h"
+
+class QTcpSocket;
+
+namespace oid {
+
+class TcpTransport final : public ITransport {
+  public:
+    explicit TcpTransport(QTcpSocket& socket);
+
+    void send(std::span<const std::byte> data) override;
+    std::size_t receive(std::span<std::byte> dst) override;
+    bool has_data() const override;
+
+  private:
+    QTcpSocket& socket_;
+};
+
+} // namespace oid
+
+#endif // IPC_TCP_TRANSPORT_H_

--- a/src/ipc/tcp_transport.h
+++ b/src/ipc/tcp_transport.h
@@ -26,7 +26,7 @@
 #ifndef IPC_TCP_TRANSPORT_H_
 #define IPC_TCP_TRANSPORT_H_
 
-#include "ipc/transport.h"
+#include "transport.h"
 
 class QTcpSocket;
 

--- a/src/ipc/transport.h
+++ b/src/ipc/transport.h
@@ -1,0 +1,44 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef IPC_TRANSPORT_H_
+#define IPC_TRANSPORT_H_
+
+#include <cstddef>
+#include <span>
+
+namespace oid {
+
+class ITransport {
+  public:
+    virtual ~ITransport() = default;
+    virtual void send(std::span<const std::byte> data) = 0;
+    virtual std::size_t receive(std::span<std::byte> dst) = 0;
+    virtual bool has_data() const = 0;
+};
+
+} // namespace oid
+
+#endif // IPC_TRANSPORT_H_

--- a/src/oid_window.cpp
+++ b/src/oid_window.cpp
@@ -27,6 +27,7 @@
 
 #include <QApplication>
 #include <QCommandLineParser>
+#include <QSurfaceFormat>
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
@@ -41,14 +42,19 @@ EM_JS(void, oid_install_js_hooks, (), {
     Module.oidEnqueueInbound(ptr, len);
     _free(ptr);
   };
-  if (window.parent !== window) {
-    window.parent.postMessage(
-        {type: 'oid-control', event: 'viewer-ready', version: 'dev'}, '*');
-  }
 });
+
 #endif
 
 int main(int argc, char* argv[]) {
+#ifdef __EMSCRIPTEN__
+    auto format = QSurfaceFormat{};
+    format.setRenderableType(QSurfaceFormat::OpenGLES);
+    format.setVersion(3, 0);
+    format.setProfile(QSurfaceFormat::CoreProfile);
+    QSurfaceFormat::setDefaultFormat(format);
+#endif
+
     auto app = QApplication{argc, argv};
 
 #ifndef __EMSCRIPTEN__

--- a/src/oid_window.cpp
+++ b/src/oid_window.cpp
@@ -35,7 +35,14 @@
 
 EM_JS(void, oid_install_js_hooks, (), {
   window.oidOnMessage = function(buf) {
-    const arr = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+    let arr;
+    if (buf instanceof Uint8Array) {
+      arr = buf;
+    } else if (Array.isArray(buf)) {
+      arr = new Uint8Array(buf);
+    } else {
+      arr = new Uint8Array(Object.values(buf));
+    }
     const len = arr.length;
     const ptr = _malloc(len);
     HEAPU8.set(arr, ptr);

--- a/src/oid_window.cpp
+++ b/src/oid_window.cpp
@@ -28,9 +28,30 @@
 #include <QApplication>
 #include <QCommandLineParser>
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#include "postmessage_transport.h"
+
+EM_JS(void, oid_install_js_hooks, (), {
+  window.oidOnMessage = function(buf) {
+    const arr = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+    const len = arr.length;
+    const ptr = _malloc(len);
+    HEAPU8.set(arr, ptr);
+    Module.oidEnqueueInbound(ptr, len);
+    _free(ptr);
+  };
+  if (window.parent !== window) {
+    window.parent.postMessage(
+        {type: 'oid-control', event: 'viewer-ready', version: 'dev'}, '*');
+  }
+});
+#endif
+
 int main(int argc, char* argv[]) {
     auto app = QApplication{argc, argv};
 
+#ifndef __EMSCRIPTEN__
     auto parser = QCommandLineParser{};
     parser.addOptions({
         {"h", "hostname", "hostname", "127.0.0.1"},
@@ -43,6 +64,10 @@ int main(int argc, char* argv[]) {
     host_settings.port = static_cast<uint16_t>(parser.value("p").toUInt());
 
     auto window = oid::MainWindow{host_settings};
+#else
+    oid_install_js_hooks();
+    auto window = oid::MainWindow{oid::ConnectionSettings{}};
+#endif
     window.showWindow();
     return QApplication::exec();
 }

--- a/src/oid_window.cpp
+++ b/src/oid_window.cpp
@@ -39,7 +39,7 @@ EM_JS(void, oid_install_js_hooks, (), {
     const len = arr.length;
     const ptr = _malloc(len);
     HEAPU8.set(arr, ptr);
-    Module.oidEnqueueInbound(ptr, len);
+    Module._oidEnqueueInbound(ptr, len);
     _free(ptr);
   };
 });

--- a/src/platform/app_platform.h
+++ b/src/platform/app_platform.h
@@ -23,21 +23,28 @@
  * IN THE SOFTWARE.
  */
 
+#ifndef PLATFORM_APP_PLATFORM_H_
+#define PLATFORM_APP_PLATFORM_H_
+
 #include "ui/main_window/main_window.h"
 
-#include <QApplication>
+namespace oid::platform {
 
-#include "platform/app_platform.h"
+/// Set up the default QSurfaceFormat (GLES 3.0 on WASM; no-op on native).
+void configure_surface_format();
 
-int main(int argc, char* argv[]) {
-    oid::platform::configure_surface_format();
+/// Parse -h / -p command-line arguments into a ConnectionSettings.
+/// On WASM there are no CLI args — returns a default-constructed value.
+ConnectionSettings parse_connection_settings(int argc, char** argv);
 
-    auto app = QApplication{argc, argv};
+/// Install JS inbound message hooks (oidOnMessage).
+/// No-op on native.
+void install_inbound_hooks();
 
-    const auto settings = oid::platform::parse_connection_settings(argc, argv);
-    oid::platform::install_inbound_hooks();
+/// WASM: emit oid_notify_viewer_ready exactly once when both flags are true.
+/// Native: no-op.
+void notify_viewer_ready_once(bool window_ready, bool first_paint_done);
 
-    auto window = oid::MainWindow{settings};
-    window.showWindow();
-    return QApplication::exec();
-}
+} // namespace oid::platform
+
+#endif // PLATFORM_APP_PLATFORM_H_

--- a/src/platform/app_platform_native.cpp
+++ b/src/platform/app_platform_native.cpp
@@ -23,21 +23,37 @@
  * IN THE SOFTWARE.
  */
 
-#include "ui/main_window/main_window.h"
-
-#include <QApplication>
-
 #include "platform/app_platform.h"
 
-int main(int argc, char* argv[]) {
-    oid::platform::configure_surface_format();
+#include <QCommandLineParser>
+#include <QCoreApplication>
 
-    auto app = QApplication{argc, argv};
+namespace oid::platform {
 
-    const auto settings = oid::platform::parse_connection_settings(argc, argv);
-    oid::platform::install_inbound_hooks();
-
-    auto window = oid::MainWindow{settings};
-    window.showWindow();
-    return QApplication::exec();
+void configure_surface_format() {
+    // No-op on native: the OpenGL format is selected automatically.
 }
+
+ConnectionSettings parse_connection_settings(int /*argc*/, char** /*argv*/) {
+    auto parser = QCommandLineParser{};
+    parser.addOptions({
+        {"h", "hostname", "hostname", "127.0.0.1"},
+        {"p", "port", "port", "9588"},
+    });
+    parser.parse(QCoreApplication::arguments());
+
+    auto settings = ConnectionSettings{};
+    settings.url  = parser.value("h").toStdString();
+    settings.port = static_cast<uint16_t>(parser.value("p").toUInt());
+    return settings;
+}
+
+void install_inbound_hooks() {
+    // No-op on native.
+}
+
+void notify_viewer_ready_once(bool /*window_ready*/, bool /*first_paint_done*/) {
+    // No-op on native.
+}
+
+} // namespace oid::platform

--- a/src/platform/app_platform_wasm.cpp
+++ b/src/platform/app_platform_wasm.cpp
@@ -1,0 +1,92 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "platform/app_platform.h"
+
+#include <emscripten.h>
+
+#include <QSurfaceFormat>
+
+// JS hook: installs window.oidOnMessage so the VS Code extension can push
+// buffers into the WASM module via Module._oidEnqueueInbound.
+EM_JS(void, oid_install_js_hooks, (), {
+  window.oidOnMessage = function(buf) {
+    let arr;
+    if (buf instanceof Uint8Array) {
+      arr = buf;
+    } else if (Array.isArray(buf)) {
+      arr = new Uint8Array(buf);
+    } else {
+      arr = new Uint8Array(Object.values(buf));
+    }
+    const len = arr.length;
+    const ptr = _malloc(len);
+    HEAPU8.set(arr, ptr);
+    Module._oidEnqueueInbound(ptr, len);
+    _free(ptr);
+  };
+});
+
+// Notifies the VS Code extension that the OID viewer is ready to receive
+// buffer data.  Fired at most once per session.
+EM_JS(void, oid_notify_viewer_ready, (), {
+  const msg = {type: 'oid-control', event: 'viewer-ready', version: 'dev'};
+  if (typeof window.oidOnViewerReady === 'function') {
+    window.oidOnViewerReady(msg);
+  }
+  if (typeof window.dispatchEvent === 'function') {
+    window.dispatchEvent(new CustomEvent('oid-viewer-ready', {detail: msg}));
+  }
+});
+
+namespace oid::platform {
+
+void configure_surface_format() {
+    auto format = QSurfaceFormat{};
+    format.setRenderableType(QSurfaceFormat::OpenGLES);
+    format.setVersion(3, 0);
+    format.setProfile(QSurfaceFormat::CoreProfile);
+    QSurfaceFormat::setDefaultFormat(format);
+}
+
+ConnectionSettings parse_connection_settings(int /*argc*/, char** /*argv*/) {
+    // WASM has no command-line arguments; connection is managed by the
+    // VS Code extension via postMessage.
+    return ConnectionSettings{};
+}
+
+void install_inbound_hooks() {
+    oid_install_js_hooks();
+}
+
+void notify_viewer_ready_once(bool window_ready, bool first_paint_done) {
+    static auto sent = false;
+    if (!sent && window_ready && first_paint_done) {
+        oid_notify_viewer_ready();
+        sent = true;
+    }
+}
+
+} // namespace oid::platform

--- a/src/platform/gl_dialect.h
+++ b/src/platform/gl_dialect.h
@@ -23,60 +23,30 @@
  * IN THE SOFTWARE.
  */
 
-#include "ui/gl_canvas.h"
+#ifndef PLATFORM_GL_DIALECT_H_
+#define PLATFORM_GL_DIALECT_H_
 
-#include <iostream>
+#include <string_view>
 
-#include "main_window/main_window.h"
-#include "ui/gl_text_renderer.h"
+#include <GL/gl.h>
+#include <QImage>
 
 namespace oid {
 
-int GLCanvas::render_width() const {
-    return width();
-}
+struct GlDialect {
+    std::string_view version_directive;
+    std::string_view fragment_preamble;
+    bool uses_out_color;
+    QImage::Format icon_image_format;
+    int icon_bytes_per_pixel;
+    bool has_texture_wrap_r;
+    GLenum icon_gl_internal_format;
+    GLenum icon_gl_format;
+    GLuint texture_internal_format(GLenum tex_type, GLenum tex_format) const;
+};
 
-int GLCanvas::render_height() const {
-    return height();
-}
-
-void GLCanvas::initializeGL() {
-    this->makeCurrent();
-    if (const auto context = this->context();
-        context == nullptr || !context->isValid()) [[unlikely]] {
-        std::cerr << "[Error] OpenGL context is not valid. OpenGL "
-                     "initialization cannot proceed."
-                  << std::endl;
-        initialized_ = false;
-        return;
-    }
-    initializeOpenGLFunctions();
-
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
-
-    init_icon_framebuffer();
-
-    // Initialize text renderer
-    if (!text_renderer_->initialize()) {
-        initialized_ = false;
-        return;
-    }
-
-    initialized_ = true;
-}
-
-void GLCanvas::paintGL() {
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    main_window().draw();
-}
-
-void GLCanvas::resizeGL(const int w, const int h) {
-    glViewport(0, 0, w, h);
-    main_window().resize_callback(w, h);
-}
-
-void GLCanvas::platform_ctor_init() {}
+const GlDialect& the_dialect();
 
 } // namespace oid
+
+#endif // PLATFORM_GL_DIALECT_H_

--- a/src/platform/gl_dialect_native.cpp
+++ b/src/platform/gl_dialect_native.cpp
@@ -23,60 +23,28 @@
  * IN THE SOFTWARE.
  */
 
-#include "ui/gl_canvas.h"
-
-#include <iostream>
-
-#include "main_window/main_window.h"
-#include "ui/gl_text_renderer.h"
+#include "platform/gl_dialect.h"
 
 namespace oid {
 
-int GLCanvas::render_width() const {
-    return width();
+GLuint GlDialect::texture_internal_format(GLenum /*tex_type*/,
+                                          GLenum /*tex_format*/) const
+{
+    return GL_RGBA32F;
 }
 
-int GLCanvas::render_height() const {
-    return height();
+const GlDialect& the_dialect() {
+    static const GlDialect dialect{
+        .version_directive        = "#version 120\n",
+        .fragment_preamble        = "",
+        .uses_out_color           = false,
+        .icon_image_format        = QImage::Format_RGB888,
+        .icon_bytes_per_pixel     = 3,
+        .has_texture_wrap_r       = true,
+        .icon_gl_internal_format  = GL_RGB8,
+        .icon_gl_format           = GL_RGB,
+    };
+    return dialect;
 }
-
-void GLCanvas::initializeGL() {
-    this->makeCurrent();
-    if (const auto context = this->context();
-        context == nullptr || !context->isValid()) [[unlikely]] {
-        std::cerr << "[Error] OpenGL context is not valid. OpenGL "
-                     "initialization cannot proceed."
-                  << std::endl;
-        initialized_ = false;
-        return;
-    }
-    initializeOpenGLFunctions();
-
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
-
-    init_icon_framebuffer();
-
-    // Initialize text renderer
-    if (!text_renderer_->initialize()) {
-        initialized_ = false;
-        return;
-    }
-
-    initialized_ = true;
-}
-
-void GLCanvas::paintGL() {
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    main_window().draw();
-}
-
-void GLCanvas::resizeGL(const int w, const int h) {
-    glViewport(0, 0, w, h);
-    main_window().resize_callback(w, h);
-}
-
-void GLCanvas::platform_ctor_init() {}
 
 } // namespace oid

--- a/src/platform/gl_dialect_wasm.cpp
+++ b/src/platform/gl_dialect_wasm.cpp
@@ -23,60 +23,51 @@
  * IN THE SOFTWARE.
  */
 
-#include "ui/gl_canvas.h"
-
-#include <iostream>
-
-#include "main_window/main_window.h"
-#include "ui/gl_text_renderer.h"
+#include "platform/gl_dialect.h"
 
 namespace oid {
 
-int GLCanvas::render_width() const {
-    return width();
-}
-
-int GLCanvas::render_height() const {
-    return height();
-}
-
-void GLCanvas::initializeGL() {
-    this->makeCurrent();
-    if (const auto context = this->context();
-        context == nullptr || !context->isValid()) [[unlikely]] {
-        std::cerr << "[Error] OpenGL context is not valid. OpenGL "
-                     "initialization cannot proceed."
-                  << std::endl;
-        initialized_ = false;
-        return;
+GLuint GlDialect::texture_internal_format(GLenum tex_type,
+                                          GLenum tex_format) const
+{
+    if (tex_type == GL_FLOAT) {
+        if (tex_format == GL_RED) {
+            return GL_R32F;
+        }
+        if (tex_format == GL_RG) {
+            return GL_RG32F;
+        }
+        if (tex_format == GL_RGB) {
+            return GL_RGB32F;
+        }
+        return GL_RGBA32F;
     }
-    initializeOpenGLFunctions();
-
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
-
-    init_icon_framebuffer();
-
-    // Initialize text renderer
-    if (!text_renderer_->initialize()) {
-        initialized_ = false;
-        return;
+    if (tex_format == GL_RED) {
+        return GL_R8;
     }
-
-    initialized_ = true;
+    if (tex_format == GL_RG) {
+        return GL_RG8;
+    }
+    if (tex_format == GL_RGB) {
+        return GL_RGB8;
+    }
+    return GL_RGBA8;
 }
 
-void GLCanvas::paintGL() {
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    main_window().draw();
+const GlDialect& the_dialect() {
+    static const GlDialect dialect{
+        .version_directive        = "#version 300 es\n",
+        .fragment_preamble        = "precision mediump float;\n"
+                                    "precision mediump int;\n"
+                                    "out vec4 oid_fragColor;\n",
+        .uses_out_color           = true,
+        .icon_image_format        = QImage::Format_RGBA8888,
+        .icon_bytes_per_pixel     = 4,
+        .has_texture_wrap_r       = false,
+        .icon_gl_internal_format  = GL_RGBA8,
+        .icon_gl_format           = GL_RGBA,
+    };
+    return dialect;
 }
-
-void GLCanvas::resizeGL(const int w, const int h) {
-    glViewport(0, 0, w, h);
-    main_window().resize_callback(w, h);
-}
-
-void GLCanvas::platform_ctor_init() {}
 
 } // namespace oid

--- a/src/platform/platform_config.h
+++ b/src/platform/platform_config.h
@@ -1,0 +1,39 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef PLATFORM_PLATFORM_CONFIG_H_
+#define PLATFORM_PLATFORM_CONFIG_H_
+
+namespace oid::platform {
+
+#ifdef __EMSCRIPTEN__
+inline constexpr bool kIsWasm = true;
+#else
+inline constexpr bool kIsWasm = false;
+#endif
+
+}  // namespace oid::platform
+
+#endif  // PLATFORM_PLATFORM_CONFIG_H_

--- a/src/platform/postmessage_transport.cpp
+++ b/src/platform/postmessage_transport.cpp
@@ -23,7 +23,7 @@
  * IN THE SOFTWARE.
  */
 
-#include "postmessage_transport.h"
+#include "platform/postmessage_transport.h"
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>

--- a/src/platform/postmessage_transport.h
+++ b/src/platform/postmessage_transport.h
@@ -35,7 +35,7 @@
 #include <emscripten.h>
 #endif
 
-#include "transport.h"
+#include "ipc/transport.h"
 
 namespace oid {
 

--- a/src/platform/render_scheduler.h
+++ b/src/platform/render_scheduler.h
@@ -1,0 +1,52 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef PLATFORM_RENDER_SCHEDULER_H_
+#define PLATFORM_RENDER_SCHEDULER_H_
+
+#include <functional>
+#include <memory>
+
+namespace oid {
+
+class GLCanvas;
+
+class RenderScheduler {
+  public:
+    virtual ~RenderScheduler() = default;
+
+    // Runs GL work on the GL thread/context: immediately on native,
+    // deferred via QRhi render callback on WASM.
+    virtual void run_gl(std::function<void()> task) = 0;
+    virtual void run_icon_gl(std::function<void()> task) = 0;
+};
+
+namespace platform {
+std::unique_ptr<RenderScheduler> make_render_scheduler(GLCanvas& canvas);
+} // namespace platform
+
+} // namespace oid
+
+#endif // PLATFORM_RENDER_SCHEDULER_H_

--- a/src/platform/render_scheduler_native.cpp
+++ b/src/platform/render_scheduler_native.cpp
@@ -1,0 +1,47 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "platform/render_scheduler.h"
+
+namespace oid {
+
+namespace {
+
+class ImmediateScheduler final : public RenderScheduler {
+  public:
+    void run_gl(std::function<void()> task) override { task(); }
+    void run_icon_gl(std::function<void()> task) override { task(); }
+};
+
+} // namespace
+
+namespace platform {
+
+std::unique_ptr<RenderScheduler> make_render_scheduler(GLCanvas& /*canvas*/) {
+    return std::make_unique<ImmediateScheduler>();
+}
+
+} // namespace platform
+} // namespace oid

--- a/src/platform/render_scheduler_wasm.cpp
+++ b/src/platform/render_scheduler_wasm.cpp
@@ -1,0 +1,59 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "platform/render_scheduler.h"
+
+#include "ui/gl_canvas.h"
+
+namespace oid {
+
+namespace {
+
+class DeferredScheduler final : public RenderScheduler {
+  public:
+    explicit DeferredScheduler(GLCanvas& canvas) : canvas_{canvas} {}
+
+    void run_gl(std::function<void()> task) override {
+        canvas_.schedule_gl(std::move(task));
+    }
+
+    void run_icon_gl(std::function<void()> task) override {
+        canvas_.schedule_icon_gl(std::move(task));
+    }
+
+  private:
+    GLCanvas& canvas_;
+};
+
+} // namespace
+
+namespace platform {
+
+std::unique_ptr<RenderScheduler> make_render_scheduler(GLCanvas& canvas) {
+    return std::make_unique<DeferredScheduler>(canvas);
+}
+
+} // namespace platform
+} // namespace oid

--- a/src/platform/session_persistence.h
+++ b/src/platform/session_persistence.h
@@ -1,0 +1,42 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef PLATFORM_SESSION_PERSISTENCE_H_
+#define PLATFORM_SESSION_PERSISTENCE_H_
+
+#include "ipc/transport.h"
+#include "ui/messaging/session_state_codec.h"
+
+namespace oid::platform {
+
+void persist_session(const SettingsManager::DataCallbacks& callbacks,
+                     const SessionStateExtraInputs& extra,
+                     ITransport* transport);
+
+void load_settings_if_local(SettingsManager& mgr);
+
+} // namespace oid::platform
+
+#endif // PLATFORM_SESSION_PERSISTENCE_H_

--- a/src/platform/session_persistence_native.cpp
+++ b/src/platform/session_persistence_native.cpp
@@ -1,0 +1,38 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "platform/session_persistence.h"
+
+namespace oid::platform {
+
+void persist_session(const SettingsManager::DataCallbacks& callbacks,
+                     const SessionStateExtraInputs& /*extra*/,
+                     ITransport* /*transport*/) {
+    SettingsManager::persist_settings(callbacks);
+}
+
+void load_settings_if_local(SettingsManager& mgr) { mgr.load_settings(); }
+
+} // namespace oid::platform

--- a/src/platform/session_persistence_wasm.cpp
+++ b/src/platform/session_persistence_wasm.cpp
@@ -1,0 +1,45 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "platform/session_persistence.h"
+
+#include "ipc/message_exchange.h"
+
+namespace oid::platform {
+
+void persist_session(const SettingsManager::DataCallbacks& callbacks,
+                     const SessionStateExtraInputs& extra,
+                     ITransport* transport) {
+    const auto json = serialize_session_state_delta(callbacks, extra);
+    auto composer = MessageComposer{};
+    composer.push(MessageType::SessionStateChanged)
+        .push(std::string(json.constData(),
+                          static_cast<std::size_t>(json.size())))
+        .send(*transport);
+}
+
+void load_settings_if_local(SettingsManager& /*mgr*/) {}
+
+} // namespace oid::platform

--- a/src/platform/transport_factory.h
+++ b/src/platform/transport_factory.h
@@ -1,0 +1,49 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef PLATFORM_TRANSPORT_FACTORY_H_
+#define PLATFORM_TRANSPORT_FACTORY_H_
+
+#include <memory>
+
+class QTcpSocket;
+
+namespace oid {
+class ITransport;
+namespace platform {
+
+struct TransportDeps {
+    QTcpSocket& socket; // ignored on WASM, used by the native TCP transport
+};
+
+std::unique_ptr<ITransport> make_transport(const TransportDeps& deps);
+
+// True only on native when the TCP socket has dropped; always false on WASM.
+bool should_quit_on_disconnect(QTcpSocket& socket);
+
+} // namespace platform
+} // namespace oid
+
+#endif // PLATFORM_TRANSPORT_FACTORY_H_

--- a/src/platform/transport_factory_native.cpp
+++ b/src/platform/transport_factory_native.cpp
@@ -1,0 +1,42 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "platform/transport_factory.h"
+
+#include <QTcpSocket>
+
+#include "ipc/tcp_transport.h"
+
+namespace oid::platform {
+
+std::unique_ptr<ITransport> make_transport(const TransportDeps& deps) {
+    return std::make_unique<TcpTransport>(deps.socket);
+}
+
+bool should_quit_on_disconnect(QTcpSocket& socket) {
+    return socket.state() == QAbstractSocket::UnconnectedState;
+}
+
+} // namespace oid::platform

--- a/src/platform/transport_factory_wasm.cpp
+++ b/src/platform/transport_factory_wasm.cpp
@@ -25,7 +25,7 @@
 
 #include "platform/transport_factory.h"
 
-#include "ipc/postmessage_transport.h"
+#include "platform/postmessage_transport.h"
 
 namespace oid::platform {
 

--- a/src/platform/transport_factory_wasm.cpp
+++ b/src/platform/transport_factory_wasm.cpp
@@ -1,0 +1,42 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "platform/transport_factory.h"
+
+#include "ipc/postmessage_transport.h"
+
+namespace oid::platform {
+
+std::unique_ptr<ITransport> make_transport(const TransportDeps& /*deps*/) {
+    auto transport = std::make_unique<PostMessageTransport>();
+    oid_set_postmessage_transport(transport.get());
+    return transport;
+}
+
+bool should_quit_on_disconnect(QTcpSocket& /*socket*/) {
+    return false;
+}
+
+} // namespace oid::platform

--- a/src/ui/events/event_handler.cpp
+++ b/src/ui/events/event_handler.cpp
@@ -343,6 +343,10 @@ void UIEventHandler::remove_selected_buffer() {
 
         deps_.buffer_data.removed_buffer_names.insert(buffer_name);
 
+        // Notify the host (VS Code extension on WASM) so it can drop the buffer
+        // from the persisted set immediately. Connected only under EMSCRIPTEN.
+        emit bufferRemoved(QString::fromStdString(buffer_name));
+
         if (deps_.buffer_data.stages.empty()) {
             emit shiftPrecisionUpdateRequested();
         }

--- a/src/ui/events/event_handler.cpp
+++ b/src/ui/events/event_handler.cpp
@@ -35,6 +35,7 @@
 #include <QWidget>
 
 #include "io/buffer_exporter.h"
+#include "platform/platform_config.h"
 #include "ui/main_window/main_window.h"
 #include "visualization/components/buffer.h"
 #include "visualization/components/buffer_values.h"
@@ -376,7 +377,6 @@ void UIEventHandler::symbol_completed(const QString& str) {
 }
 
 void UIEventHandler::export_buffer(const QString& buffer_name) {
-#ifdef __EMSCRIPTEN__
     const auto lock = std::unique_lock{deps_.ui_mutex};
     const auto stage_it =
         deps_.buffer_data.stages.find(buffer_name.toStdString());
@@ -396,73 +396,54 @@ void UIEventHandler::export_buffer(const QString& buffer_name) {
     }
     const auto& component = component_opt->get();
 
-    const auto* bc = component.auto_buffer_contrast_brightness();
-    auto contrast = QList<float>{};
-    contrast.reserve(8);
-    for (int i = 0; i < 8; ++i) {
-        contrast.append(bc[i]);
-    }
+    if constexpr (platform::kIsWasm) {
+        const auto* bc = component.auto_buffer_contrast_brightness();
+        auto contrast = QList<float>{};
+        contrast.reserve(8);
+        for (int i = 0; i < 8; ++i) {
+            contrast.append(bc[i]);
+        }
 
-    // QFileDialog::exec() uses a nested event loop, which is unsupported on WASM.
-    emit exportBufferRequested(buffer_name, 0, contrast);
-    return;
-#else
-    const auto lock = std::unique_lock{deps_.ui_mutex};
-    const auto stage_it =
-        deps_.buffer_data.stages.find(buffer_name.toStdString());
-    if (stage_it == deps_.buffer_data.stages.end()) {
-        return;
-    }
+        // QFileDialog::exec() uses a nested event loop, which is unsupported on WASM.
+        emit exportBufferRequested(buffer_name, 0, contrast);
+    } else {
+        auto file_dialog = QFileDialog{deps_.ui_components.ui->bufferPreview};
+        file_dialog.setAcceptMode(QFileDialog::AcceptSave);
+        file_dialog.setFileMode(QFileDialog::AnyFile);
 
-    const auto stage = stage_it->second;
-    const auto buffer_obj = stage->get_game_object("buffer");
-    if (!buffer_obj.has_value()) {
-        return;
-    }
-    const auto component_opt =
-        buffer_obj->get().get_component<Buffer>("buffer_component");
-    if (!component_opt.has_value()) {
-        return;
-    }
-    const auto& component = component_opt->get();
+        auto output_extensions = QHash<QString, BufferExporter::OutputType>{};
+        output_extensions[QObject::tr("Image File (*.png)")] =
+            BufferExporter::OutputType::Bitmap;
+        output_extensions[QObject::tr("Octave Raw Matrix (*.oct)")] =
+            BufferExporter::OutputType::OctaveMatrix;
 
-    auto file_dialog = QFileDialog{deps_.ui_components.ui->bufferPreview};
-    file_dialog.setAcceptMode(QFileDialog::AcceptSave);
-    file_dialog.setFileMode(QFileDialog::AnyFile);
+        auto it = QHashIterator{output_extensions};
 
-    auto output_extensions = QHash<QString, BufferExporter::OutputType>{};
-    output_extensions[QObject::tr("Image File (*.png)")] =
-        BufferExporter::OutputType::Bitmap;
-    output_extensions[QObject::tr("Octave Raw Matrix (*.oct)")] =
-        BufferExporter::OutputType::OctaveMatrix;
+        auto save_message = QString{};
 
-    auto it = QHashIterator{output_extensions};
+        while (it.hasNext()) {
+            it.next();
+            save_message += it.key();
+            if (it.hasNext()) {
+                save_message += ";;";
+            }
+        }
 
-    auto save_message = QString{};
+        file_dialog.setNameFilter(save_message);
+        file_dialog.selectNameFilter(deps_.default_export_suffix);
 
-    while (it.hasNext()) {
-        it.next();
-        save_message += it.key();
-        if (it.hasNext()) {
-            save_message += ";;";
+        if (file_dialog.exec() == QDialog::Accepted) {
+            const auto file_name = file_dialog.selectedFiles()[0].toStdString();
+            const auto selected_filter = file_dialog.selectedNameFilter();
+
+            BufferExporter::export_buffer(
+                component, file_name, output_extensions[selected_filter]);
+
+            deps_.default_export_suffix = selected_filter;
+
+            emit settingsPersistenceRequested();
         }
     }
-
-    file_dialog.setNameFilter(save_message);
-    file_dialog.selectNameFilter(deps_.default_export_suffix);
-
-    if (file_dialog.exec() == QDialog::Accepted) {
-        const auto file_name = file_dialog.selectedFiles()[0].toStdString();
-        const auto selected_filter = file_dialog.selectedNameFilter();
-
-        BufferExporter::export_buffer(
-            component, file_name, output_extensions[selected_filter]);
-
-        deps_.default_export_suffix = selected_filter;
-
-        emit settingsPersistenceRequested();
-    }
-#endif
 }
 
 void UIEventHandler::export_selected_buffer() {
@@ -488,21 +469,21 @@ void UIEventHandler::show_context_menu(const QPoint& pos) {
     const auto buffer_name =
         deps_.ui_components.ui->imageList->itemAt(pos)->data(Qt::UserRole);
 
-#ifdef __EMSCRIPTEN__
-    // popup() is async; a stack QMenu is destroyed before the menu can paint.
-    auto* menu = new QMenu(deps_.ui_components.ui->imageList);
-    menu->setAttribute(Qt::WA_DeleteOnClose);
-    menu->addAction("Export buffer", [this, buffer_name] {
-        export_buffer(buffer_name.toString());
-    });
-    menu->popup(globalPos);
-#else
-    auto menu = QMenu{deps_.ui_components.ui->imageList};
-    menu.addAction("Export buffer", [this, buffer_name] {
-        export_buffer(buffer_name.toString());
-    });
-    menu.exec(globalPos);
-#endif
+    if constexpr (platform::kIsWasm) {
+        // popup() is async; a stack QMenu is destroyed before the menu can paint.
+        auto* menu = new QMenu(deps_.ui_components.ui->imageList);
+        menu->setAttribute(Qt::WA_DeleteOnClose);
+        menu->addAction("Export buffer", [this, buffer_name] {
+            export_buffer(buffer_name.toString());
+        });
+        menu->popup(globalPos);
+    } else {
+        auto menu = QMenu{deps_.ui_components.ui->imageList};
+        menu.addAction("Export buffer", [this, buffer_name] {
+            export_buffer(buffer_name.toString());
+        });
+        menu.exec(globalPos);
+    }
 }
 
 void UIEventHandler::toggle_go_to_dialog() const {

--- a/src/ui/events/event_handler.cpp
+++ b/src/ui/events/event_handler.cpp
@@ -29,6 +29,7 @@
 #include <ranges>
 
 #include <QFileDialog>
+#include <QMenu>
 #include <QPoint>
 #include <QString>
 #include <QWidget>
@@ -474,25 +475,30 @@ void UIEventHandler::export_selected_buffer() {
 }
 
 void UIEventHandler::show_context_menu(const QPoint& pos) {
-    if (deps_.ui_components.ui->imageList->itemAt(pos) != nullptr) {
-        const auto globalPos =
-            deps_.ui_components.ui->imageList->mapToGlobal(pos);
+    if (deps_.ui_components.ui->imageList->itemAt(pos) == nullptr) {
+        return;
+    }
+    const auto globalPos =
+        deps_.ui_components.ui->imageList->mapToGlobal(pos);
 
-        auto menu = QMenu{deps_.ui_components.ui->imageList};
-
-        const auto buffer_name =
-            deps_.ui_components.ui->imageList->itemAt(pos)->data(Qt::UserRole);
-        menu.addAction("Export buffer", [this, buffer_name] {
-            export_buffer(buffer_name.toString());
-        });
+    const auto buffer_name =
+        deps_.ui_components.ui->imageList->itemAt(pos)->data(Qt::UserRole);
 
 #ifdef __EMSCRIPTEN__
-        // QMenu::exec() uses a nested event loop, which is unsupported on WASM.
-        menu.popup(globalPos);
+    // popup() is async; a stack QMenu is destroyed before the menu can paint.
+    auto* menu = new QMenu(deps_.ui_components.ui->imageList);
+    menu->setAttribute(Qt::WA_DeleteOnClose);
+    menu->addAction("Export buffer", [this, buffer_name] {
+        export_buffer(buffer_name.toString());
+    });
+    menu->popup(globalPos);
 #else
-        menu.exec(globalPos);
+    auto menu = QMenu{deps_.ui_components.ui->imageList};
+    menu.addAction("Export buffer", [this, buffer_name] {
+        export_buffer(buffer_name.toString());
+    });
+    menu.exec(globalPos);
 #endif
-    }
 }
 
 void UIEventHandler::toggle_go_to_dialog() const {

--- a/src/ui/events/event_handler.cpp
+++ b/src/ui/events/event_handler.cpp
@@ -372,11 +372,36 @@ void UIEventHandler::symbol_completed(const QString& str) {
 
 void UIEventHandler::export_buffer(const QString& buffer_name) {
 #ifdef __EMSCRIPTEN__
-    // QFileDialog::exec() uses a nested event loop, which is unsupported on WASM.
-    emit exportBufferRequested(buffer_name);
-    return;
-#endif
+    const auto lock = std::unique_lock{deps_.ui_mutex};
+    const auto stage_it =
+        deps_.buffer_data.stages.find(buffer_name.toStdString());
+    if (stage_it == deps_.buffer_data.stages.end()) {
+        return;
+    }
 
+    const auto stage = stage_it->second;
+    const auto buffer_obj = stage->get_game_object("buffer");
+    if (!buffer_obj.has_value()) {
+        return;
+    }
+    const auto component_opt =
+        buffer_obj->get().get_component<Buffer>("buffer_component");
+    if (!component_opt.has_value()) {
+        return;
+    }
+    const auto& component = component_opt->get();
+
+    const auto* bc = component.auto_buffer_contrast_brightness();
+    auto contrast = QList<float>{};
+    contrast.reserve(8);
+    for (int i = 0; i < 8; ++i) {
+        contrast.append(bc[i]);
+    }
+
+    // QFileDialog::exec() uses a nested event loop, which is unsupported on WASM.
+    emit exportBufferRequested(buffer_name, 0, contrast);
+    return;
+#else
     const auto lock = std::unique_lock{deps_.ui_mutex};
     const auto stage_it =
         deps_.buffer_data.stages.find(buffer_name.toStdString());
@@ -432,6 +457,7 @@ void UIEventHandler::export_buffer(const QString& buffer_name) {
 
         emit settingsPersistenceRequested();
     }
+#endif
 }
 
 void UIEventHandler::show_context_menu(const QPoint& pos) {

--- a/src/ui/events/event_handler.cpp
+++ b/src/ui/events/event_handler.cpp
@@ -460,6 +460,19 @@ void UIEventHandler::export_buffer(const QString& buffer_name) {
 #endif
 }
 
+void UIEventHandler::export_selected_buffer() {
+    QString name;
+    {
+        const auto lock = std::unique_lock{deps_.ui_mutex};
+        const auto* item = deps_.ui_components.ui->imageList->currentItem();
+        if (item == nullptr) {
+            return;
+        }
+        name = item->data(Qt::UserRole).toString();
+    }
+    export_buffer(name);
+}
+
 void UIEventHandler::show_context_menu(const QPoint& pos) {
     if (deps_.ui_components.ui->imageList->itemAt(pos) != nullptr) {
         const auto globalPos =

--- a/src/ui/events/event_handler.cpp
+++ b/src/ui/events/event_handler.cpp
@@ -371,6 +371,12 @@ void UIEventHandler::symbol_completed(const QString& str) {
 }
 
 void UIEventHandler::export_buffer(const QString& buffer_name) {
+#ifdef __EMSCRIPTEN__
+    // QFileDialog::exec() uses a nested event loop, which is unsupported on WASM.
+    emit exportBufferRequested(buffer_name);
+    return;
+#endif
+
     const auto lock = std::unique_lock{deps_.ui_mutex};
     const auto stage_it =
         deps_.buffer_data.stages.find(buffer_name.toStdString());
@@ -441,7 +447,12 @@ void UIEventHandler::show_context_menu(const QPoint& pos) {
             export_buffer(buffer_name.toString());
         });
 
+#ifdef __EMSCRIPTEN__
+        // QMenu::exec() uses a nested event loop, which is unsupported on WASM.
+        menu.popup(globalPos);
+#else
         menu.exec(globalPos);
+#endif
     }
 }
 

--- a/src/ui/events/event_handler.h
+++ b/src/ui/events/event_handler.h
@@ -95,6 +95,7 @@ class UIEventHandler : public QObject {
     void acMaxLabelsResetRequested();
     void shiftPrecisionUpdateRequested();
     void settingsPersistenceRequested();
+    void exportBufferRequested(const QString& buffer_name);
 
   private:
     Dependencies deps_;

--- a/src/ui/events/event_handler.h
+++ b/src/ui/events/event_handler.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <mutex>
 
+#include <QList>
 #include <QObject>
 #include <QString>
 
@@ -95,7 +96,8 @@ class UIEventHandler : public QObject {
     void acMaxLabelsResetRequested();
     void shiftPrecisionUpdateRequested();
     void settingsPersistenceRequested();
-    void exportBufferRequested(const QString& buffer_name);
+    void exportBufferRequested(const QString& buffer_name, int format,
+                               const QList<float>& contrast);
 
   private:
     Dependencies deps_;

--- a/src/ui/events/event_handler.h
+++ b/src/ui/events/event_handler.h
@@ -99,6 +99,7 @@ class UIEventHandler : public QObject {
     void settingsPersistenceRequested();
     void exportBufferRequested(const QString& buffer_name, int format,
                                const QList<float>& contrast);
+    void bufferRemoved(const QString& buffer_name);
 
   private:
     Dependencies deps_;

--- a/src/ui/events/event_handler.h
+++ b/src/ui/events/event_handler.h
@@ -80,6 +80,7 @@ class UIEventHandler : public QObject {
     void symbol_selected();
     void symbol_completed(const QString& str);
     void export_buffer(const QString& buffer_name);
+    void export_selected_buffer();
     void show_context_menu(const QPoint& pos);
     void toggle_go_to_dialog() const;
     void go_to_pixel(float x, float y) const;

--- a/src/ui/gl_canvas.cpp
+++ b/src/ui/gl_canvas.cpp
@@ -134,7 +134,7 @@ void GLCanvas::initializeGL() {
         return;
     }
 
-    glBindFramebuffer(GL_FRAMEBUFFER_EXT, 0);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
     // Initialize text renderer
     if (!text_renderer_->initialize()) {
@@ -162,7 +162,7 @@ const GLTextRenderer* GLCanvas::get_text_renderer() const {
 void GLCanvas::render_buffer_icon(Stage& stage,
                                   const int icon_width,
                                   const int icon_height) {
-    glBindFramebuffer(GL_FRAMEBUFFER_EXT, icon_fbo_);
+    glBindFramebuffer(GL_FRAMEBUFFER, icon_fbo_);
 
     glViewport(0, 0, icon_width, icon_height);
 
@@ -208,7 +208,7 @@ void GLCanvas::render_buffer_icon(Stage& stage,
 
     // Reset stage camera
     stage.set_icon_drawing_mode(false);
-    glBindFramebuffer(GL_FRAMEBUFFER_EXT, 0);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
     glViewport(0, 0, width(), height());
     cam = original_pose;
     cam.window_resized(width(), height());

--- a/src/ui/gl_canvas.cpp
+++ b/src/ui/gl_canvas.cpp
@@ -25,6 +25,7 @@
 
 #include "gl_canvas.h"
 
+#include <cmath>
 #include <iostream>
 
 #ifdef __EMSCRIPTEN__
@@ -62,8 +63,12 @@ void GLCanvas::mouseMoveEvent(QMouseEvent* ev) {
     const auto last_mouse_x = mouse_x_;
     const auto last_mouse_y = mouse_y_;
 
-    mouse_x_ = static_cast<int>(ev->position().x());
-    mouse_y_ = static_cast<int>(ev->position().y());
+    const auto scale_x =
+        static_cast<float>(render_width()) / static_cast<float>(qMax(1, width()));
+    const auto scale_y = static_cast<float>(render_height()) /
+                         static_cast<float>(qMax(1, height()));
+    mouse_x_ = static_cast<int>(ev->position().x() * scale_x);
+    mouse_y_ = static_cast<int>(ev->position().y() * scale_y);
 
     if (mouse_down_[0]) {
         main_window().mouse_drag_event(mouse_x_ - last_mouse_x,
@@ -95,6 +100,20 @@ void GLCanvas::mouseReleaseEvent(QMouseEvent* ev) {
 }
 
 #ifdef __EMSCRIPTEN__
+
+int GLCanvas::render_width() const {
+    if (const auto* tex = colorTexture(); tex != nullptr) {
+        return tex->pixelSize().width();
+    }
+    return static_cast<int>(std::lround(width() * devicePixelRatioF()));
+}
+
+int GLCanvas::render_height() const {
+    if (const auto* tex = colorTexture(); tex != nullptr) {
+        return tex->pixelSize().height();
+    }
+    return static_cast<int>(std::lround(height() * devicePixelRatioF()));
+}
 
 bool GLCanvas::init_gl_state() {
     glEnable(GL_BLEND);
@@ -154,7 +173,14 @@ void GLCanvas::render(QRhiCommandBuffer* cb) {
 
     drain_gl_queue();
 
-    glViewport(0, 0, width(), height());
+    const auto w = render_width();
+    const auto h = render_height();
+    glViewport(0, 0, w, h);
+    if (w != last_render_width_ || h != last_render_height_) {
+        last_render_width_ = w;
+        last_render_height_ = h;
+        main_window().resize_callback(w, h);
+    }
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     main_window().draw();
 
@@ -167,13 +193,13 @@ void GLCanvas::render(QRhiCommandBuffer* cb) {
 void GLCanvas::releaseResources() {
     initialized_ = false;
     first_paint_completed_ = false;
+    last_render_width_ = 0;
+    last_render_height_ = 0;
 }
 
 void GLCanvas::resizeEvent(QResizeEvent* e) {
     QRhiWidget::resizeEvent(e);
-    if (initialized_) {
-        main_window().resize_callback(width(), height());
-    }
+    update();
 }
 
 void GLCanvas::schedule_gl(std::function<void()> task) {
@@ -190,6 +216,14 @@ void GLCanvas::drain_gl_queue() {
 }
 
 #else
+
+int GLCanvas::render_width() const {
+    return width();
+}
+
+int GLCanvas::render_height() const {
+    return height();
+}
 
 void GLCanvas::initializeGL() {
     this->makeCurrent();

--- a/src/ui/gl_canvas.cpp
+++ b/src/ui/gl_canvas.cpp
@@ -27,7 +27,9 @@
 
 #include <iostream>
 
+#ifdef __EMSCRIPTEN__
 #include <rhi/qrhi.h>
+#endif
 
 #include "main_window/main_window.h"
 #include "ui/gl_text_renderer.h"

--- a/src/ui/gl_canvas.cpp
+++ b/src/ui/gl_canvas.cpp
@@ -28,10 +28,6 @@
 #include <cmath>
 #include <iostream>
 
-#ifdef __EMSCRIPTEN__
-#include <rhi/qrhi.h>
-#endif
-
 #include "main_window/main_window.h"
 #include "ui/gl_text_renderer.h"
 #include "visualization/components/camera.h"
@@ -41,20 +37,10 @@
 namespace oid {
 
 GLCanvas::GLCanvas(QWidget* parent)
-#ifdef __EMSCRIPTEN__
-    : QRhiWidget{parent},
-#else
-    : QOpenGLWidget{parent},
-#endif
+    : GlWidgetBase{parent},
       text_renderer_{std::make_unique<GLTextRenderer>(*this)} {
     mouse_down_[0] = mouse_down_[1] = false;
-#ifdef __EMSCRIPTEN__
-    setApi(Api::OpenGL);
-    connect(this, &QRhiWidget::renderFailed, this, [this] {
-        initialized_ = false;
-        first_paint_completed_ = false;
-    });
-#endif
+    platform_ctor_init();
 }
 
 GLCanvas::~GLCanvas() = default;
@@ -161,189 +147,6 @@ void GLCanvas::destroy_icon_framebuffer() {
     }
     icon_framebuffer_ready_ = false;
 }
-
-#ifdef __EMSCRIPTEN__
-
-int GLCanvas::render_width() const {
-    if (const auto* tex = colorTexture(); tex != nullptr) {
-        return tex->pixelSize().width();
-    }
-    return static_cast<int>(std::lround(width() * devicePixelRatioF()));
-}
-
-int GLCanvas::render_height() const {
-    if (const auto* tex = colorTexture(); tex != nullptr) {
-        return tex->pixelSize().height();
-    }
-    return static_cast<int>(std::lround(height() * devicePixelRatioF()));
-}
-
-bool GLCanvas::init_gl_state() {
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
-
-    if (!text_renderer_->initialize()) {
-        return false;
-    }
-
-    return true;
-}
-
-void GLCanvas::initialize(QRhiCommandBuffer* cb) {
-    static QRhi* last_rhi = nullptr;
-    if (last_rhi != rhi()) {
-        initialized_ = false;
-        first_paint_completed_ = false;
-        last_rhi = rhi();
-    }
-    if (initialized_) {
-        return;
-    }
-
-    const auto clear_color = QColor::fromRgbF(0.1f, 0.1f, 0.1f, 1.0f);
-    cb->beginPass(renderTarget(),
-                  clear_color,
-                  {1.0f, 0},
-                  nullptr,
-                  QRhiCommandBuffer::ExternalContent);
-    cb->beginExternal();
-    initializeOpenGLFunctions();
-
-    if (!init_gl_state()) {
-        cb->endExternal();
-        cb->endPass();
-        return;
-    }
-
-    init_icon_framebuffer();
-
-    cb->endExternal();
-    cb->endPass();
-    initialized_ = true;
-}
-
-void GLCanvas::render(QRhiCommandBuffer* cb) {
-    if (!initialized_) {
-        return;
-    }
-
-    const auto clear_color = QColor::fromRgbF(0.1f, 0.1f, 0.1f, 1.0f);
-    cb->beginPass(renderTarget(),
-                  clear_color,
-                  {1.0f, 0},
-                  nullptr,
-                  QRhiCommandBuffer::ExternalContent);
-    cb->beginExternal();
-
-    drain_gl_queue();
-
-    const auto w = render_width();
-    const auto h = render_height();
-    glViewport(0, 0, w, h);
-    if (w != last_render_width_ || h != last_render_height_) {
-        last_render_width_ = w;
-        last_render_height_ = h;
-        main_window().resize_callback(w, h);
-    }
-    main_window().prepare_gl_draw();
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    main_window().draw();
-    drain_icon_gl_queue();
-
-    cb->endExternal();
-    cb->endPass();
-
-    first_paint_completed_ = true;
-}
-
-void GLCanvas::releaseResources() {
-    initialized_ = false;
-    first_paint_completed_ = false;
-    last_render_width_ = 0;
-    last_render_height_ = 0;
-    destroy_icon_framebuffer();
-}
-
-void GLCanvas::resizeEvent(QResizeEvent* e) {
-    QRhiWidget::resizeEvent(e);
-    update();
-}
-
-void GLCanvas::schedule_gl(std::function<void()> task) {
-    gl_queue_.push_back(std::move(task));
-    update();
-}
-
-void GLCanvas::schedule_icon_gl(std::function<void()> task) {
-    icon_gl_queue_.push_back(std::move(task));
-    update();
-}
-
-void GLCanvas::drain_gl_queue() {
-    while (!gl_queue_.empty()) {
-        auto task = std::move(gl_queue_.front());
-        gl_queue_.pop_front();
-        task();
-    }
-}
-
-void GLCanvas::drain_icon_gl_queue() {
-    while (!icon_gl_queue_.empty()) {
-        auto task = std::move(icon_gl_queue_.front());
-        icon_gl_queue_.pop_front();
-        task();
-    }
-}
-
-#else
-
-int GLCanvas::render_width() const {
-    return width();
-}
-
-int GLCanvas::render_height() const {
-    return height();
-}
-
-void GLCanvas::initializeGL() {
-    this->makeCurrent();
-    if (const auto context = this->context();
-        context == nullptr || !context->isValid()) [[unlikely]] {
-        std::cerr << "[Error] OpenGL context is not valid. OpenGL "
-                     "initialization cannot proceed."
-                  << std::endl;
-        initialized_ = false;
-        return;
-    }
-    initializeOpenGLFunctions();
-
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
-
-    init_icon_framebuffer();
-
-    // Initialize text renderer
-    if (!text_renderer_->initialize()) {
-        initialized_ = false;
-        return;
-    }
-
-    initialized_ = true;
-}
-
-void GLCanvas::paintGL() {
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    main_window().draw();
-}
-
-void GLCanvas::resizeGL(const int w, const int h) {
-    glViewport(0, 0, w, h);
-    main_window().resize_callback(w, h);
-}
-
-#endif
 
 void GLCanvas::wheelEvent(QWheelEvent* ev) {
     main_window().scroll_callback(static_cast<float>(ev->angleDelta().y()) /

--- a/src/ui/gl_canvas.cpp
+++ b/src/ui/gl_canvas.cpp
@@ -27,6 +27,8 @@
 
 #include <iostream>
 
+#include <rhi/qrhi.h>
+
 #include "main_window/main_window.h"
 #include "ui/gl_text_renderer.h"
 #include "visualization/components/camera.h"
@@ -36,9 +38,20 @@
 namespace oid {
 
 GLCanvas::GLCanvas(QWidget* parent)
+#ifdef __EMSCRIPTEN__
+    : QRhiWidget{parent},
+#else
     : QOpenGLWidget{parent},
+#endif
       text_renderer_{std::make_unique<GLTextRenderer>(*this)} {
     mouse_down_[0] = mouse_down_[1] = false;
+#ifdef __EMSCRIPTEN__
+    setApi(Api::OpenGL);
+    connect(this, &QRhiWidget::renderFailed, this, [this] {
+        initialized_ = false;
+        first_paint_completed_ = false;
+    });
+#endif
 }
 
 GLCanvas::~GLCanvas() = default;
@@ -78,6 +91,103 @@ void GLCanvas::mouseReleaseEvent(QMouseEvent* ev) {
         mouse_down_[1] = false;
     }
 }
+
+#ifdef __EMSCRIPTEN__
+
+bool GLCanvas::init_gl_state() {
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
+
+    if (!text_renderer_->initialize()) {
+        return false;
+    }
+
+    return true;
+}
+
+void GLCanvas::initialize(QRhiCommandBuffer* cb) {
+    static QRhi* last_rhi = nullptr;
+    if (last_rhi != rhi()) {
+        initialized_ = false;
+        first_paint_completed_ = false;
+        last_rhi = rhi();
+    }
+    if (initialized_) {
+        return;
+    }
+
+    const auto clear_color = QColor::fromRgbF(0.1f, 0.1f, 0.1f, 1.0f);
+    cb->beginPass(renderTarget(),
+                  clear_color,
+                  {1.0f, 0},
+                  nullptr,
+                  QRhiCommandBuffer::ExternalContent);
+    cb->beginExternal();
+    initializeOpenGLFunctions();
+
+    if (!init_gl_state()) {
+        cb->endExternal();
+        cb->endPass();
+        return;
+    }
+
+    cb->endExternal();
+    cb->endPass();
+    initialized_ = true;
+}
+
+void GLCanvas::render(QRhiCommandBuffer* cb) {
+    if (!initialized_) {
+        return;
+    }
+
+    const auto clear_color = QColor::fromRgbF(0.1f, 0.1f, 0.1f, 1.0f);
+    cb->beginPass(renderTarget(),
+                  clear_color,
+                  {1.0f, 0},
+                  nullptr,
+                  QRhiCommandBuffer::ExternalContent);
+    cb->beginExternal();
+
+    drain_gl_queue();
+
+    glViewport(0, 0, width(), height());
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    main_window().draw();
+
+    cb->endExternal();
+    cb->endPass();
+
+    first_paint_completed_ = true;
+}
+
+void GLCanvas::releaseResources() {
+    initialized_ = false;
+    first_paint_completed_ = false;
+}
+
+void GLCanvas::resizeEvent(QResizeEvent* e) {
+    QRhiWidget::resizeEvent(e);
+    if (initialized_) {
+        main_window().resize_callback(width(), height());
+    }
+}
+
+void GLCanvas::schedule_gl(std::function<void()> task) {
+    gl_queue_.push_back(std::move(task));
+    update();
+}
+
+void GLCanvas::drain_gl_queue() {
+    while (!gl_queue_.empty()) {
+        auto task = std::move(gl_queue_.front());
+        gl_queue_.pop_front();
+        task();
+    }
+}
+
+#else
 
 void GLCanvas::initializeGL() {
     this->makeCurrent();
@@ -150,6 +260,13 @@ void GLCanvas::paintGL() {
     main_window().draw();
 }
 
+void GLCanvas::resizeGL(const int w, const int h) {
+    glViewport(0, 0, w, h);
+    main_window().resize_callback(w, h);
+}
+
+#endif
+
 void GLCanvas::wheelEvent(QWheelEvent* ev) {
     main_window().scroll_callback(static_cast<float>(ev->angleDelta().y()) /
                                   120.0f);
@@ -162,6 +279,10 @@ const GLTextRenderer* GLCanvas::get_text_renderer() const {
 void GLCanvas::render_buffer_icon(Stage& stage,
                                   const int icon_width,
                                   const int icon_height) {
+    if (!initialized_) {
+        return;
+    }
+#ifndef __EMSCRIPTEN__
     glBindFramebuffer(GL_FRAMEBUFFER, icon_fbo_);
 
     glViewport(0, 0, icon_width, icon_height);
@@ -212,11 +333,7 @@ void GLCanvas::render_buffer_icon(Stage& stage,
     glViewport(0, 0, width(), height());
     cam = original_pose;
     cam.window_resized(width(), height());
-}
-
-void GLCanvas::resizeGL(const int w, const int h) {
-    glViewport(0, 0, w, h);
-    main_window().resize_callback(w, h);
+#endif
 }
 
 void GLCanvas::set_main_window(MainWindow& mw) {

--- a/src/ui/gl_canvas.cpp
+++ b/src/ui/gl_canvas.cpp
@@ -108,6 +108,14 @@ void GLCanvas::init_icon_framebuffer() {
     const auto icon_width = static_cast<int>(icon_size.width());
     const auto icon_height = static_cast<int>(icon_size.height());
 
+#ifdef __EMSCRIPTEN__
+    constexpr auto icon_internal_format = GL_RGBA8;
+    constexpr auto icon_format = GL_RGBA;
+#else
+    constexpr auto icon_internal_format = GL_RGB8;
+    constexpr auto icon_format = GL_RGB;
+#endif
+
     glGenTextures(1, &icon_texture_);
     glBindTexture(GL_TEXTURE_2D, icon_texture_);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
@@ -116,11 +124,11 @@ void GLCanvas::init_icon_framebuffer() {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexImage2D(GL_TEXTURE_2D,
                  0,
-                 GL_RGB8,
+                 icon_internal_format,
                  icon_width,
                  icon_height,
                  0,
-                 GL_RGB,
+                 icon_format,
                  GL_UNSIGNED_BYTE,
                  nullptr);
 
@@ -331,27 +339,40 @@ const GLTextRenderer* GLCanvas::get_text_renderer() const {
     return text_renderer_.get();
 }
 
-void GLCanvas::render_buffer_icon(Stage& stage,
+bool GLCanvas::render_buffer_icon(Stage& stage,
                                   const int icon_width,
                                   const int icon_height) {
     if (!initialized_ || !icon_framebuffer_ready_) {
-        return;
+        return false;
     }
+
+#ifdef __EMSCRIPTEN__
+    constexpr auto icon_read_format = GL_RGBA;
+    constexpr int icon_bytes_per_pixel = 4;
+#else
+    constexpr auto icon_read_format = GL_RGB;
+    constexpr int icon_bytes_per_pixel = 3;
+#endif
 
     glBindFramebuffer(GL_FRAMEBUFFER, icon_fbo_);
 
     glViewport(0, 0, icon_width, icon_height);
+    glDisable(GL_SCISSOR_TEST);
+    glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
 
     const auto camera = stage.get_game_object("camera");
     if (!camera.has_value()) [[unlikely]] {
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
-        return;
+        glViewport(0, 0, render_width(), render_height());
+        return false;
     }
     const auto cam_opt =
         camera->get().get_component<Camera>("camera_component");
     if (!cam_opt.has_value()) [[unlikely]] {
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
-        return;
+        glViewport(0, 0, render_width(), render_height());
+        return false;
     }
     auto& cam = cam_opt->get();
 
@@ -373,14 +394,16 @@ void GLCanvas::render_buffer_icon(Stage& stage,
     stage.set_icon_drawing_mode(true);
 
     stage.draw();
-    stage.get_buffer_icon().resize(3 * static_cast<size_t>(icon_width) *
-                                   static_cast<size_t>(icon_height));
+    stage.get_buffer_icon().resize(
+        static_cast<size_t>(icon_bytes_per_pixel) *
+        static_cast<size_t>(icon_width) * static_cast<size_t>(icon_height));
     glPixelStorei(GL_PACK_ALIGNMENT, 1);
+    glPixelStorei(GL_PACK_ROW_LENGTH, 0);
     glReadPixels(0,
                  0,
                  icon_width,
                  icon_height,
-                 GL_RGB,
+                 icon_read_format,
                  GL_UNSIGNED_BYTE,
                  stage.get_buffer_icon().data());
 
@@ -390,6 +413,7 @@ void GLCanvas::render_buffer_icon(Stage& stage,
     glViewport(0, 0, render_width(), render_height());
     cam = original_pose;
     cam.window_resized(render_width(), render_height());
+    return true;
 }
 
 void GLCanvas::set_main_window(MainWindow& mw) {

--- a/src/ui/gl_canvas.cpp
+++ b/src/ui/gl_canvas.cpp
@@ -246,8 +246,10 @@ void GLCanvas::render(QRhiCommandBuffer* cb) {
         last_render_height_ = h;
         main_window().resize_callback(w, h);
     }
+    main_window().prepare_gl_draw();
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     main_window().draw();
+    drain_icon_gl_queue();
 
     cb->endExternal();
     cb->endPass();
@@ -273,10 +275,23 @@ void GLCanvas::schedule_gl(std::function<void()> task) {
     update();
 }
 
+void GLCanvas::schedule_icon_gl(std::function<void()> task) {
+    icon_gl_queue_.push_back(std::move(task));
+    update();
+}
+
 void GLCanvas::drain_gl_queue() {
     while (!gl_queue_.empty()) {
         auto task = std::move(gl_queue_.front());
         gl_queue_.pop_front();
+        task();
+    }
+}
+
+void GLCanvas::drain_icon_gl_queue() {
+    while (!icon_gl_queue_.empty()) {
+        auto task = std::move(icon_gl_queue_.front());
+        icon_gl_queue_.pop_front();
         task();
     }
 }

--- a/src/ui/gl_canvas.cpp
+++ b/src/ui/gl_canvas.cpp
@@ -29,6 +29,7 @@
 #include <iostream>
 
 #include "main_window/main_window.h"
+#include "platform/gl_dialect.h"
 #include "ui/gl_text_renderer.h"
 #include "visualization/components/camera.h"
 // Required for GameObject::get_component<>() template method instantiation
@@ -94,13 +95,9 @@ void GLCanvas::init_icon_framebuffer() {
     const auto icon_width = static_cast<int>(icon_size.width());
     const auto icon_height = static_cast<int>(icon_size.height());
 
-#ifdef __EMSCRIPTEN__
-    constexpr auto icon_internal_format = GL_RGBA8;
-    constexpr auto icon_format = GL_RGBA;
-#else
-    constexpr auto icon_internal_format = GL_RGB8;
-    constexpr auto icon_format = GL_RGB;
-#endif
+    const auto& dialect = the_dialect();
+    const auto icon_internal_format = dialect.icon_gl_internal_format;
+    const auto icon_format = dialect.icon_gl_format;
 
     glGenTextures(1, &icon_texture_);
     glBindTexture(GL_TEXTURE_2D, icon_texture_);
@@ -110,7 +107,7 @@ void GLCanvas::init_icon_framebuffer() {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexImage2D(GL_TEXTURE_2D,
                  0,
-                 icon_internal_format,
+                 static_cast<GLint>(icon_internal_format),
                  icon_width,
                  icon_height,
                  0,
@@ -164,13 +161,9 @@ bool GLCanvas::render_buffer_icon(Stage& stage,
         return false;
     }
 
-#ifdef __EMSCRIPTEN__
-    constexpr auto icon_read_format = GL_RGBA;
-    constexpr int icon_bytes_per_pixel = 4;
-#else
-    constexpr auto icon_read_format = GL_RGB;
-    constexpr int icon_bytes_per_pixel = 3;
-#endif
+    const auto& dialect = the_dialect();
+    const auto icon_read_format = dialect.icon_gl_format;
+    const auto icon_bytes_per_pixel = dialect.icon_bytes_per_pixel;
 
     glBindFramebuffer(GL_FRAMEBUFFER, icon_fbo_);
 

--- a/src/ui/gl_canvas.cpp
+++ b/src/ui/gl_canvas.cpp
@@ -99,6 +99,61 @@ void GLCanvas::mouseReleaseEvent(QMouseEvent* ev) {
     }
 }
 
+void GLCanvas::init_icon_framebuffer() {
+    if (icon_framebuffer_ready_) {
+        return;
+    }
+
+    const auto icon_size = MainWindow::get_icon_size();
+    const auto icon_width = static_cast<int>(icon_size.width());
+    const auto icon_height = static_cast<int>(icon_size.height());
+
+    glGenTextures(1, &icon_texture_);
+    glBindTexture(GL_TEXTURE_2D, icon_texture_);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexImage2D(GL_TEXTURE_2D,
+                 0,
+                 GL_RGB8,
+                 icon_width,
+                 icon_height,
+                 0,
+                 GL_RGB,
+                 GL_UNSIGNED_BYTE,
+                 nullptr);
+
+    glGenFramebuffers(1, &icon_fbo_);
+    glBindFramebuffer(GL_FRAMEBUFFER, icon_fbo_);
+    glFramebufferTexture2D(
+        GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, icon_texture_, 0);
+
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+        [[unlikely]] {
+        std::cerr << "[Error] FBO configuration is not supported. Framebuffer "
+                     "initialization failed."
+                  << std::endl;
+        destroy_icon_framebuffer();
+        return;
+    }
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    icon_framebuffer_ready_ = true;
+}
+
+void GLCanvas::destroy_icon_framebuffer() {
+    if (icon_fbo_ != 0) {
+        glDeleteFramebuffers(1, &icon_fbo_);
+        icon_fbo_ = 0;
+    }
+    if (icon_texture_ != 0) {
+        glDeleteTextures(1, &icon_texture_);
+        icon_texture_ = 0;
+    }
+    icon_framebuffer_ready_ = false;
+}
+
 #ifdef __EMSCRIPTEN__
 
 int GLCanvas::render_width() const {
@@ -153,6 +208,8 @@ void GLCanvas::initialize(QRhiCommandBuffer* cb) {
         return;
     }
 
+    init_icon_framebuffer();
+
     cb->endExternal();
     cb->endPass();
     initialized_ = true;
@@ -195,6 +252,7 @@ void GLCanvas::releaseResources() {
     first_paint_completed_ = false;
     last_render_width_ = 0;
     last_render_height_ = 0;
+    destroy_icon_framebuffer();
 }
 
 void GLCanvas::resizeEvent(QResizeEvent* e) {
@@ -241,46 +299,7 @@ void GLCanvas::initializeGL() {
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
 
-    ///
-    // Texture for generating icons
-    const auto icon_size = MainWindow::get_icon_size();
-    const auto icon_width = static_cast<int>(icon_size.width());
-    const auto icon_height = static_cast<int>(icon_size.height());
-    glGenTextures(1, &icon_texture_);
-    glBindTexture(GL_TEXTURE_2D, icon_texture_);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glTexImage2D(GL_TEXTURE_2D,
-                 0,
-                 GL_RGB8,
-                 icon_width,
-                 icon_height,
-                 0,
-                 GL_RGB,
-                 GL_UNSIGNED_BYTE,
-                 nullptr);
-
-    // Generate FBO
-    glGenFramebuffers(1, &icon_fbo_);
-    glBindFramebuffer(GL_FRAMEBUFFER, icon_fbo_);
-
-    // Attach 2D texture to this FBO
-    glFramebufferTexture2D(
-        GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, icon_texture_, 0);
-
-    // Check if the GPU won't freak out about our FBO
-    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
-        [[unlikely]] {
-        std::cerr << "[Error] FBO configuration is not supported. Framebuffer "
-                     "initialization failed."
-                  << std::endl;
-        initialized_ = false;
-        return;
-    }
-
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    init_icon_framebuffer();
 
     // Initialize text renderer
     if (!text_renderer_->initialize()) {
@@ -315,21 +334,23 @@ const GLTextRenderer* GLCanvas::get_text_renderer() const {
 void GLCanvas::render_buffer_icon(Stage& stage,
                                   const int icon_width,
                                   const int icon_height) {
-    if (!initialized_) {
+    if (!initialized_ || !icon_framebuffer_ready_) {
         return;
     }
-#ifndef __EMSCRIPTEN__
+
     glBindFramebuffer(GL_FRAMEBUFFER, icon_fbo_);
 
     glViewport(0, 0, icon_width, icon_height);
 
     const auto camera = stage.get_game_object("camera");
     if (!camera.has_value()) [[unlikely]] {
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
         return;
     }
     const auto cam_opt =
         camera->get().get_component<Camera>("camera_component");
     if (!cam_opt.has_value()) [[unlikely]] {
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
         return;
     }
     auto& cam = cam_opt->get();
@@ -366,10 +387,9 @@ void GLCanvas::render_buffer_icon(Stage& stage,
     // Reset stage camera
     stage.set_icon_drawing_mode(false);
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
-    glViewport(0, 0, width(), height());
+    glViewport(0, 0, render_width(), render_height());
     cam = original_pose;
-    cam.window_resized(width(), height());
-#endif
+    cam.window_resized(render_width(), render_height());
 }
 
 void GLCanvas::set_main_window(MainWindow& mw) {

--- a/src/ui/gl_canvas.h
+++ b/src/ui/gl_canvas.h
@@ -85,10 +85,6 @@ class GLCanvas final : public GlWidgetBase, public QOpenGLFunctions {
     void schedule_gl(std::function<void()> task);
 
     void schedule_icon_gl(std::function<void()> task);
-
-    [[nodiscard]] bool has_completed_first_paint() const {
-        return first_paint_completed_;
-    }
 #else
     void initializeGL() override;
 
@@ -96,6 +92,10 @@ class GLCanvas final : public GlWidgetBase, public QOpenGLFunctions {
 
     void resizeGL(int w, int h) override;
 #endif
+
+    [[nodiscard]] bool has_completed_first_paint() const {
+        return first_paint_completed_;
+    }
 
     [[nodiscard]] int mouse_x() const {
         return mouse_x_;

--- a/src/ui/gl_canvas.h
+++ b/src/ui/gl_canvas.h
@@ -53,10 +53,12 @@ class MainWindow;
 class Stage;
 
 #ifdef __EMSCRIPTEN__
-class GLCanvas final : public QRhiWidget, public QOpenGLFunctions {
+using GlWidgetBase = QRhiWidget;
 #else
-class GLCanvas final : public QOpenGLWidget, public QOpenGLFunctions {
+using GlWidgetBase = QOpenGLWidget;
 #endif
+
+class GLCanvas final : public GlWidgetBase, public QOpenGLFunctions {
     Q_OBJECT
   public:
     explicit GLCanvas(QWidget* parent = nullptr);
@@ -124,6 +126,7 @@ class GLCanvas final : public QOpenGLWidget, public QOpenGLFunctions {
                                           int icon_height);
 
   private:
+    void platform_ctor_init(); // defined per-platform in gl_canvas_<platform>.cpp
     void init_icon_framebuffer();
     void destroy_icon_framebuffer();
     std::array<bool, 2> mouse_down_{};

--- a/src/ui/gl_canvas.h
+++ b/src/ui/gl_canvas.h
@@ -82,6 +82,8 @@ class GLCanvas final : public QOpenGLWidget, public QOpenGLFunctions {
 
     void schedule_gl(std::function<void()> task);
 
+    void schedule_icon_gl(std::function<void()> task);
+
     [[nodiscard]] bool has_completed_first_paint() const {
         return first_paint_completed_;
     }
@@ -149,11 +151,13 @@ class GLCanvas final : public QOpenGLWidget, public QOpenGLFunctions {
 
 #ifdef __EMSCRIPTEN__
     std::deque<std::function<void()>> gl_queue_{};
+    std::deque<std::function<void()>> icon_gl_queue_{};
 
     int last_render_width_{0};
     int last_render_height_{0};
 
     void drain_gl_queue();
+    void drain_icon_gl_queue();
 
     bool init_gl_state();
 #endif

--- a/src/ui/gl_canvas.h
+++ b/src/ui/gl_canvas.h
@@ -120,6 +120,8 @@ class GLCanvas final : public QOpenGLWidget, public QOpenGLFunctions {
     void render_buffer_icon(Stage& stage, int icon_width, int icon_height);
 
   private:
+    void init_icon_framebuffer();
+    void destroy_icon_framebuffer();
     std::array<bool, 2> mouse_down_{};
 
     int mouse_x_{0};
@@ -136,6 +138,7 @@ class GLCanvas final : public QOpenGLWidget, public QOpenGLFunctions {
 
     GLuint icon_texture_{0};
     GLuint icon_fbo_{0};
+    bool icon_framebuffer_ready_{false};
 
     bool initialized_{false};
     bool first_paint_completed_{false};

--- a/src/ui/gl_canvas.h
+++ b/src/ui/gl_canvas.h
@@ -117,7 +117,9 @@ class GLCanvas final : public QOpenGLWidget, public QOpenGLFunctions {
 
     void set_main_window(MainWindow& mw);
 
-    void render_buffer_icon(Stage& stage, int icon_width, int icon_height);
+    [[nodiscard]] bool render_buffer_icon(Stage& stage,
+                                          int icon_width,
+                                          int icon_height);
 
   private:
     void init_icon_framebuffer();

--- a/src/ui/gl_canvas.h
+++ b/src/ui/gl_canvas.h
@@ -109,6 +109,10 @@ class GLCanvas final : public QOpenGLWidget, public QOpenGLFunctions {
         return initialized_;
     }
 
+    [[nodiscard]] int render_width() const;
+
+    [[nodiscard]] int render_height() const;
+
     [[nodiscard]] const GLTextRenderer* get_text_renderer() const;
 
     void set_main_window(MainWindow& mw);
@@ -140,6 +144,9 @@ class GLCanvas final : public QOpenGLWidget, public QOpenGLFunctions {
 
 #ifdef __EMSCRIPTEN__
     std::deque<std::function<void()>> gl_queue_{};
+
+    int last_render_width_{0};
+    int last_render_height_{0};
 
     void drain_gl_queue();
 

--- a/src/ui/gl_canvas.h
+++ b/src/ui/gl_canvas.h
@@ -28,6 +28,7 @@
 
 #include <array>
 #include <cassert>
+#include <deque>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -36,7 +37,14 @@
 
 #include <QMouseEvent>
 #include <QOpenGLFunctions>
+
+#ifdef __EMSCRIPTEN__
+#include <QRhiWidget>
+
+class QRhiCommandBuffer;
+#else
 #include <QOpenGLWidget>
+#endif
 
 namespace oid {
 
@@ -44,7 +52,11 @@ class GLTextRenderer;
 class MainWindow;
 class Stage;
 
+#ifdef __EMSCRIPTEN__
+class GLCanvas final : public QRhiWidget, public QOpenGLFunctions {
+#else
 class GLCanvas final : public QOpenGLWidget, public QOpenGLFunctions {
+#endif
     Q_OBJECT
   public:
     explicit GLCanvas(QWidget* parent = nullptr);
@@ -57,13 +69,29 @@ class GLCanvas final : public QOpenGLWidget, public QOpenGLFunctions {
 
     void mouseReleaseEvent(QMouseEvent* ev) override;
 
+    void wheelEvent(QWheelEvent* ev) override;
+
+#ifdef __EMSCRIPTEN__
+    void initialize(QRhiCommandBuffer* cb) override;
+
+    void render(QRhiCommandBuffer* cb) override;
+
+    void releaseResources() override;
+
+    void resizeEvent(QResizeEvent* e) override;
+
+    void schedule_gl(std::function<void()> task);
+
+    [[nodiscard]] bool has_completed_first_paint() const {
+        return first_paint_completed_;
+    }
+#else
     void initializeGL() override;
 
     void paintGL() override;
 
     void resizeGL(int w, int h) override;
-
-    void wheelEvent(QWheelEvent* ev) override;
+#endif
 
     [[nodiscard]] int mouse_x() const {
         return mouse_x_;
@@ -106,8 +134,17 @@ class GLCanvas final : public QOpenGLWidget, public QOpenGLFunctions {
     GLuint icon_fbo_{0};
 
     bool initialized_{false};
+    bool first_paint_completed_{false};
 
     std::unique_ptr<GLTextRenderer> text_renderer_{};
+
+#ifdef __EMSCRIPTEN__
+    std::deque<std::function<void()>> gl_queue_{};
+
+    void drain_gl_queue();
+
+    bool init_gl_state();
+#endif
 };
 
 } // namespace oid

--- a/src/ui/gl_canvas_native.cpp
+++ b/src/ui/gl_canvas_native.cpp
@@ -1,0 +1,81 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "ui/gl_canvas.h"
+
+#include <iostream>
+
+#include "main_window/main_window.h"
+#include "ui/gl_text_renderer.h"
+
+namespace oid {
+
+int GLCanvas::render_width() const {
+    return width();
+}
+
+int GLCanvas::render_height() const {
+    return height();
+}
+
+void GLCanvas::initializeGL() {
+    this->makeCurrent();
+    if (const auto context = this->context();
+        context == nullptr || !context->isValid()) [[unlikely]] {
+        std::cerr << "[Error] OpenGL context is not valid. OpenGL "
+                     "initialization cannot proceed."
+                  << std::endl;
+        initialized_ = false;
+        return;
+    }
+    initializeOpenGLFunctions();
+
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
+
+    init_icon_framebuffer();
+
+    // Initialize text renderer
+    if (!text_renderer_->initialize()) {
+        initialized_ = false;
+        return;
+    }
+
+    initialized_ = true;
+}
+
+void GLCanvas::paintGL() {
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    main_window().draw();
+}
+
+void GLCanvas::resizeGL(const int w, const int h) {
+    glViewport(0, 0, w, h);
+    main_window().resize_callback(w, h);
+}
+
+void GLCanvas::platform_ctor_init() {}
+} // namespace oid

--- a/src/ui/gl_canvas_wasm.cpp
+++ b/src/ui/gl_canvas_wasm.cpp
@@ -1,0 +1,174 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "ui/gl_canvas.h"
+
+#include <rhi/qrhi.h>
+
+#include "main_window/main_window.h"
+#include "ui/gl_text_renderer.h"
+
+namespace oid {
+
+int GLCanvas::render_width() const {
+    if (const auto* tex = colorTexture(); tex != nullptr) {
+        return tex->pixelSize().width();
+    }
+    return static_cast<int>(std::lround(width() * devicePixelRatioF()));
+}
+
+int GLCanvas::render_height() const {
+    if (const auto* tex = colorTexture(); tex != nullptr) {
+        return tex->pixelSize().height();
+    }
+    return static_cast<int>(std::lround(height() * devicePixelRatioF()));
+}
+
+bool GLCanvas::init_gl_state() {
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
+
+    if (!text_renderer_->initialize()) {
+        return false;
+    }
+
+    return true;
+}
+
+void GLCanvas::initialize(QRhiCommandBuffer* cb) {
+    static QRhi* last_rhi = nullptr;
+    if (last_rhi != rhi()) {
+        initialized_ = false;
+        first_paint_completed_ = false;
+        last_rhi = rhi();
+    }
+    if (initialized_) {
+        return;
+    }
+
+    const auto clear_color = QColor::fromRgbF(0.1f, 0.1f, 0.1f, 1.0f);
+    cb->beginPass(renderTarget(),
+                  clear_color,
+                  {1.0f, 0},
+                  nullptr,
+                  QRhiCommandBuffer::ExternalContent);
+    cb->beginExternal();
+    initializeOpenGLFunctions();
+
+    if (!init_gl_state()) {
+        cb->endExternal();
+        cb->endPass();
+        return;
+    }
+
+    init_icon_framebuffer();
+
+    cb->endExternal();
+    cb->endPass();
+    initialized_ = true;
+}
+
+void GLCanvas::render(QRhiCommandBuffer* cb) {
+    if (!initialized_) {
+        return;
+    }
+
+    const auto clear_color = QColor::fromRgbF(0.1f, 0.1f, 0.1f, 1.0f);
+    cb->beginPass(renderTarget(),
+                  clear_color,
+                  {1.0f, 0},
+                  nullptr,
+                  QRhiCommandBuffer::ExternalContent);
+    cb->beginExternal();
+
+    drain_gl_queue();
+
+    const auto w = render_width();
+    const auto h = render_height();
+    glViewport(0, 0, w, h);
+    if (w != last_render_width_ || h != last_render_height_) {
+        last_render_width_ = w;
+        last_render_height_ = h;
+        main_window().resize_callback(w, h);
+    }
+    main_window().prepare_gl_draw();
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    main_window().draw();
+    drain_icon_gl_queue();
+
+    cb->endExternal();
+    cb->endPass();
+
+    first_paint_completed_ = true;
+}
+
+void GLCanvas::releaseResources() {
+    initialized_ = false;
+    first_paint_completed_ = false;
+    last_render_width_ = 0;
+    last_render_height_ = 0;
+    destroy_icon_framebuffer();
+}
+
+void GLCanvas::resizeEvent(QResizeEvent* e) {
+    QRhiWidget::resizeEvent(e);
+    update();
+}
+
+void GLCanvas::schedule_gl(std::function<void()> task) {
+    gl_queue_.push_back(std::move(task));
+    update();
+}
+
+void GLCanvas::schedule_icon_gl(std::function<void()> task) {
+    icon_gl_queue_.push_back(std::move(task));
+    update();
+}
+
+void GLCanvas::drain_gl_queue() {
+    while (!gl_queue_.empty()) {
+        auto task = std::move(gl_queue_.front());
+        gl_queue_.pop_front();
+        task();
+    }
+}
+
+void GLCanvas::drain_icon_gl_queue() {
+    while (!icon_gl_queue_.empty()) {
+        auto task = std::move(icon_gl_queue_.front());
+        icon_gl_queue_.pop_front();
+        task();
+    }
+}
+
+void GLCanvas::platform_ctor_init() {
+    setApi(Api::OpenGL);
+    connect(this, &QRhiWidget::renderFailed, this, [this] {
+        initialized_ = false;
+        first_paint_completed_ = false;
+    });
+}
+} // namespace oid

--- a/src/ui/gl_canvas_wasm.cpp
+++ b/src/ui/gl_canvas_wasm.cpp
@@ -25,6 +25,7 @@
 
 #include "ui/gl_canvas.h"
 
+#include <cmath>
 #include <rhi/qrhi.h>
 
 #include "main_window/main_window.h"
@@ -171,4 +172,5 @@ void GLCanvas::platform_ctor_init() {
         first_paint_completed_ = false;
     });
 }
+
 } // namespace oid

--- a/src/ui/gl_text_renderer.cpp
+++ b/src/ui/gl_text_renderer.cpp
@@ -200,12 +200,19 @@ void GLTextRenderer::generate_glyphs_texture() {
     gl_canvas_.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     gl_canvas_.glTexParameteri(
         GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+#ifdef __EMSCRIPTEN__
+    gl_canvas_.glTexParameteri(
+        GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    gl_canvas_.glTexParameteri(
+        GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+#else
     gl_canvas_.glTexParameteri(
         GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
     gl_canvas_.glTexParameteri(
         GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
     gl_canvas_.glTexParameteri(
         GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_BORDER);
+#endif
 }
 
 } // namespace oid

--- a/src/ui/gl_text_renderer.cpp
+++ b/src/ui/gl_text_renderer.cpp
@@ -27,6 +27,7 @@
 #include <QPainter>
 #include <QPixmap>
 
+#include "platform/gl_dialect.h"
 #include "visualization/shaders/oid_shaders.h"
 
 namespace oid {
@@ -200,19 +201,15 @@ void GLTextRenderer::generate_glyphs_texture() {
     gl_canvas_.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     gl_canvas_.glTexParameteri(
         GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-#ifdef __EMSCRIPTEN__
-    gl_canvas_.glTexParameteri(
-        GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    gl_canvas_.glTexParameteri(
-        GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-#else
-    gl_canvas_.glTexParameteri(
-        GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
-    gl_canvas_.glTexParameteri(
-        GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
-    gl_canvas_.glTexParameteri(
-        GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_BORDER);
-#endif
+    const auto& dialect = the_dialect();
+    const auto wrap_mode = dialect.has_texture_wrap_r ? GL_CLAMP_TO_BORDER
+                                                      : GL_CLAMP_TO_EDGE;
+    gl_canvas_.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrap_mode);
+    gl_canvas_.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrap_mode);
+    if (dialect.has_texture_wrap_r) {
+        gl_canvas_.glTexParameteri(
+            GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_BORDER);
+    }
 }
 
 } // namespace oid

--- a/src/ui/main_window/main_window.cpp
+++ b/src/ui/main_window/main_window.cpp
@@ -299,8 +299,10 @@ MainWindow::~MainWindow() {
 }
 
 void MainWindow::showWindow() {
-    ui_components_.update_timer.start(
-        static_cast<int>(1000.0 / render_framerate_));
+    // Guard against a non-positive framerate, which would produce an invalid
+    // timer interval and stall the update/render loop.
+    const auto framerate = render_framerate_ > 0.0 ? render_framerate_ : 60.0;
+    ui_components_.update_timer.start(static_cast<int>(1000.0 / framerate));
     show();
 }
 

--- a/src/ui/main_window/main_window.cpp
+++ b/src/ui/main_window/main_window.cpp
@@ -349,18 +349,13 @@ void MainWindow::loop() {
     }
 
     // Update an icon of every entry in image list
-#ifndef __EMSCRIPTEN__
     if (state_.request_icons_update) {
-
         for (const auto& name : buffer_data_.stages | std::views::keys) {
             message_handler_->repaint_image_list_icon(name);
         }
 
         state_.request_icons_update = false;
     }
-#else
-    state_.request_icons_update = false;
-#endif
 }
 
 void MainWindow::request_render_update() {

--- a/src/ui/main_window/main_window.cpp
+++ b/src/ui/main_window/main_window.cpp
@@ -139,6 +139,19 @@ MainWindow::MainWindow(ConnectionSettings host_settings, QWidget* parent)
         AutoContrastController::Dependencies{
             ui_mutex_, buffer_data_, state_, ui_components_});
 
+    // Initialize settings applier (before the message handler so inbound
+    // ApplySessionState can be applied through it)
+    settings_applier_ = std::make_unique<SettingsApplier>(
+        SettingsApplier::Dependencies{ui_mutex_,
+                                      state_,
+                                      ui_components_,
+                                      buffer_data_,
+                                      channel_names_,
+                                      render_framerate_,
+                                      default_export_suffix_,
+                                      *this},
+        this);
+
     // Initialize message handler
 #ifdef __EMSCRIPTEN__
     postmessage_transport_ = std::make_unique<PostMessageTransport>();
@@ -154,7 +167,8 @@ MainWindow::MainWindow(ConnectionSettings host_settings, QWidget* parent)
             [this] { return std::make_shared<Stage>(*this); },
             [this](const std::shared_ptr<Stage>& stage) {
                 set_currently_selected_stage(stage);
-            }},
+            },
+            settings_applier_.get()},
         this);
 #else
     tcp_transport_ = std::make_unique<TcpTransport>(socket_);
@@ -169,7 +183,8 @@ MainWindow::MainWindow(ConnectionSettings host_settings, QWidget* parent)
             [this] { return std::make_shared<Stage>(*this); },
             [this](const std::shared_ptr<Stage>& stage) {
                 set_currently_selected_stage(stage);
-            }},
+            },
+            settings_applier_.get()},
         this);
 #endif
 
@@ -186,18 +201,6 @@ MainWindow::MainWindow(ConnectionSettings host_settings, QWidget* parent)
 
     // Initialize settings manager
     settings_manager_ = std::make_unique<SettingsManager>(this);
-
-    // Initialize settings applier
-    settings_applier_ = std::make_unique<SettingsApplier>(
-        SettingsApplier::Dependencies{ui_mutex_,
-                                      state_,
-                                      ui_components_,
-                                      buffer_data_,
-                                      channel_names_,
-                                      render_framerate_,
-                                      default_export_suffix_,
-                                      *this},
-        this);
 
     connect_settings_signals();
 
@@ -277,8 +280,12 @@ MainWindow::MainWindow(ConnectionSettings host_settings, QWidget* parent)
             this,
             &MainWindow::persist_settings_deferred);
 
-    // Load settings (must be done before initialization)
+    // Load settings (must be done before initialization).
+    // On WASM the extension owns persistence and prefs arrive via
+    // ApplySessionState (IPC type 6); skip the local QSettings load.
+#ifndef __EMSCRIPTEN__
     settings_manager_->load_settings();
+#endif
 
     // Initialize UI components
     initializer_->initialize();

--- a/src/ui/main_window/main_window.cpp
+++ b/src/ui/main_window/main_window.cpp
@@ -37,6 +37,7 @@
 
 #include "main_window_initializer.h"
 #include "platform/app_platform.h"
+#include "platform/platform_config.h"
 #include "platform/render_scheduler.h"
 #include "platform/session_persistence.h"
 #include "platform/transport_factory.h"
@@ -230,20 +231,20 @@ MainWindow::MainWindow(ConnectionSettings host_settings, QWidget* parent)
             &UIEventHandler::settingsPersistenceRequested,
             this,
             &MainWindow::persist_settings_deferred);
-#ifdef __EMSCRIPTEN__
-    connect(event_handler_.get(),
-            &UIEventHandler::exportBufferRequested,
-            message_handler_.get(),
-            &MessageHandler::request_export_buffer);
-    connect(message_handler_.get(),
-            &MessageHandler::exportSelectedBufferRequested,
-            event_handler_.get(),
-            &UIEventHandler::export_selected_buffer);
-    connect(event_handler_.get(),
-            &UIEventHandler::bufferRemoved,
-            message_handler_.get(),
-            &MessageHandler::notify_buffer_removed);
-#endif
+    if constexpr (platform::kIsWasm) {
+        connect(event_handler_.get(),
+                &UIEventHandler::exportBufferRequested,
+                message_handler_.get(),
+                &MessageHandler::request_export_buffer);
+        connect(message_handler_.get(),
+                &MessageHandler::exportSelectedBufferRequested,
+                event_handler_.get(),
+                &UIEventHandler::export_selected_buffer);
+        connect(event_handler_.get(),
+                &UIEventHandler::bufferRemoved,
+                message_handler_.get(),
+                &MessageHandler::notify_buffer_removed);
+    }
 
     // Connect MessageHandler signals to MainWindow slots
     connect(message_handler_.get(),

--- a/src/ui/main_window/main_window.cpp
+++ b/src/ui/main_window/main_window.cpp
@@ -51,6 +51,7 @@ EM_JS(void, oid_notify_viewer_ready, (), {
 
 #include "ipc/message_exchange.h"
 #include "main_window_initializer.h"
+#include "platform/transport_factory.h"
 #include "math/linear_algebra.h"
 #include "settings_applier.h"
 #include "settings_manager.h"
@@ -155,16 +156,14 @@ MainWindow::MainWindow(ConnectionSettings host_settings, QWidget* parent)
         this);
 
     // Initialize message handler
-#ifdef __EMSCRIPTEN__
-    postmessage_transport_ = std::make_unique<PostMessageTransport>();
-    oid_set_postmessage_transport(postmessage_transport_.get());
+    transport_ = platform::make_transport({socket_});
     message_handler_ = std::make_unique<MessageHandler>(
         MessageHandler::Dependencies{
             ui_mutex_,
             buffer_data_,
             state_,
             ui_components_,
-            *postmessage_transport_,
+            *transport_,
             [] { return get_icon_size(); },
             [this] { return std::make_shared<Stage>(*this); },
             [this](const std::shared_ptr<Stage>& stage) {
@@ -172,23 +171,6 @@ MainWindow::MainWindow(ConnectionSettings host_settings, QWidget* parent)
             },
             settings_applier_.get()},
         this);
-#else
-    tcp_transport_ = std::make_unique<TcpTransport>(socket_);
-    message_handler_ = std::make_unique<MessageHandler>(
-        MessageHandler::Dependencies{
-            ui_mutex_,
-            buffer_data_,
-            state_,
-            ui_components_,
-            *tcp_transport_,
-            [] { return get_icon_size(); },
-            [this] { return std::make_shared<Stage>(*this); },
-            [this](const std::shared_ptr<Stage>& stage) {
-                set_currently_selected_stage(stage);
-            },
-            settings_applier_.get()},
-        this);
-#endif
 
     // Initialize UI event handler
     event_handler_ = std::make_unique<UIEventHandler>(
@@ -359,12 +341,10 @@ bool MainWindow::is_window_ready() const {
 }
 
 void MainWindow::loop() {
-#ifndef __EMSCRIPTEN__
-    if (socket_.state() == QTcpSocket::UnconnectedState) [[unlikely]] {
+    if (platform::should_quit_on_disconnect(socket_)) [[unlikely]] {
         QApplication::quit();
         return;
     }
-#endif
 
     message_handler_->decode_incoming_messages();
 
@@ -514,12 +494,12 @@ void MainWindow::persist_settings() {
     };
 
     const auto json = serialize_session_state_delta(callbacks, extra);
-    if (postmessage_transport_ != nullptr) {
+    if (transport_ != nullptr) {
         auto composer = MessageComposer{};
         composer.push(MessageType::SessionStateChanged)
             .push(std::string(json.constData(),
                               static_cast<std::size_t>(json.size())))
-            .send(*postmessage_transport_);
+            .send(*transport_);
     }
 #else
     SettingsManager::persist_settings(callbacks);

--- a/src/ui/main_window/main_window.cpp
+++ b/src/ui/main_window/main_window.cpp
@@ -266,6 +266,10 @@ MainWindow::MainWindow(ConnectionSettings host_settings, QWidget* parent)
             &MessageHandler::exportSelectedBufferRequested,
             event_handler_.get(),
             &UIEventHandler::export_selected_buffer);
+    connect(event_handler_.get(),
+            &UIEventHandler::bufferRemoved,
+            message_handler_.get(),
+            &MessageHandler::notify_buffer_removed);
 #endif
 
     // Connect MessageHandler signals to MainWindow slots

--- a/src/ui/main_window/main_window.cpp
+++ b/src/ui/main_window/main_window.cpp
@@ -29,9 +29,11 @@
 #include <ranges>
 #include <utility>
 
+#include <QApplication>
 #include <QDateTime>
 #include <QScreen>
 #include <QSettings>
+#include <QTcpSocket>
 
 #include "main_window_initializer.h"
 #include "math/linear_algebra.h"
@@ -124,13 +126,14 @@ MainWindow::MainWindow(ConnectionSettings host_settings, QWidget* parent)
             ui_mutex_, buffer_data_, state_, ui_components_});
 
     // Initialize message handler
+    tcp_transport_ = std::make_unique<TcpTransport>(socket_);
     message_handler_ = std::make_unique<MessageHandler>(
         MessageHandler::Dependencies{
             ui_mutex_,
             buffer_data_,
             state_,
             ui_components_,
-            socket_,
+            *tcp_transport_,
             [] { return get_icon_size(); },
             [this] { return std::make_shared<Stage>(*this); }},
         this);
@@ -271,6 +274,11 @@ bool MainWindow::is_window_ready() const {
 }
 
 void MainWindow::loop() {
+    if (socket_.state() == QTcpSocket::UnconnectedState) [[unlikely]] {
+        QApplication::quit();
+        return;
+    }
+
     message_handler_->decode_incoming_messages();
 
     const auto lock = std::unique_lock{ui_mutex_};

--- a/src/ui/main_window/main_window.cpp
+++ b/src/ui/main_window/main_window.cpp
@@ -460,9 +460,9 @@ vec4 MainWindow::get_stage_coordinates(const float pos_window_x,
     const auto& buffer = buffer_opt->get();
 
     const auto win_w =
-        static_cast<float>(ui_components_.ui->bufferPreview->width());
+        static_cast<float>(ui_components_.ui->bufferPreview->render_width());
     const auto win_h =
-        static_cast<float>(ui_components_.ui->bufferPreview->height());
+        static_cast<float>(ui_components_.ui->bufferPreview->render_height());
     const auto mouse_pos_ndc = vec4{2.0f * (pos_window_x - win_w / 2) / win_w,
                                     -2.0f * (pos_window_y - win_h / 2) / win_h,
                                     0.0f,

--- a/src/ui/main_window/main_window.cpp
+++ b/src/ui/main_window/main_window.cpp
@@ -49,10 +49,12 @@ EM_JS(void, oid_notify_viewer_ready, (), {
 #include <QSettings>
 #include <QTcpSocket>
 
+#include "ipc/message_exchange.h"
 #include "main_window_initializer.h"
 #include "math/linear_algebra.h"
 #include "settings_applier.h"
 #include "settings_manager.h"
+#include "ui/messaging/session_state_codec.h"
 #include "ui_main_window.h"
 #include "visualization/components/buffer_values.h"
 #include "visualization/components/camera.h"
@@ -468,7 +470,54 @@ void MainWindow::persist_settings() {
         buffer_data_.removed_buffer_names.clear();
     };
 
+#ifdef __EMSCRIPTEN__
+    // The VS Code extension owns persistence on WASM: serialize prefs only and
+    // stream them as SessionStateChanged (IPC type 7). Buffers are handled
+    // extension-side via GetObservedSymbols, not here.
+    SessionStateExtraInputs extra;
+    extra.getColorspace = [this] {
+        const auto to_char = [](const QString& name) -> QChar {
+            if (name == QStringLiteral("red")) return QLatin1Char('r');
+            if (name == QStringLiteral("green")) return QLatin1Char('g');
+            if (name == QStringLiteral("blue")) return QLatin1Char('b');
+            if (name == QStringLiteral("alpha")) return QLatin1Char('a');
+            return {};
+        };
+        auto colorspace = QString{};
+        for (const auto& name : {channel_names_.name_channel_1,
+                                 channel_names_.name_channel_2,
+                                 channel_names_.name_channel_3,
+                                 channel_names_.name_channel_4}) {
+            if (const auto character = to_char(name); !character.isNull()) {
+                colorspace.append(character);
+            }
+        }
+        return colorspace;
+    };
+    extra.getListPosition = [this] {
+        auto* const splitter = ui_components_.ui->splitter;
+        const auto vertical = splitter->orientation() == Qt::Vertical;
+        const auto list_last =
+            splitter->indexOf(ui_components_.ui->frame_list) != 0;
+        if (vertical) {
+            return QString(list_last ? QStringLiteral("bottom")
+                                     : QStringLiteral("top"));
+        }
+        return QString(list_last ? QStringLiteral("right")
+                                 : QStringLiteral("left"));
+    };
+
+    const auto json = serialize_session_state_delta(callbacks, extra);
+    if (postmessage_transport_ != nullptr) {
+        auto composer = MessageComposer{};
+        composer.push(MessageType::SessionStateChanged)
+            .push(std::string(json.constData(),
+                              static_cast<std::size_t>(json.size())))
+            .send(*postmessage_transport_);
+    }
+#else
     SettingsManager::persist_settings(callbacks);
+#endif
 }
 
 vec4 MainWindow::get_stage_coordinates(const float pos_window_x,

--- a/src/ui/main_window/main_window.cpp
+++ b/src/ui/main_window/main_window.cpp
@@ -257,6 +257,10 @@ MainWindow::MainWindow(ConnectionSettings host_settings, QWidget* parent)
             &UIEventHandler::exportBufferRequested,
             message_handler_.get(),
             &MessageHandler::request_export_buffer);
+    connect(message_handler_.get(),
+            &MessageHandler::exportSelectedBufferRequested,
+            event_handler_.get(),
+            &UIEventHandler::export_selected_buffer);
 #endif
 
     // Connect MessageHandler signals to MainWindow slots

--- a/src/ui/main_window/main_window.cpp
+++ b/src/ui/main_window/main_window.cpp
@@ -29,20 +29,6 @@
 #include <ranges>
 #include <utility>
 
-#ifdef __EMSCRIPTEN__
-#include <emscripten.h>
-
-EM_JS(void, oid_notify_viewer_ready, (), {
-  const msg = {type: 'oid-control', event: 'viewer-ready', version: 'dev'};
-  if (typeof window.oidOnViewerReady === 'function') {
-    window.oidOnViewerReady(msg);
-  }
-  if (typeof window.dispatchEvent === 'function') {
-    window.dispatchEvent(new CustomEvent('oid-viewer-ready', {detail: msg}));
-  }
-});
-#endif
-
 #include <QApplication>
 #include <QDateTime>
 #include <QScreen>
@@ -51,6 +37,7 @@ EM_JS(void, oid_notify_viewer_ready, (), {
 
 #include "ipc/message_exchange.h"
 #include "main_window_initializer.h"
+#include "platform/app_platform.h"
 #include "platform/render_scheduler.h"
 #include "platform/transport_factory.h"
 #include "math/linear_algebra.h"
@@ -350,14 +337,8 @@ void MainWindow::loop() {
 
     message_handler_->decode_incoming_messages();
 
-#ifdef __EMSCRIPTEN__
-    static auto viewer_ready_sent = false;
-    if (!viewer_ready_sent && gl_canvas_ptr_->has_completed_first_paint() &&
-        is_window_ready()) {
-        oid_notify_viewer_ready();
-        viewer_ready_sent = true;
-    }
-#endif
+    platform::notify_viewer_ready_once(is_window_ready(),
+                                       gl_canvas_ptr_->has_completed_first_paint());
 
     const auto lock = std::unique_lock{ui_mutex_};
     if (state_.completer_updated) {

--- a/src/ui/main_window/main_window.cpp
+++ b/src/ui/main_window/main_window.cpp
@@ -34,12 +34,11 @@
 
 EM_JS(void, oid_notify_viewer_ready, (), {
   const msg = {type: 'oid-control', event: 'viewer-ready', version: 'dev'};
+  if (typeof window.oidOnViewerReady === 'function') {
+    window.oidOnViewerReady(msg);
+  }
   if (typeof window.dispatchEvent === 'function') {
     window.dispatchEvent(new CustomEvent('oid-viewer-ready', {detail: msg}));
-  }
-  if (window.parent !== window &&
-      typeof window.parent.postMessage === 'function') {
-    window.parent.postMessage(msg, '*');
   }
 });
 #endif

--- a/src/ui/main_window/main_window.cpp
+++ b/src/ui/main_window/main_window.cpp
@@ -29,6 +29,17 @@
 #include <ranges>
 #include <utility>
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+
+EM_JS(void, oid_notify_viewer_ready, (), {
+  if (window.parent !== window) {
+    window.parent.postMessage(
+        {type: 'oid-control', event: 'viewer-ready', version: 'dev'}, '*');
+  }
+});
+#endif
+
 #include <QApplication>
 #include <QDateTime>
 #include <QScreen>
@@ -137,7 +148,10 @@ MainWindow::MainWindow(ConnectionSettings host_settings, QWidget* parent)
             ui_components_,
             *postmessage_transport_,
             [] { return get_icon_size(); },
-            [this] { return std::make_shared<Stage>(*this); }},
+            [this] { return std::make_shared<Stage>(*this); },
+            [this](const std::shared_ptr<Stage>& stage) {
+                set_currently_selected_stage(stage);
+            }},
         this);
 #else
     tcp_transport_ = std::make_unique<TcpTransport>(socket_);
@@ -149,7 +163,10 @@ MainWindow::MainWindow(ConnectionSettings host_settings, QWidget* parent)
             ui_components_,
             *tcp_transport_,
             [] { return get_icon_size(); },
-            [this] { return std::make_shared<Stage>(*this); }},
+            [this] { return std::make_shared<Stage>(*this); },
+            [this](const std::shared_ptr<Stage>& stage) {
+                set_currently_selected_stage(stage);
+            }},
         this);
 #endif
 
@@ -298,6 +315,15 @@ void MainWindow::loop() {
 
     message_handler_->decode_incoming_messages();
 
+#ifdef __EMSCRIPTEN__
+    static auto viewer_ready_sent = false;
+    if (!viewer_ready_sent && gl_canvas_ptr_->has_completed_first_paint() &&
+        is_window_ready()) {
+        oid_notify_viewer_ready();
+        viewer_ready_sent = true;
+    }
+#endif
+
     const auto lock = std::unique_lock{ui_mutex_};
     if (state_.completer_updated) {
         // Update auto-complete suggestion list
@@ -312,13 +338,15 @@ void MainWindow::loop() {
     }
 
     // Update visualization pane
-    if (state_.request_render_update) {
+    if (state_.request_render_update &&
+        ui_components_.ui->bufferPreview->is_ready()) {
         ui_components_.ui->bufferPreview->update();
         update_status_bar();
         state_.request_render_update = false;
     }
 
     // Update an icon of every entry in image list
+#ifndef __EMSCRIPTEN__
     if (state_.request_icons_update) {
 
         for (const auto& name : buffer_data_.stages | std::views::keys) {
@@ -327,6 +355,9 @@ void MainWindow::loop() {
 
         state_.request_icons_update = false;
     }
+#else
+    state_.request_icons_update = false;
+#endif
 }
 
 void MainWindow::request_render_update() {

--- a/src/ui/main_window/main_window.cpp
+++ b/src/ui/main_window/main_window.cpp
@@ -51,6 +51,7 @@ EM_JS(void, oid_notify_viewer_ready, (), {
 
 #include "ipc/message_exchange.h"
 #include "main_window_initializer.h"
+#include "platform/render_scheduler.h"
 #include "platform/transport_factory.h"
 #include "math/linear_algebra.h"
 #include "settings_applier.h"
@@ -157,6 +158,8 @@ MainWindow::MainWindow(ConnectionSettings host_settings, QWidget* parent)
 
     // Initialize message handler
     transport_ = platform::make_transport({socket_});
+    render_scheduler_ =
+        platform::make_render_scheduler(*ui_components_.ui->bufferPreview);
     message_handler_ = std::make_unique<MessageHandler>(
         MessageHandler::Dependencies{
             ui_mutex_,
@@ -164,6 +167,7 @@ MainWindow::MainWindow(ConnectionSettings host_settings, QWidget* parent)
             state_,
             ui_components_,
             *transport_,
+            *render_scheduler_,
             [] { return get_icon_size(); },
             [this] { return std::make_shared<Stage>(*this); },
             [this](const std::shared_ptr<Stage>& stage) {

--- a/src/ui/main_window/main_window.cpp
+++ b/src/ui/main_window/main_window.cpp
@@ -35,10 +35,10 @@
 #include <QSettings>
 #include <QTcpSocket>
 
-#include "ipc/message_exchange.h"
 #include "main_window_initializer.h"
 #include "platform/app_platform.h"
 #include "platform/render_scheduler.h"
+#include "platform/session_persistence.h"
 #include "platform/transport_factory.h"
 #include "math/linear_algebra.h"
 #include "settings_applier.h"
@@ -262,9 +262,7 @@ MainWindow::MainWindow(ConnectionSettings host_settings, QWidget* parent)
     // Load settings (must be done before initialization).
     // On WASM the extension owns persistence and prefs arrive via
     // ApplySessionState (IPC type 6); skip the local QSettings load.
-#ifndef __EMSCRIPTEN__
-    settings_manager_->load_settings();
-#endif
+    platform::load_settings_if_local(*settings_manager_);
 
     // Initialize UI components
     initializer_->initialize();
@@ -439,10 +437,6 @@ void MainWindow::persist_settings() {
         buffer_data_.removed_buffer_names.clear();
     };
 
-#ifdef __EMSCRIPTEN__
-    // The VS Code extension owns persistence on WASM: serialize prefs only and
-    // stream them as SessionStateChanged (IPC type 7). Buffers are handled
-    // extension-side via GetObservedSymbols, not here.
     SessionStateExtraInputs extra;
     extra.getColorspace = [this] {
         const auto to_char = [](const QString& name) -> QChar {
@@ -476,17 +470,7 @@ void MainWindow::persist_settings() {
                                  : QStringLiteral("left"));
     };
 
-    const auto json = serialize_session_state_delta(callbacks, extra);
-    if (transport_ != nullptr) {
-        auto composer = MessageComposer{};
-        composer.push(MessageType::SessionStateChanged)
-            .push(std::string(json.constData(),
-                              static_cast<std::size_t>(json.size())))
-            .send(*transport_);
-    }
-#else
-    SettingsManager::persist_settings(callbacks);
-#endif
+    platform::persist_session(callbacks, extra, transport_.get());
 }
 
 vec4 MainWindow::get_stage_coordinates(const float pos_window_x,

--- a/src/ui/main_window/main_window.cpp
+++ b/src/ui/main_window/main_window.cpp
@@ -252,6 +252,12 @@ MainWindow::MainWindow(ConnectionSettings host_settings, QWidget* parent)
             &UIEventHandler::settingsPersistenceRequested,
             this,
             &MainWindow::persist_settings_deferred);
+#ifdef __EMSCRIPTEN__
+    connect(event_handler_.get(),
+            &UIEventHandler::exportBufferRequested,
+            message_handler_.get(),
+            &MessageHandler::request_export_buffer);
+#endif
 
     // Connect MessageHandler signals to MainWindow slots
     connect(message_handler_.get(),

--- a/src/ui/main_window/main_window.cpp
+++ b/src/ui/main_window/main_window.cpp
@@ -303,7 +303,6 @@ void MainWindow::draw() const {
     }
 }
 
-#ifdef __EMSCRIPTEN__
 void MainWindow::prepare_gl_draw() const {
     const auto lock = std::unique_lock{ui_mutex_};
     const auto stage = buffer_data_.currently_selected_stage.lock();
@@ -326,7 +325,6 @@ void MainWindow::prepare_gl_draw() const {
     cam.window_resized(ui_components_.ui->bufferPreview->render_width(),
                        ui_components_.ui->bufferPreview->render_height());
 }
-#endif
 
 std::shared_ptr<GLCanvas> MainWindow::gl_canvas() const {
     return gl_canvas_ptr_;

--- a/src/ui/main_window/main_window.cpp
+++ b/src/ui/main_window/main_window.cpp
@@ -292,6 +292,31 @@ void MainWindow::draw() const {
     }
 }
 
+#ifdef __EMSCRIPTEN__
+void MainWindow::prepare_gl_draw() const {
+    const auto lock = std::unique_lock{ui_mutex_};
+    const auto stage = buffer_data_.currently_selected_stage.lock();
+    if (!stage) {
+        return;
+    }
+
+    stage->update();
+
+    const auto cam_obj = stage->get_game_object("camera");
+    if (!cam_obj.has_value()) {
+        return;
+    }
+    const auto cam_opt =
+        cam_obj->get().get_component<Camera>("camera_component");
+    if (!cam_opt.has_value()) {
+        return;
+    }
+    auto& cam = cam_opt->get();
+    cam.window_resized(ui_components_.ui->bufferPreview->render_width(),
+                       ui_components_.ui->bufferPreview->render_height());
+}
+#endif
+
 std::shared_ptr<GLCanvas> MainWindow::gl_canvas() const {
     return gl_canvas_ptr_;
 }

--- a/src/ui/main_window/main_window.cpp
+++ b/src/ui/main_window/main_window.cpp
@@ -33,9 +33,13 @@
 #include <emscripten.h>
 
 EM_JS(void, oid_notify_viewer_ready, (), {
-  if (window.parent !== window) {
-    window.parent.postMessage(
-        {type: 'oid-control', event: 'viewer-ready', version: 'dev'}, '*');
+  const msg = {type: 'oid-control', event: 'viewer-ready', version: 'dev'};
+  if (typeof window.dispatchEvent === 'function') {
+    window.dispatchEvent(new CustomEvent('oid-viewer-ready', {detail: msg}));
+  }
+  if (window.parent !== window &&
+      typeof window.parent.postMessage === 'function') {
+    window.parent.postMessage(msg, '*');
   }
 });
 #endif

--- a/src/ui/main_window/main_window.cpp
+++ b/src/ui/main_window/main_window.cpp
@@ -126,6 +126,20 @@ MainWindow::MainWindow(ConnectionSettings host_settings, QWidget* parent)
             ui_mutex_, buffer_data_, state_, ui_components_});
 
     // Initialize message handler
+#ifdef __EMSCRIPTEN__
+    postmessage_transport_ = std::make_unique<PostMessageTransport>();
+    oid_set_postmessage_transport(postmessage_transport_.get());
+    message_handler_ = std::make_unique<MessageHandler>(
+        MessageHandler::Dependencies{
+            ui_mutex_,
+            buffer_data_,
+            state_,
+            ui_components_,
+            *postmessage_transport_,
+            [] { return get_icon_size(); },
+            [this] { return std::make_shared<Stage>(*this); }},
+        this);
+#else
     tcp_transport_ = std::make_unique<TcpTransport>(socket_);
     message_handler_ = std::make_unique<MessageHandler>(
         MessageHandler::Dependencies{
@@ -137,6 +151,7 @@ MainWindow::MainWindow(ConnectionSettings host_settings, QWidget* parent)
             [] { return get_icon_size(); },
             [this] { return std::make_shared<Stage>(*this); }},
         this);
+#endif
 
     // Initialize UI event handler
     event_handler_ = std::make_unique<UIEventHandler>(
@@ -274,10 +289,12 @@ bool MainWindow::is_window_ready() const {
 }
 
 void MainWindow::loop() {
+#ifndef __EMSCRIPTEN__
     if (socket_.state() == QTcpSocket::UnconnectedState) [[unlikely]] {
         QApplication::quit();
         return;
     }
+#endif
 
     message_handler_->decode_incoming_messages();
 

--- a/src/ui/main_window/main_window.h
+++ b/src/ui/main_window/main_window.h
@@ -116,9 +116,7 @@ class MainWindow final : public QMainWindow {
 
     void draw() const;
 
-#ifdef __EMSCRIPTEN__
     void prepare_gl_draw() const;
-#endif
 
     [[nodiscard]] std::shared_ptr<GLCanvas> gl_canvas() const;
 

--- a/src/ui/main_window/main_window.h
+++ b/src/ui/main_window/main_window.h
@@ -38,6 +38,7 @@
 #include <QTimer>
 
 #include "math/linear_algebra.h"
+#include "ipc/tcp_transport.h"
 #include "ui/controllers/auto_contrast_controller.h"
 #include "ui/events/event_handler.h"
 #include "ui/go_to_widget.h"
@@ -181,6 +182,7 @@ class MainWindow final : public QMainWindow {
     mutable std::recursive_mutex ui_mutex_{};
     ConnectionSettings host_settings_{};
     QTcpSocket socket_{};
+    std::unique_ptr<TcpTransport> tcp_transport_{};
 
     ///
     // Assorted methods - private - implemented in main_window.cpp

--- a/src/ui/main_window/main_window.h
+++ b/src/ui/main_window/main_window.h
@@ -37,12 +37,8 @@
 #include <QTcpSocket>
 #include <QTimer>
 
+#include "ipc/transport.h"
 #include "math/linear_algebra.h"
-#ifndef __EMSCRIPTEN__
-#include "ipc/tcp_transport.h"
-#else
-#include "ipc/postmessage_transport.h"
-#endif
 #include "ui/controllers/auto_contrast_controller.h"
 #include "ui/events/event_handler.h"
 #include "ui/go_to_widget.h"
@@ -195,11 +191,7 @@ class MainWindow final : public QMainWindow {
     mutable std::recursive_mutex ui_mutex_{};
     ConnectionSettings host_settings_{};
     QTcpSocket socket_{};
-#ifndef __EMSCRIPTEN__
-    std::unique_ptr<TcpTransport> tcp_transport_{};
-#else
-    std::unique_ptr<PostMessageTransport> postmessage_transport_{};
-#endif
+    std::unique_ptr<ITransport> transport_{};
 
     ///
     // Assorted methods - private - implemented in main_window.cpp

--- a/src/ui/main_window/main_window.h
+++ b/src/ui/main_window/main_window.h
@@ -38,7 +38,11 @@
 #include <QTimer>
 
 #include "math/linear_algebra.h"
+#ifndef __EMSCRIPTEN__
 #include "ipc/tcp_transport.h"
+#else
+#include "ipc/postmessage_transport.h"
+#endif
 #include "ui/controllers/auto_contrast_controller.h"
 #include "ui/events/event_handler.h"
 #include "ui/go_to_widget.h"
@@ -182,7 +186,11 @@ class MainWindow final : public QMainWindow {
     mutable std::recursive_mutex ui_mutex_{};
     ConnectionSettings host_settings_{};
     QTcpSocket socket_{};
+#ifndef __EMSCRIPTEN__
     std::unique_ptr<TcpTransport> tcp_transport_{};
+#else
+    std::unique_ptr<PostMessageTransport> postmessage_transport_{};
+#endif
 
     ///
     // Assorted methods - private - implemented in main_window.cpp

--- a/src/ui/main_window/main_window.h
+++ b/src/ui/main_window/main_window.h
@@ -39,6 +39,7 @@
 
 #include "ipc/transport.h"
 #include "math/linear_algebra.h"
+#include "platform/render_scheduler.h"
 #include "ui/controllers/auto_contrast_controller.h"
 #include "ui/events/event_handler.h"
 #include "ui/go_to_widget.h"
@@ -175,6 +176,7 @@ class MainWindow final : public QMainWindow {
     double render_framerate_{60.0};
     QString default_export_suffix_{};
     std::unique_ptr<AutoContrastController> ac_controller_{};
+    std::unique_ptr<RenderScheduler> render_scheduler_{};
     std::unique_ptr<MessageHandler> message_handler_{};
     std::unique_ptr<UIEventHandler> event_handler_{};
     std::unique_ptr<SettingsManager> settings_manager_{};

--- a/src/ui/main_window/main_window.h
+++ b/src/ui/main_window/main_window.h
@@ -119,6 +119,10 @@ class MainWindow final : public QMainWindow {
 
     void draw() const;
 
+#ifdef __EMSCRIPTEN__
+    void prepare_gl_draw() const;
+#endif
+
     [[nodiscard]] std::shared_ptr<GLCanvas> gl_canvas() const;
 
     [[nodiscard]] static QSizeF get_icon_size();

--- a/src/ui/main_window/main_window.h
+++ b/src/ui/main_window/main_window.h
@@ -171,7 +171,12 @@ class MainWindow final : public QMainWindow {
     BufferData buffer_data_{};
     ChannelNames channel_names_{};
     std::shared_ptr<GLCanvas> gl_canvas_ptr_{};
-    double render_framerate_{};
+    // Default mirrors SettingsConstants::DEFAULT_FRAMERATE. Must be valid
+    // before showWindow() starts the update timer: on WASM load_settings() is
+    // skipped (prefs arrive later via ApplySessionState), so without a sane
+    // default the timer interval (1000/framerate) would be invalid and stall
+    // the render/message loop.
+    double render_framerate_{60.0};
     QString default_export_suffix_{};
     std::unique_ptr<AutoContrastController> ac_controller_{};
     std::unique_ptr<MessageHandler> message_handler_{};

--- a/src/ui/main_window/main_window_initializer.cpp
+++ b/src/ui/main_window/main_window_initializer.cpp
@@ -359,6 +359,10 @@ void MainWindowInitializer::initialize_toolbar() const {
 
 void MainWindowInitializer::initialize_visualization_pane() const {
     deps_.ui_components.ui->bufferPreview->set_main_window(deps_.main_window);
+#ifdef __EMSCRIPTEN__
+    deps_.ui_components.ui->bufferPreview->setAttribute(Qt::WA_NativeWindow,
+                                                        false);
+#endif
 }
 
 void MainWindowInitializer::initialize_status_bar() const {

--- a/src/ui/main_window/main_window_initializer.cpp
+++ b/src/ui/main_window/main_window_initializer.cpp
@@ -34,6 +34,7 @@
 #include <QString>
 
 #include "main_window.h"
+#include "platform/platform_config.h"
 #include "ui/go_to_widget.h"
 #include "ui/symbol_completer.h"
 #include "ui_main_window.h"
@@ -359,10 +360,12 @@ void MainWindowInitializer::initialize_toolbar() const {
 
 void MainWindowInitializer::initialize_visualization_pane() const {
     deps_.ui_components.ui->bufferPreview->set_main_window(deps_.main_window);
-#ifdef __EMSCRIPTEN__
-    deps_.ui_components.ui->bufferPreview->setAttribute(Qt::WA_NativeWindow,
-                                                        false);
-#endif
+    // Qt::WA_NativeWindow and setAttribute are cross-platform; both branches
+    // compile on both platforms, so if constexpr is safe here.
+    if constexpr (platform::kIsWasm) {
+        deps_.ui_components.ui->bufferPreview->setAttribute(
+            Qt::WA_NativeWindow, false);
+    }
 }
 
 void MainWindowInitializer::initialize_status_bar() const {
@@ -380,11 +383,13 @@ void MainWindowInitializer::initialize_go_to_widget() const {
 }
 
 void MainWindowInitializer::initialize_networking() const {
-#ifndef __EMSCRIPTEN__
-    deps_.socket.connectToHost(QString(deps_.host_settings.url.c_str()),
-                               deps_.host_settings.port);
-    deps_.socket.waitForConnected();
-#endif
+    // QTcpSocket::connectToHost / waitForConnected exist on both platforms, so
+    // both branches compile everywhere — if constexpr is safe here.
+    if constexpr (!platform::kIsWasm) {
+        deps_.socket.connectToHost(QString(deps_.host_settings.url.c_str()),
+                                   deps_.host_settings.port);
+        deps_.socket.waitForConnected();
+    }
 }
 
 void MainWindowInitializer::setFontIcon(QAbstractButton* ui_element,

--- a/src/ui/main_window/main_window_initializer.cpp
+++ b/src/ui/main_window/main_window_initializer.cpp
@@ -376,9 +376,11 @@ void MainWindowInitializer::initialize_go_to_widget() const {
 }
 
 void MainWindowInitializer::initialize_networking() const {
+#ifndef __EMSCRIPTEN__
     deps_.socket.connectToHost(QString(deps_.host_settings.url.c_str()),
                                deps_.host_settings.port);
     deps_.socket.waitForConnected();
+#endif
 }
 
 void MainWindowInitializer::setFontIcon(QAbstractButton* ui_element,

--- a/src/ui/messaging/message_handler.cpp
+++ b/src/ui/messaging/message_handler.cpp
@@ -342,6 +342,9 @@ void MessageHandler::decode_incoming_messages() {
     case MessageType::PlotBufferContents:
         decode_plot_buffer_contents();
         break;
+    case MessageType::ExportSelectedBuffer:
+        emit exportSelectedBufferRequested();
+        break;
     default:
         break;
     }

--- a/src/ui/messaging/message_handler.cpp
+++ b/src/ui/messaging/message_handler.cpp
@@ -317,6 +317,13 @@ void MessageHandler::decode_plot_buffer_contents() {
     deps_.state.request_render_update = true;
 }
 
+void MessageHandler::notify_buffer_removed(const QString& buffer_name) const {
+    auto message_composer = MessageComposer{};
+    message_composer.push(MessageType::BufferRemoved)
+        .push(buffer_name.toStdString());
+    message_composer.send(deps_.transport);
+}
+
 void MessageHandler::decode_apply_session_state() const {
     auto message_decoder = MessageDecoder{deps_.transport};
     auto json = std::string{};

--- a/src/ui/messaging/message_handler.cpp
+++ b/src/ui/messaging/message_handler.cpp
@@ -340,6 +340,62 @@ void MessageHandler::plot_buffer_from_fields(
     deps_.state.request_render_update = true;
 }
 
+void MessageHandler::decode_plot_buffer_begin() {
+    auto p = BufferAssembler::BeginParams{};
+    auto type_int = int{};
+    auto message_decoder = MessageDecoder{deps_.transport};
+    message_decoder.read(p.variable_name)
+        .read(p.display_name)
+        .read(p.pixel_layout)
+        .read(p.transpose)
+        .read(p.width)
+        .read(p.height)
+        .read(p.channels)
+        .read(p.stride)
+        .read(type_int)
+        .read(p.total_byte_size);
+    p.type = type_int;
+    buffer_assembler_.begin(std::move(p));
+}
+
+void MessageHandler::decode_plot_buffer_chunk() {
+    auto variable_name = std::string{};
+    auto row_offset = std::size_t{};
+    auto row_count = std::size_t{};
+    auto bytes = std::vector<std::byte>{};
+    auto message_decoder = MessageDecoder{deps_.transport};
+    message_decoder.read(variable_name)
+        .read(row_offset)
+        .read(row_count)
+        .read(bytes);
+    if (!buffer_assembler_.chunk(variable_name, row_offset, row_count, bytes)) {
+        std::cerr << "[Error] Dropped buffer chunk for: " << variable_name
+                  << std::endl;
+    }
+}
+
+void MessageHandler::decode_plot_buffer_end() {
+    auto variable_name = std::string{};
+    auto message_decoder = MessageDecoder{deps_.transport};
+    message_decoder.read(variable_name);
+    auto assembled = buffer_assembler_.end(variable_name);
+    if (!assembled) {
+        std::cerr << "[Error] PlotBufferEnd for unknown buffer: " << variable_name
+                  << std::endl;
+        return;
+    }
+    plot_buffer_from_fields(assembled->variable_name,
+                            assembled->display_name,
+                            assembled->pixel_layout,
+                            assembled->transpose,
+                            assembled->width,
+                            assembled->height,
+                            assembled->channels,
+                            assembled->stride,
+                            static_cast<BufferType>(assembled->type),
+                            std::move(assembled->bytes));
+}
+
 void MessageHandler::notify_buffer_removed(const QString& buffer_name) const {
     auto message_composer = MessageComposer{};
     message_composer.push(MessageType::BufferRemoved)
@@ -389,6 +445,15 @@ void MessageHandler::decode_incoming_messages() {
         break;
     case MessageType::PlotBufferContents:
         decode_plot_buffer_contents();
+        break;
+    case MessageType::PlotBufferBegin:
+        decode_plot_buffer_begin();
+        break;
+    case MessageType::PlotBufferChunk:
+        decode_plot_buffer_chunk();
+        break;
+    case MessageType::PlotBufferEnd:
+        decode_plot_buffer_end();
         break;
     case MessageType::ExportSelectedBuffer:
         emit exportSelectedBufferRequested();

--- a/src/ui/messaging/message_handler.cpp
+++ b/src/ui/messaging/message_handler.cpp
@@ -89,33 +89,39 @@ QListWidgetItem* MessageHandler::find_image_list_item(
 
 void MessageHandler::repaint_image_list_icon(
     const std::string& variable_name_str) const {
-#ifndef __EMSCRIPTEN__
-    const auto lock = std::unique_lock{deps_.ui_mutex};
-    const auto itStage = deps_.buffer_data.stages.find(variable_name_str);
-    if (itStage == deps_.buffer_data.stages.end()) [[unlikely]] {
-        return;
-    }
+    const auto paint_icon = [this, variable_name_str]() {
+        const auto lock = std::unique_lock{deps_.ui_mutex};
+        const auto itStage = deps_.buffer_data.stages.find(variable_name_str);
+        if (itStage == deps_.buffer_data.stages.end()) [[unlikely]] {
+            return;
+        }
 
-    const auto& [name, stage] = *itStage;
+        const auto& [name, stage] = *itStage;
 
-    const auto icon_size = deps_.get_icon_size();
-    const auto icon_width = static_cast<int>(icon_size.width());
-    const auto icon_height = static_cast<int>(icon_size.height());
-    const auto bytes_per_line = icon_width * 3;
+        const auto icon_size = deps_.get_icon_size();
+        const auto icon_width = static_cast<int>(icon_size.width());
+        const auto icon_height = static_cast<int>(icon_size.height());
+        const auto bytes_per_line = icon_width * 3;
 
-    deps_.ui_components.ui->bufferPreview->render_buffer_icon(
-        *stage, icon_width, icon_height);
+        deps_.ui_components.ui->bufferPreview->render_buffer_icon(
+            *stage, icon_width, icon_height);
 
-    const auto bufferIcon = QImage{stage->get_buffer_icon().data(),
-                                   icon_width,
-                                   icon_height,
-                                   bytes_per_line,
-                                   QImage::Format_RGB888};
+        const auto bufferIcon = QImage{stage->get_buffer_icon().data(),
+                                       icon_width,
+                                       icon_height,
+                                       bytes_per_line,
+                                       QImage::Format_RGB888};
 
-    if (const auto item = find_image_list_item(variable_name_str);
-        item != nullptr) {
-        item->setIcon(QPixmap::fromImage(bufferIcon));
-    }
+        if (const auto item = find_image_list_item(variable_name_str);
+            item != nullptr) {
+            item->setIcon(QPixmap::fromImage(bufferIcon));
+        }
+    };
+
+#ifdef __EMSCRIPTEN__
+    deps_.ui_components.ui->bufferPreview->schedule_gl(paint_icon);
+#else
+    paint_icon();
 #endif
 }
 
@@ -231,6 +237,7 @@ void MessageHandler::decode_plot_buffer_contents() {
                 list->blockSignals(false);
             }
             deps_.state.request_render_update = true;
+            deps_.state.request_icons_update = true;
         });
 #else
         if (!stage->initialize(params)) [[unlikely]] {
@@ -256,6 +263,7 @@ void MessageHandler::decode_plot_buffer_contents() {
                 std::cerr << "[Error] Buffer update failed for: "
                           << variable_name_str << std::endl;
             }
+            deps_.state.request_icons_update = true;
         });
 #else
         if (const auto& [buffer_name, buffer_stage_ptr] = *buffer_stage;

--- a/src/ui/messaging/message_handler.cpp
+++ b/src/ui/messaging/message_handler.cpp
@@ -26,6 +26,7 @@
 #include "message_handler.h"
 
 #include <bit>
+#include <array>
 #include <iostream>
 #include <memory>
 #include <ranges>
@@ -47,7 +48,7 @@ MessageHandler::MessageHandler(Dependencies deps, QObject* parent)
 
 void MessageHandler::decode_set_available_symbols() const {
     const auto lock = std::unique_lock{deps_.ui_mutex};
-    auto message_decoder = MessageDecoder{&deps_.socket};
+    auto message_decoder = MessageDecoder{deps_.transport};
     message_decoder.read<QStringList, QString>(
         deps_.buffer_data.available_vars);
 
@@ -70,7 +71,7 @@ void MessageHandler::respond_get_observed_symbols() const {
     for (const auto& name : deps_.buffer_data.held_buffers | std::views::keys) {
         message_composer.push(name);
     }
-    message_composer.send(&deps_.socket);
+    message_composer.send(deps_.transport);
 }
 
 QListWidgetItem* MessageHandler::find_image_list_item(
@@ -135,7 +136,7 @@ void MessageHandler::decode_plot_buffer_contents() {
     auto buff_type = BufferType{};
     auto buff_contents = std::vector<std::byte>{};
 
-    auto message_decoder = MessageDecoder{&deps_.socket};
+    auto message_decoder = MessageDecoder{deps_.transport};
     message_decoder.read(variable_name_str)
         .read(display_name_str)
         .read(pixel_layout_str)
@@ -239,39 +240,21 @@ void MessageHandler::decode_plot_buffer_contents() {
 }
 
 void MessageHandler::decode_incoming_messages() {
-    if (deps_.socket.state() == QTcpSocket::UnconnectedState) [[unlikely]] {
-        QApplication::quit();
-    }
-
     {
         const auto lock = std::unique_lock{deps_.ui_mutex};
         deps_.buffer_data.available_vars.clear();
     }
 
-    if (deps_.socket.bytesAvailable() == 0) [[unlikely]] {
+    if (!deps_.transport.has_data()) [[unlikely]] {
         return;
     }
 
     auto header = MessageType{};
-    if (!deps_.socket.read(std::bit_cast<char*>(&header), sizeof(header)))
-        [[unlikely]] {
-        const auto error = deps_.socket.error();
-        std::cerr << "[Error] Failed to read message header: "
-                  << deps_.socket.errorString().toStdString() << std::endl;
-
-        if (error == QAbstractSocket::RemoteHostClosedError ||
-            error == QAbstractSocket::NetworkError ||
-            error == QAbstractSocket::ConnectionRefusedError ||
-            error == QAbstractSocket::SocketTimeoutError) [[unlikely]] {
-            std::cerr
-                << "[Error] Critical socket error detected. Closing connection."
-                << std::endl;
-            deps_.socket.close();
-        }
+    std::array<std::byte, sizeof(header)> header_bytes{};
+    if (deps_.transport.receive(header_bytes) != header_bytes.size()) [[unlikely]] {
         return;
     }
-
-    deps_.socket.waitForReadyRead(100);
+    header = std::bit_cast<MessageType>(header_bytes);
 
     switch (header) {
     case MessageType::SetAvailableSymbols:
@@ -293,7 +276,7 @@ void MessageHandler::request_plot_buffer(
     auto message_composer = MessageComposer{};
     message_composer.push(MessageType::PlotBufferRequest)
         .push(std::string(buffer_name))
-        .send(&deps_.socket);
+        .send(deps_.transport);
 }
 
 std::string MessageHandler::get_type_label(const int type, const int channels) {

--- a/src/ui/messaging/message_handler.cpp
+++ b/src/ui/messaging/message_handler.cpp
@@ -355,6 +355,13 @@ void MessageHandler::request_plot_buffer(
         .send(deps_.transport);
 }
 
+void MessageHandler::request_export_buffer(const QString& buffer_name) const {
+    auto message_composer = MessageComposer{};
+    message_composer.push(MessageType::ExportBufferRequest)
+        .push(buffer_name.toStdString())
+        .send(deps_.transport);
+}
+
 std::string MessageHandler::get_type_label(const int type, const int channels) {
     auto result = std::stringstream{};
     switch (static_cast<BufferType>(type)) {

--- a/src/ui/messaging/message_handler.cpp
+++ b/src/ui/messaging/message_handler.cpp
@@ -37,6 +37,7 @@
 
 #include "ipc/message_exchange.h"
 #include "ipc/raw_data_decode.h"
+#include "ui/gl_canvas.h"
 #include "ui/main_window/main_window.h"
 #include "visualization/components/buffer.h"
 #include "visualization/stage.h"
@@ -88,6 +89,7 @@ QListWidgetItem* MessageHandler::find_image_list_item(
 
 void MessageHandler::repaint_image_list_icon(
     const std::string& variable_name_str) const {
+#ifndef __EMSCRIPTEN__
     const auto lock = std::unique_lock{deps_.ui_mutex};
     const auto itStage = deps_.buffer_data.stages.find(variable_name_str);
     if (itStage == deps_.buffer_data.stages.end()) [[unlikely]] {
@@ -114,6 +116,7 @@ void MessageHandler::repaint_image_list_icon(
         item != nullptr) {
         item->setIcon(QPixmap::fromImage(bufferIcon));
     }
+#endif
 }
 
 void MessageHandler::update_image_list_label(
@@ -180,19 +183,57 @@ void MessageHandler::decode_plot_buffer_contents() {
         return label_ss.str();
     }();
 
+    const BufferParams params{.buffer = buff_span,
+                              .buffer_width_i = buff_width,
+                              .buffer_height_i = buff_height,
+                              .channels = buff_channels,
+                              .type = buff_type,
+                              .step = buff_stride,
+                              .pixel_layout = pixel_layout_str,
+                              .transpose_buffer = transpose_buffer};
+
     if (auto buffer_stage = deps_.buffer_data.stages.find(variable_name_str);
         buffer_stage == deps_.buffer_data.stages.end()) {
 
         auto stage = deps_.create_stage();
-        if (const BufferParams params{.buffer = buff_span,
-                                      .buffer_width_i = buff_width,
-                                      .buffer_height_i = buff_height,
-                                      .channels = buff_channels,
-                                      .type = buff_type,
-                                      .step = buff_stride,
-                                      .pixel_layout = pixel_layout_str,
-                                      .transpose_buffer = transpose_buffer};
-            !stage->initialize(params)) [[unlikely]] {
+#ifdef __EMSCRIPTEN__
+        const auto ac_enabled = deps_.state.ac_enabled;
+        auto* canvas = deps_.ui_components.ui->bufferPreview;
+        canvas->schedule_gl([this,
+                             stage,
+                             params,
+                             variable_name_str,
+                             ac_enabled]() mutable {
+            if (!stage->initialize(params)) [[unlikely]] {
+                std::cerr << "[Error] Could not initialize OpenGL canvas. Stage "
+                             "initialization failed."
+                          << std::endl;
+                return;
+            }
+            stage->set_contrast_enabled(ac_enabled);
+            {
+                const auto gl_lock = std::unique_lock{deps_.ui_mutex};
+                deps_.buffer_data.stages.try_emplace(variable_name_str, stage);
+            }
+            deps_.select_stage(stage);
+            {
+                const auto ui_lock = std::unique_lock{deps_.ui_mutex};
+                auto* list = deps_.ui_components.ui->imageList;
+                list->blockSignals(true);
+                for (int i = 0; i < list->count(); ++i) {
+                    const auto* item = list->item(i);
+                    if (item->data(Qt::UserRole).toString().toStdString() ==
+                        variable_name_str) {
+                        list->setCurrentRow(i);
+                        break;
+                    }
+                }
+                list->blockSignals(false);
+            }
+            deps_.state.request_render_update = true;
+        });
+#else
+        if (!stage->initialize(params)) [[unlikely]] {
             std::cerr << "[Error] Could not initialize OpenGL canvas. Stage "
                          "initialization failed."
                       << std::endl;
@@ -201,20 +242,28 @@ void MessageHandler::decode_plot_buffer_contents() {
         buffer_stage =
             deps_.buffer_data.stages.try_emplace(variable_name_str, stage)
                 .first;
+#endif
     } else {
-        const BufferParams params{.buffer = buff_span,
-                                  .buffer_width_i = buff_width,
-                                  .buffer_height_i = buff_height,
-                                  .channels = buff_channels,
-                                  .type = buff_type,
-                                  .step = buff_stride,
-                                  .pixel_layout = pixel_layout_str,
-                                  .transpose_buffer = transpose_buffer};
+#ifdef __EMSCRIPTEN__
+        auto* canvas = deps_.ui_components.ui->bufferPreview;
+        canvas->schedule_gl([this, params, variable_name_str]() {
+            const auto gl_lock = std::unique_lock{deps_.ui_mutex};
+            const auto it = deps_.buffer_data.stages.find(variable_name_str);
+            if (it == deps_.buffer_data.stages.end()) [[unlikely]] {
+                return;
+            }
+            if (!it->second->buffer_update(params)) [[unlikely]] {
+                std::cerr << "[Error] Buffer update failed for: "
+                          << variable_name_str << std::endl;
+            }
+        });
+#else
         if (const auto& [buffer_name, buffer_stage_ptr] = *buffer_stage;
             !buffer_stage_ptr->buffer_update(params)) [[unlikely]] {
             std::cerr << "[Error] Buffer update failed for: "
                       << variable_name_str << std::endl;
         }
+#endif
     }
 
     if (auto item = find_image_list_item(variable_name_str); item == nullptr) {
@@ -223,7 +272,14 @@ void MessageHandler::decode_plot_buffer_contents() {
         new_item->setData(Qt::UserRole, QString(variable_name_str.c_str()));
         new_item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled |
                            Qt::ItemIsDragEnabled);
+#ifdef __EMSCRIPTEN__
+        // Stage GL init is deferred; avoid selecting before it exists in the map.
+        deps_.ui_components.ui->imageList->blockSignals(true);
         deps_.ui_components.ui->imageList->addItem(new_item.release());
+        deps_.ui_components.ui->imageList->blockSignals(false);
+#else
+        deps_.ui_components.ui->imageList->addItem(new_item.release());
+#endif
     }
 
     repaint_image_list_icon(variable_name_str);

--- a/src/ui/messaging/message_handler.cpp
+++ b/src/ui/messaging/message_handler.cpp
@@ -130,7 +130,7 @@ void MessageHandler::repaint_image_list_icon(
     };
 
 #ifdef __EMSCRIPTEN__
-    deps_.ui_components.ui->bufferPreview->schedule_gl(paint_icon);
+    deps_.ui_components.ui->bufferPreview->schedule_icon_gl(paint_icon);
 #else
     paint_icon();
 #endif
@@ -275,6 +275,7 @@ void MessageHandler::decode_plot_buffer_contents() {
                           << variable_name_str << std::endl;
             }
             deps_.state.request_icons_update = true;
+            deps_.state.request_render_update = true;
         });
 #else
         if (const auto& [buffer_name, buffer_stage_ptr] = *buffer_stage;

--- a/src/ui/messaging/message_handler.cpp
+++ b/src/ui/messaging/message_handler.cpp
@@ -101,16 +101,27 @@ void MessageHandler::repaint_image_list_icon(
         const auto icon_size = deps_.get_icon_size();
         const auto icon_width = static_cast<int>(icon_size.width());
         const auto icon_height = static_cast<int>(icon_size.height());
+
+        if (!deps_.ui_components.ui->bufferPreview->render_buffer_icon(
+                *stage, icon_width, icon_height)) {
+            return;
+        }
+
+#ifdef __EMSCRIPTEN__
+        const auto bytes_per_line = icon_width * 4;
+        const auto bufferIcon = QImage{stage->get_buffer_icon().data(),
+                                       icon_width,
+                                       icon_height,
+                                       bytes_per_line,
+                                       QImage::Format_RGBA8888};
+#else
         const auto bytes_per_line = icon_width * 3;
-
-        deps_.ui_components.ui->bufferPreview->render_buffer_icon(
-            *stage, icon_width, icon_height);
-
         const auto bufferIcon = QImage{stage->get_buffer_icon().data(),
                                        icon_width,
                                        icon_height,
                                        bytes_per_line,
                                        QImage::Format_RGB888};
+#endif
 
         if (const auto item = find_image_list_item(variable_name_str);
             item != nullptr) {

--- a/src/ui/messaging/message_handler.cpp
+++ b/src/ui/messaging/message_handler.cpp
@@ -234,27 +234,12 @@ void MessageHandler::plot_buffer_from_fields(
     if (deps_.buffer_data.stages.find(variable_name_str) ==
         deps_.buffer_data.stages.end()) {
 
-        // Add the list item before scheduling GL init so that setCurrentRow
-        // inside the lambda finds the item whether run_gl is immediate (native)
-        // or deferred (WASM). blockSignals prevents premature stage selection
-        // before the stage exists in the map.
-        {
-            auto new_item = std::make_unique<QListWidgetItem>(
-                label_str.c_str(), deps_.ui_components.ui->imageList);
-            new_item->setData(Qt::UserRole, QString(variable_name_str.c_str()));
-            new_item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled |
-                               Qt::ItemIsDragEnabled);
-            auto* list = deps_.ui_components.ui->imageList;
-            list->blockSignals(true);
-            list->addItem(new_item.release());
-            list->blockSignals(false);
-        }
-
         auto stage = deps_.create_stage();
         deps_.scheduler.run_gl([this,
                                 stage,
                                 params,
                                 variable_name_str,
+                                label_str,
                                 ac_enabled = deps_.state.ac_enabled]() mutable {
             if (!stage->initialize(params)) [[unlikely]] {
                 std::cerr << "[Error] Could not initialize OpenGL canvas. Stage "
@@ -266,6 +251,21 @@ void MessageHandler::plot_buffer_from_fields(
             {
                 const auto gl_lock = std::unique_lock{deps_.ui_mutex};
                 deps_.buffer_data.stages.try_emplace(variable_name_str, stage);
+            }
+            // Add the list row only after the stage initialized and is in the
+            // map, so a failed init leaves no orphan row. blockSignals prevents
+            // premature stage selection before select_stage is called.
+            {
+                auto new_item = std::make_unique<QListWidgetItem>(
+                    label_str.c_str(), deps_.ui_components.ui->imageList);
+                new_item->setData(Qt::UserRole,
+                                  QString(variable_name_str.c_str()));
+                new_item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled |
+                                   Qt::ItemIsDragEnabled);
+                auto* list = deps_.ui_components.ui->imageList;
+                list->blockSignals(true);
+                list->addItem(new_item.release());
+                list->blockSignals(false);
             }
             deps_.select_stage(stage);
             {

--- a/src/ui/messaging/message_handler.cpp
+++ b/src/ui/messaging/message_handler.cpp
@@ -355,11 +355,18 @@ void MessageHandler::request_plot_buffer(
         .send(deps_.transport);
 }
 
-void MessageHandler::request_export_buffer(const QString& buffer_name) const {
+void MessageHandler::request_export_buffer(const QString& buffer_name,
+                                           const int format,
+                                           const QList<float>& contrast) const {
     auto message_composer = MessageComposer{};
     message_composer.push(MessageType::ExportBufferRequest)
         .push(buffer_name.toStdString())
-        .send(deps_.transport);
+        .push(format);
+    for (int i = 0; i < 8; ++i) {
+        const auto value = i < contrast.size() ? contrast[i] : 0.f;
+        message_composer.push(value);
+    }
+    message_composer.send(deps_.transport);
 }
 
 std::string MessageHandler::get_type_label(const int type, const int channels) {

--- a/src/ui/messaging/message_handler.cpp
+++ b/src/ui/messaging/message_handler.cpp
@@ -37,6 +37,7 @@
 
 #include "ipc/message_exchange.h"
 #include "ipc/raw_data_decode.h"
+#include "platform/gl_dialect.h"
 #include "platform/render_scheduler.h"
 #include "ui/gl_canvas.h"
 #include "ui/main_window/main_window.h"
@@ -110,21 +111,13 @@ void MessageHandler::repaint_image_list_icon(
             return;
         }
 
-#ifdef __EMSCRIPTEN__
-        const auto bytes_per_line = icon_width * 4;
+        const auto& dialect = the_dialect();
+        const auto bytes_per_line = icon_width * dialect.icon_bytes_per_pixel;
         const auto bufferIcon = QImage{stage->get_buffer_icon().data(),
                                        icon_width,
                                        icon_height,
                                        bytes_per_line,
-                                       QImage::Format_RGBA8888};
-#else
-        const auto bytes_per_line = icon_width * 3;
-        const auto bufferIcon = QImage{stage->get_buffer_icon().data(),
-                                       icon_width,
-                                       icon_height,
-                                       bytes_per_line,
-                                       QImage::Format_RGB888};
-#endif
+                                       dialect.icon_image_format};
 
         if (const auto item = find_image_list_item(variable_name_str);
             item != nullptr) {

--- a/src/ui/messaging/message_handler.cpp
+++ b/src/ui/messaging/message_handler.cpp
@@ -37,6 +37,7 @@
 
 #include "ipc/message_exchange.h"
 #include "ipc/raw_data_decode.h"
+#include "platform/render_scheduler.h"
 #include "ui/gl_canvas.h"
 #include "ui/main_window/main_window.h"
 #include "ui/main_window/settings_applier.h"
@@ -131,11 +132,7 @@ void MessageHandler::repaint_image_list_icon(
         }
     };
 
-#ifdef __EMSCRIPTEN__
-    deps_.ui_components.ui->bufferPreview->schedule_icon_gl(paint_icon);
-#else
-    paint_icon();
-#endif
+    deps_.scheduler.run_icon_gl(paint_icon);
 }
 
 void MessageHandler::update_image_list_label(
@@ -234,18 +231,31 @@ void MessageHandler::plot_buffer_from_fields(
                               .pixel_layout = pixel_layout_str,
                               .transpose_buffer = transpose_buffer};
 
-    if (auto buffer_stage = deps_.buffer_data.stages.find(variable_name_str);
-        buffer_stage == deps_.buffer_data.stages.end()) {
+    if (deps_.buffer_data.stages.find(variable_name_str) ==
+        deps_.buffer_data.stages.end()) {
+
+        // Add the list item before scheduling GL init so that setCurrentRow
+        // inside the lambda finds the item whether run_gl is immediate (native)
+        // or deferred (WASM). blockSignals prevents premature stage selection
+        // before the stage exists in the map.
+        {
+            auto new_item = std::make_unique<QListWidgetItem>(
+                label_str.c_str(), deps_.ui_components.ui->imageList);
+            new_item->setData(Qt::UserRole, QString(variable_name_str.c_str()));
+            new_item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled |
+                               Qt::ItemIsDragEnabled);
+            auto* list = deps_.ui_components.ui->imageList;
+            list->blockSignals(true);
+            list->addItem(new_item.release());
+            list->blockSignals(false);
+        }
 
         auto stage = deps_.create_stage();
-#ifdef __EMSCRIPTEN__
-        const auto ac_enabled = deps_.state.ac_enabled;
-        auto* canvas = deps_.ui_components.ui->bufferPreview;
-        canvas->schedule_gl([this,
-                             stage,
-                             params,
-                             variable_name_str,
-                             ac_enabled]() mutable {
+        deps_.scheduler.run_gl([this,
+                                stage,
+                                params,
+                                variable_name_str,
+                                ac_enabled = deps_.state.ac_enabled]() mutable {
             if (!stage->initialize(params)) [[unlikely]] {
                 std::cerr << "[Error] Could not initialize OpenGL canvas. Stage "
                              "initialization failed."
@@ -275,21 +285,8 @@ void MessageHandler::plot_buffer_from_fields(
             deps_.state.request_render_update = true;
             deps_.state.request_icons_update = true;
         });
-#else
-        if (!stage->initialize(params)) [[unlikely]] {
-            std::cerr << "[Error] Could not initialize OpenGL canvas. Stage "
-                         "initialization failed."
-                      << std::endl;
-        }
-        stage->set_contrast_enabled(deps_.state.ac_enabled);
-        buffer_stage =
-            deps_.buffer_data.stages.try_emplace(variable_name_str, stage)
-                .first;
-#endif
     } else {
-#ifdef __EMSCRIPTEN__
-        auto* canvas = deps_.ui_components.ui->bufferPreview;
-        canvas->schedule_gl([this, params, variable_name_str]() {
+        deps_.scheduler.run_gl([this, params, variable_name_str]() {
             const auto gl_lock = std::unique_lock{deps_.ui_mutex};
             const auto it = deps_.buffer_data.stages.find(variable_name_str);
             if (it == deps_.buffer_data.stages.end()) [[unlikely]] {
@@ -302,29 +299,6 @@ void MessageHandler::plot_buffer_from_fields(
             deps_.state.request_icons_update = true;
             deps_.state.request_render_update = true;
         });
-#else
-        if (const auto& [buffer_name, buffer_stage_ptr] = *buffer_stage;
-            !buffer_stage_ptr->buffer_update(params)) [[unlikely]] {
-            std::cerr << "[Error] Buffer update failed for: "
-                      << variable_name_str << std::endl;
-        }
-#endif
-    }
-
-    if (auto item = find_image_list_item(variable_name_str); item == nullptr) {
-        auto new_item = std::make_unique<QListWidgetItem>(
-            label_str.c_str(), deps_.ui_components.ui->imageList);
-        new_item->setData(Qt::UserRole, QString(variable_name_str.c_str()));
-        new_item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled |
-                           Qt::ItemIsDragEnabled);
-#ifdef __EMSCRIPTEN__
-        // Stage GL init is deferred; avoid selecting before it exists in the map.
-        deps_.ui_components.ui->imageList->blockSignals(true);
-        deps_.ui_components.ui->imageList->addItem(new_item.release());
-        deps_.ui_components.ui->imageList->blockSignals(false);
-#else
-        deps_.ui_components.ui->imageList->addItem(new_item.release());
-#endif
     }
 
     repaint_image_list_icon(variable_name_str);

--- a/src/ui/messaging/message_handler.cpp
+++ b/src/ui/messaging/message_handler.cpp
@@ -39,6 +39,8 @@
 #include "ipc/raw_data_decode.h"
 #include "ui/gl_canvas.h"
 #include "ui/main_window/main_window.h"
+#include "ui/main_window/settings_applier.h"
+#include "ui/messaging/session_state_codec.h"
 #include "visualization/components/buffer.h"
 #include "visualization/stage.h"
 
@@ -315,6 +317,22 @@ void MessageHandler::decode_plot_buffer_contents() {
     deps_.state.request_render_update = true;
 }
 
+void MessageHandler::decode_apply_session_state() const {
+    auto message_decoder = MessageDecoder{deps_.transport};
+    auto json = std::string{};
+    message_decoder.read(json);
+
+    if (deps_.settings_applier == nullptr) {
+        return;
+    }
+    auto fields = SessionStateFields{};
+    if (!parse_session_state_json(QByteArray::fromStdString(json), fields)) {
+        std::cerr << "[OID] Invalid ApplySessionState JSON" << std::endl;
+        return;
+    }
+    apply_session_state_fields(fields, *deps_.settings_applier);
+}
+
 void MessageHandler::decode_incoming_messages() {
     {
         const auto lock = std::unique_lock{deps_.ui_mutex};
@@ -344,6 +362,9 @@ void MessageHandler::decode_incoming_messages() {
         break;
     case MessageType::ExportSelectedBuffer:
         emit exportSelectedBufferRequested();
+        break;
+    case MessageType::ApplySessionState:
+        decode_apply_session_state();
         break;
     default:
         break;

--- a/src/ui/messaging/message_handler.cpp
+++ b/src/ui/messaging/message_handler.cpp
@@ -170,6 +170,29 @@ void MessageHandler::decode_plot_buffer_contents() {
         .read(buff_type)
         .read(buff_contents);
 
+    plot_buffer_from_fields(variable_name_str,
+                            display_name_str,
+                            pixel_layout_str,
+                            transpose_buffer,
+                            buff_width,
+                            buff_height,
+                            buff_channels,
+                            buff_stride,
+                            buff_type,
+                            std::move(buff_contents));
+}
+
+void MessageHandler::plot_buffer_from_fields(
+    const std::string& variable_name_str,
+    const std::string& display_name_str,
+    const std::string& pixel_layout_str,
+    bool transpose_buffer,
+    int buff_width,
+    int buff_height,
+    int buff_channels,
+    int buff_stride,
+    BufferType buff_type,
+    std::vector<std::byte> buff_contents) {
     const auto lock = std::unique_lock{deps_.ui_mutex};
 
     if (buff_type == BufferType::Float64) {

--- a/src/ui/messaging/message_handler.h
+++ b/src/ui/messaging/message_handler.h
@@ -39,6 +39,7 @@
 #include <QSizeF>
 #include <QString>
 
+#include "ipc/buffer_assembler.h"
 #include "ipc/raw_data_decode.h"
 #include "ipc/transport.h"
 
@@ -87,6 +88,7 @@ class MessageHandler : public QObject {
 
   private:
     Dependencies deps_;
+    BufferAssembler buffer_assembler_{};
 
     void decode_set_available_symbols() const;
     void respond_get_observed_symbols() const;
@@ -101,6 +103,9 @@ class MessageHandler : public QObject {
                                  int buff_stride,
                                  BufferType buff_type,
                                  std::vector<std::byte> buff_contents);
+    void decode_plot_buffer_begin();
+    void decode_plot_buffer_chunk();
+    void decode_plot_buffer_end();
     void decode_apply_session_state() const;
 
     QListWidgetItem*

--- a/src/ui/messaging/message_handler.h
+++ b/src/ui/messaging/message_handler.h
@@ -46,6 +46,7 @@ namespace oid {
 struct BufferData;
 struct UIComponents;
 struct WindowState;
+class SettingsApplier;
 class Stage;
 
 class MessageHandler : public QObject {
@@ -61,6 +62,9 @@ class MessageHandler : public QObject {
         std::function<QSizeF()> get_icon_size;
         std::function<std::shared_ptr<Stage>()> create_stage;
         std::function<void(const std::shared_ptr<Stage>&)> select_stage;
+        // Non-owning; applies inbound ApplySessionState. May be null where no
+        // session state is ever received (e.g. desktop).
+        SettingsApplier* settings_applier = nullptr;
     };
 
     explicit MessageHandler(Dependencies deps, QObject* parent = nullptr);
@@ -83,6 +87,7 @@ class MessageHandler : public QObject {
     void decode_set_available_symbols() const;
     void respond_get_observed_symbols() const;
     void decode_plot_buffer_contents();
+    void decode_apply_session_state() const;
 
     QListWidgetItem*
     find_image_list_item(const std::string& variable_name_str) const;

--- a/src/ui/messaging/message_handler.h
+++ b/src/ui/messaging/message_handler.h
@@ -50,6 +50,7 @@ namespace oid {
 struct BufferData;
 struct UIComponents;
 struct WindowState;
+class RenderScheduler;
 class SettingsApplier;
 class Stage;
 
@@ -63,6 +64,7 @@ class MessageHandler : public QObject {
         WindowState& state;
         UIComponents& ui_components;
         ITransport& transport;
+        RenderScheduler& scheduler;
         std::function<QSizeF()> get_icon_size;
         std::function<std::shared_ptr<Stage>()> create_stage;
         std::function<void(const std::shared_ptr<Stage>&)> select_stage;

--- a/src/ui/messaging/message_handler.h
+++ b/src/ui/messaging/message_handler.h
@@ -32,6 +32,7 @@
 #include <string>
 #include <string_view>
 
+#include <QList>
 #include <QObject>
 #include <QSizeF>
 #include <QString>
@@ -66,7 +67,8 @@ class MessageHandler : public QObject {
 
     void decode_incoming_messages();
     void request_plot_buffer(std::string_view buffer_name) const;
-    void request_export_buffer(const QString& buffer_name) const;
+    void request_export_buffer(const QString& buffer_name, int format,
+                               const QList<float>& contrast) const;
     void repaint_image_list_icon(const std::string& variable_name_str) const;
 
   signals:

--- a/src/ui/messaging/message_handler.h
+++ b/src/ui/messaging/message_handler.h
@@ -73,6 +73,7 @@ class MessageHandler : public QObject {
     void request_plot_buffer(std::string_view buffer_name) const;
     void request_export_buffer(const QString& buffer_name, int format,
                                const QList<float>& contrast) const;
+    void notify_buffer_removed(const QString& buffer_name) const;
     void repaint_image_list_icon(const std::string& variable_name_str) const;
 
   signals:

--- a/src/ui/messaging/message_handler.h
+++ b/src/ui/messaging/message_handler.h
@@ -34,6 +34,7 @@
 
 #include <QObject>
 #include <QSizeF>
+#include <QString>
 
 #include "ipc/transport.h"
 
@@ -65,6 +66,7 @@ class MessageHandler : public QObject {
 
     void decode_incoming_messages();
     void request_plot_buffer(std::string_view buffer_name) const;
+    void request_export_buffer(const QString& buffer_name) const;
     void repaint_image_list_icon(const std::string& variable_name_str) const;
 
   signals:

--- a/src/ui/messaging/message_handler.h
+++ b/src/ui/messaging/message_handler.h
@@ -26,17 +26,20 @@
 #ifndef MESSAGE_HANDLER_H_
 #define MESSAGE_HANDLER_H_
 
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include <QList>
 #include <QObject>
 #include <QSizeF>
 #include <QString>
 
+#include "ipc/raw_data_decode.h"
 #include "ipc/transport.h"
 
 class QListWidgetItem;
@@ -88,6 +91,16 @@ class MessageHandler : public QObject {
     void decode_set_available_symbols() const;
     void respond_get_observed_symbols() const;
     void decode_plot_buffer_contents();
+    void plot_buffer_from_fields(const std::string& variable_name_str,
+                                 const std::string& display_name_str,
+                                 const std::string& pixel_layout_str,
+                                 bool transpose_buffer,
+                                 int buff_width,
+                                 int buff_height,
+                                 int buff_channels,
+                                 int buff_stride,
+                                 BufferType buff_type,
+                                 std::vector<std::byte> buff_contents);
     void decode_apply_session_state() const;
 
     QListWidgetItem*

--- a/src/ui/messaging/message_handler.h
+++ b/src/ui/messaging/message_handler.h
@@ -35,8 +35,9 @@
 #include <QObject>
 #include <QSizeF>
 
+#include "ipc/transport.h"
+
 class QListWidgetItem;
-class QTcpSocket;
 
 namespace oid {
 
@@ -54,7 +55,7 @@ class MessageHandler : public QObject {
         BufferData& buffer_data;
         WindowState& state;
         UIComponents& ui_components;
-        QTcpSocket& socket;
+        ITransport& transport;
         std::function<QSizeF()> get_icon_size;
         std::function<std::shared_ptr<Stage>()> create_stage;
     };

--- a/src/ui/messaging/message_handler.h
+++ b/src/ui/messaging/message_handler.h
@@ -75,6 +75,7 @@ class MessageHandler : public QObject {
     void acMinLabelsResetRequested();
     void acMaxLabelsResetRequested();
     void settingsPersistenceRequested();
+    void exportSelectedBufferRequested();
 
   private:
     Dependencies deps_;

--- a/src/ui/messaging/message_handler.h
+++ b/src/ui/messaging/message_handler.h
@@ -58,6 +58,7 @@ class MessageHandler : public QObject {
         ITransport& transport;
         std::function<QSizeF()> get_icon_size;
         std::function<std::shared_ptr<Stage>()> create_stage;
+        std::function<void(const std::shared_ptr<Stage>&)> select_stage;
     };
 
     explicit MessageHandler(Dependencies deps, QObject* parent = nullptr);

--- a/src/ui/messaging/session_state_apply.cpp
+++ b/src/ui/messaging/session_state_apply.cpp
@@ -1,0 +1,99 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "session_state_codec.h"
+
+#include "ui/main_window/settings_applier.h"
+
+namespace oid {
+
+namespace {
+
+QString colorspace_channel_from_char(const QChar& character) {
+    switch (character.toLatin1()) {
+    case 'b':
+        return QStringLiteral("blue");
+    case 'g':
+        return QStringLiteral("green");
+    case 'r':
+        return QStringLiteral("red");
+    case 'a':
+        return QStringLiteral("alpha");
+    default:
+        return {};
+    }
+}
+
+} // namespace
+
+void apply_session_state_fields(const SessionStateFields& fields,
+                                SettingsApplier& applier) {
+    if (fields.framerate.has_value()) {
+        applier.apply_rendering_settings(*fields.framerate);
+    }
+    if (fields.default_export_suffix.has_value()) {
+        applier.apply_export_settings(*fields.default_export_suffix);
+    }
+    if (fields.list_position.has_value()) {
+        applier.apply_ui_list_position(*fields.list_position);
+    }
+    if (fields.splitter_sizes.has_value()) {
+        applier.apply_ui_splitter_sizes(*fields.splitter_sizes);
+    }
+    if (fields.minmax_compact.has_value() && fields.minmax_visible.has_value()) {
+        applier.apply_ui_minmax_compact(*fields.minmax_compact,
+                                        *fields.minmax_visible);
+    } else if (fields.minmax_visible.has_value()) {
+        applier.apply_ui_minmax_visible(*fields.minmax_visible);
+    }
+    if (fields.colorspace.has_value()) {
+        const auto& colorspace_str = *fields.colorspace;
+        QString ch1;
+        QString ch2;
+        QString ch3;
+        QString ch4;
+        if (!colorspace_str.isEmpty()) {
+            ch1 = colorspace_channel_from_char(colorspace_str.at(0));
+        }
+        if (colorspace_str.size() > 1) {
+            ch2 = colorspace_channel_from_char(colorspace_str.at(1));
+        }
+        if (colorspace_str.size() > 2) {
+            ch3 = colorspace_channel_from_char(colorspace_str.at(2));
+        }
+        if (colorspace_str.size() > 3) {
+            ch4 = colorspace_channel_from_char(colorspace_str.at(3));
+        }
+        applier.apply_ui_colorspace(ch1, ch2, ch3, ch4);
+    }
+    if (fields.contrast_enabled.has_value()) {
+        applier.apply_ui_contrast_enabled(*fields.contrast_enabled);
+    }
+    if (fields.link_views_enabled.has_value()) {
+        applier.apply_ui_link_views_enabled(*fields.link_views_enabled);
+    }
+}
+
+} // namespace oid

--- a/src/ui/messaging/session_state_codec.cpp
+++ b/src/ui/messaging/session_state_codec.cpp
@@ -1,0 +1,140 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "session_state_codec.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+
+namespace oid {
+
+namespace {
+
+std::optional<bool> read_bool(const QJsonObject& obj, const char* key) {
+    if (!obj.contains(key)) {
+        return std::nullopt;
+    }
+    return obj.value(key).toBool();
+}
+
+std::optional<double> read_double(const QJsonObject& obj, const char* key) {
+    if (!obj.contains(key)) {
+        return std::nullopt;
+    }
+    return obj.value(key).toDouble();
+}
+
+std::optional<QString> read_string(const QJsonObject& obj, const char* key) {
+    if (!obj.contains(key)) {
+        return std::nullopt;
+    }
+    return obj.value(key).toString();
+}
+
+} // namespace
+
+bool parse_session_state_json(const QByteArray& json, SessionStateFields& out) {
+    const auto doc = QJsonDocument::fromJson(json);
+    if (!doc.isObject()) {
+        return false;
+    }
+
+    const auto root = doc.object();
+
+    if (const auto rendering = root.value(QStringLiteral("rendering")).toObject();
+        !rendering.isEmpty()) {
+        out.framerate = read_double(rendering, "framerate");
+    }
+
+    if (const auto export_group = root.value(QStringLiteral("export")).toObject();
+        !export_group.isEmpty()) {
+        out.default_export_suffix = read_string(export_group, "defaultSuffix");
+    }
+
+    if (const auto ui = root.value(QStringLiteral("ui")).toObject(); !ui.isEmpty()) {
+        out.list_position = read_string(ui, "listPosition");
+        out.minmax_visible = read_bool(ui, "minmaxVisible");
+        out.minmax_compact = read_bool(ui, "minmaxCompact");
+        out.contrast_enabled = read_bool(ui, "contrastEnabled");
+        out.link_views_enabled = read_bool(ui, "linkViewsEnabled");
+        out.colorspace = read_string(ui, "colorspace");
+
+        if (ui.contains(QStringLiteral("splitterSizes"))) {
+            const auto sizes_array =
+                ui.value(QStringLiteral("splitterSizes")).toArray();
+            auto sizes = QList<int>{};
+            for (const auto& value : sizes_array) {
+                sizes.append(value.toInt());
+            }
+            out.splitter_sizes = sizes;
+        }
+    }
+
+    return true;
+}
+
+QByteArray serialize_session_state_delta(
+    const SettingsManager::DataCallbacks& callbacks,
+    const SessionStateExtraInputs& extra) {
+    auto rendering = QJsonObject{};
+    rendering.insert(QStringLiteral("framerate"), callbacks.getRenderFramerate());
+
+    auto exp = QJsonObject{};
+    exp.insert(QStringLiteral("defaultSuffix"), callbacks.getDefaultExportSuffix());
+
+    auto ui = QJsonObject{};
+    const auto splitter_sizes = callbacks.getSplitterSizes();
+    auto sizes_array = QJsonArray{};
+    for (const int size : splitter_sizes) {
+        sizes_array.append(size);
+    }
+    ui.insert(QStringLiteral("splitterSizes"), sizes_array);
+    ui.insert(QStringLiteral("minmaxVisible"), callbacks.getMinMaxVisible());
+    ui.insert(QStringLiteral("contrastEnabled"), callbacks.getContrastEnabled());
+    ui.insert(QStringLiteral("linkViewsEnabled"), callbacks.getLinkViewsEnabled());
+
+    if (extra.getListPosition) {
+        const auto list_position = extra.getListPosition();
+        if (!list_position.isEmpty()) {
+            ui.insert(QStringLiteral("listPosition"), list_position);
+        }
+    }
+    if (extra.getColorspace) {
+        const auto colorspace = extra.getColorspace();
+        if (!colorspace.isEmpty()) {
+            ui.insert(QStringLiteral("colorspace"), colorspace);
+        }
+    }
+
+    auto root = QJsonObject{};
+    root.insert(QStringLiteral("rendering"), rendering);
+    root.insert(QStringLiteral("export"), exp);
+    root.insert(QStringLiteral("ui"), ui);
+    return QJsonDocument{root}.toJson(QJsonDocument::Compact);
+}
+
+} // namespace oid

--- a/src/ui/messaging/session_state_codec.h
+++ b/src/ui/messaging/session_state_codec.h
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef SESSION_STATE_CODEC_H_
+#define SESSION_STATE_CODEC_H_
+
+#include <functional>
+#include <optional>
+
+#include <QByteArray>
+#include <QList>
+#include <QString>
+
+#include "ui/main_window/settings_manager.h"
+
+namespace oid {
+
+class SettingsApplier;
+
+struct SessionStateFields {
+    std::optional<double> framerate;
+    std::optional<QString> default_export_suffix;
+    std::optional<QList<int>> splitter_sizes;
+    std::optional<QString> list_position;
+    std::optional<bool> minmax_visible;
+    std::optional<bool> minmax_compact;
+    std::optional<bool> contrast_enabled;
+    std::optional<bool> link_views_enabled;
+    std::optional<QString> colorspace;
+};
+
+struct SessionStateExtraInputs {
+    std::function<QString()> getListPosition;
+    std::function<QString()> getColorspace;
+};
+
+bool parse_session_state_json(const QByteArray& json, SessionStateFields& out);
+
+void apply_session_state_fields(const SessionStateFields& fields,
+                                SettingsApplier& applier);
+
+QByteArray serialize_session_state_delta(
+    const SettingsManager::DataCallbacks& callbacks,
+    const SessionStateExtraInputs& extra);
+
+} // namespace oid
+
+#endif // SESSION_STATE_CODEC_H_

--- a/src/visualization/components/buffer.cpp
+++ b/src/visualization/components/buffer.cpp
@@ -362,9 +362,9 @@ void Buffer::configure(const BufferParams& params) {
     // Validate buffer size (prevent potential DoS)
     // Calculate: width * height * step (step is stride in bytes per row)
     // Use checked multiplication to prevent overflow
-    const auto width_u = static_cast<std::size_t>(params.buffer_width_i);
-    const auto height_u = static_cast<std::size_t>(params.buffer_height_i);
-    const auto step_u = static_cast<std::size_t>(params.step);
+    const auto width_u = static_cast<std::uint64_t>(params.buffer_width_i);
+    const auto height_u = static_cast<std::uint64_t>(params.buffer_height_i);
+    const auto step_u = static_cast<std::uint64_t>(params.step);
 
     // Check for potential overflow before multiplication
     if (width_u > 0 && height_u > BufferConstants::MAX_BUFFER_SIZE / width_u) {
@@ -738,6 +738,21 @@ void Buffer::setup_gl_buffer() {
         tex_format = GL_RGBA;
     }
 
+    auto internal_format = GLuint{GL_RGBA32F};
+#ifdef __EMSCRIPTEN__
+    if (tex_type == GL_FLOAT) {
+        internal_format = GL_RGBA32F;
+    } else if (tex_format == GL_RED) {
+        internal_format = GL_R8;
+    } else if (tex_format == GL_RG) {
+        internal_format = GL_RG8;
+    } else if (tex_format == GL_RGB) {
+        internal_format = GL_RGB8;
+    } else {
+        internal_format = GL_RGBA8;
+    }
+#endif
+
     auto remaining_h = buffer_height_i;
 
     gl_canvas_ref().glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
@@ -762,7 +777,7 @@ void Buffer::setup_gl_buffer() {
 
             gl_canvas_ref().glTexImage2D(GL_TEXTURE_2D,
                                          0,
-                                         GL_RGBA32F,
+                                         static_cast<GLint>(internal_format),
                                          buff_w,
                                          buff_h,
                                          0,

--- a/src/visualization/components/buffer.cpp
+++ b/src/visualization/components/buffer.cpp
@@ -36,6 +36,7 @@
 
 #include "camera.h"
 #include "math/linear_algebra.h"
+#include "platform/gl_dialect.h"
 #include "visualization/game_object.h"
 #include "visualization/shaders/oid_shaders.h"
 #include "visualization/stage.h"
@@ -733,28 +734,8 @@ void Buffer::setup_gl_buffer() {
         tex_format = GL_RGBA;
     }
 
-    auto internal_format = GLuint{GL_RGBA32F};
-#ifdef __EMSCRIPTEN__
-    if (tex_type == GL_FLOAT) {
-        if (tex_format == GL_RED) {
-            internal_format = GL_R32F;
-        } else if (tex_format == GL_RG) {
-            internal_format = GL_RG32F;
-        } else if (tex_format == GL_RGB) {
-            internal_format = GL_RGB32F;
-        } else {
-            internal_format = GL_RGBA32F;
-        }
-    } else if (tex_format == GL_RED) {
-        internal_format = GL_R8;
-    } else if (tex_format == GL_RG) {
-        internal_format = GL_RG8;
-    } else if (tex_format == GL_RGB) {
-        internal_format = GL_RGB8;
-    } else {
-        internal_format = GL_RGBA8;
-    }
-#endif
+    const auto internal_format =
+        the_dialect().texture_internal_format(tex_type, tex_format);
 
     auto remaining_h = buffer_height_i;
 
@@ -807,10 +788,10 @@ void Buffer::setup_gl_buffer() {
                 GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
             gl_canvas_ref().glTexParameteri(
                 GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-#ifndef __EMSCRIPTEN__
-            gl_canvas_ref().glTexParameteri(
-                GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
-#endif
+            if (the_dialect().has_texture_wrap_r) {
+                gl_canvas_ref().glTexParameteri(
+                    GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+            }
         }
     }
 

--- a/src/visualization/components/buffer.cpp
+++ b/src/visualization/components/buffer.cpp
@@ -359,21 +359,16 @@ void Buffer::configure(const BufferParams& params) {
         return;
     }
 
-    // Validate buffer size (prevent potential DoS)
-    // Calculate: width * height * step (step is stride in bytes per row)
-    // Use checked multiplication to prevent overflow
-    const auto width_u = static_cast<std::uint64_t>(params.buffer_width_i);
-    const auto height_u = static_cast<std::uint64_t>(params.buffer_height_i);
-    const auto step_u = static_cast<std::uint64_t>(params.step);
-
-    // Check for potential overflow before multiplication
-    if (width_u > 0 && height_u > BufferConstants::MAX_BUFFER_SIZE / width_u) {
-        std::cerr << "[Error] Buffer dimensions too large (would overflow)"
-                  << std::endl;
-        return;
-    }
-
-    if (const auto buffer_size = width_u * height_u * step_u;
+    // Validate buffer size (prevent potential DoS). The real memory footprint
+    // is the size of the received pixel data. `step` is in pixels per row (see
+    // GL_UNPACK_ROW_LENGTH below), so a width*height*step estimate would
+    // double-count the row width and reject valid large buffers. Validate the
+    // actual byte count against the same 16 GB ceiling the desktop build uses.
+    // Cast to uint64 so the comparison is well-formed on 32-bit (WASM) builds,
+    // where size_t cannot represent the 16 GB ceiling (the real WASM limit is
+    // the ~2 GB heap; this ceiling only ever binds on the 64-bit desktop build).
+    if (const auto buffer_size =
+            static_cast<std::uint64_t>(params.buffer.size());
         buffer_size > BufferConstants::MAX_BUFFER_SIZE) {
         std::cerr << "[Error] Buffer size too large: " << buffer_size
                   << " bytes (maximum: " << BufferConstants::MAX_BUFFER_SIZE

--- a/src/visualization/components/buffer.cpp
+++ b/src/visualization/components/buffer.cpp
@@ -741,7 +741,15 @@ void Buffer::setup_gl_buffer() {
     auto internal_format = GLuint{GL_RGBA32F};
 #ifdef __EMSCRIPTEN__
     if (tex_type == GL_FLOAT) {
-        internal_format = GL_RGBA32F;
+        if (tex_format == GL_RED) {
+            internal_format = GL_R32F;
+        } else if (tex_format == GL_RG) {
+            internal_format = GL_RG32F;
+        } else if (tex_format == GL_RGB) {
+            internal_format = GL_RGB32F;
+        } else {
+            internal_format = GL_RGBA32F;
+        }
     } else if (tex_format == GL_RED) {
         internal_format = GL_R8;
     } else if (tex_format == GL_RG) {

--- a/src/visualization/components/buffer.cpp
+++ b/src/visualization/components/buffer.cpp
@@ -789,8 +789,10 @@ void Buffer::setup_gl_buffer() {
                 GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
             gl_canvas_ref().glTexParameteri(
                 GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+#ifndef __EMSCRIPTEN__
             gl_canvas_ref().glTexParameteri(
                 GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+#endif
         }
     }
 

--- a/src/visualization/components/buffer.h
+++ b/src/visualization/components/buffer.h
@@ -27,6 +27,7 @@
 #define BUFFER_H_
 
 #include <array>
+#include <cstdint>
 #include <span>
 #include <sstream>
 #include <string>
@@ -46,7 +47,7 @@ constexpr int MAX_BUFFER_DIMENSION =
     131072; // 2^17 = 128K (closest power of 2 to 100k)
 constexpr int MIN_CHANNELS = 1;
 constexpr int MAX_CHANNELS = 4;
-constexpr std::size_t MAX_BUFFER_SIZE =
+constexpr std::uint64_t MAX_BUFFER_SIZE =
     16ULL * 1024ULL * 1024ULL * 1024ULL; // 16GB
 } // namespace BufferConstants
 

--- a/src/visualization/components/camera.cpp
+++ b/src/visualization/components/camera.cpp
@@ -93,8 +93,8 @@ void Camera::window_resized(const int w, const int h) {
 void Camera::scroll_callback(const float delta) {
     const auto mouse_x = static_cast<float>(gl_canvas_ref().mouse_x());
     const auto mouse_y = static_cast<float>(gl_canvas_ref().mouse_y());
-    const auto win_w = static_cast<float>(gl_canvas_ref().width());
-    const auto win_h = static_cast<float>(gl_canvas_ref().height());
+    const auto win_w = static_cast<float>(gl_canvas_ref().render_width());
+    const auto win_h = static_cast<float>(gl_canvas_ref().render_height());
 
     const auto mouse_pos_ndc = vec4{2.0f * (mouse_x - win_w / 2.0f) / win_w,
                                     -2.0f * (mouse_y - win_h / 2.0f) / win_h,
@@ -145,7 +145,8 @@ void Camera::update_object_pose() const {
 }
 
 bool Camera::post_initialize() {
-    window_resized(gl_canvas_ref().width(), gl_canvas_ref().height());
+    window_resized(gl_canvas_ref().render_width(),
+                   gl_canvas_ref().render_height());
     set_initial_zoom();
     update_object_pose();
 

--- a/src/visualization/shader.cpp
+++ b/src/visualization/shader.cpp
@@ -29,7 +29,8 @@
 #include <sstream>
 #include <string>
 
-#ifdef __EMSCRIPTEN__
+#include "platform/gl_dialect.h"
+
 namespace {
 
 void replace_all(std::string& text,
@@ -55,7 +56,6 @@ std::string adapt_shader_source_for_gles(const GLuint type, std::string source) 
 }
 
 } // namespace
-#endif
 
 namespace oid {
 
@@ -225,31 +225,20 @@ const char* ShaderProgram::get_source_channel_define() const {
 GLuint ShaderProgram::compile(const GLuint type, const GLchar* source) const {
     const auto shader = gl_canvas_.glCreateShader(type);
 
-#ifdef __EMSCRIPTEN__
-    auto adapted = adapt_shader_source_for_gles(type, std::string{source});
+    const auto& dialect = the_dialect();
+    const auto body = dialect.uses_out_color
+        ? adapt_shader_source_for_gles(type, std::string{source})
+        : std::string{source};
     std::ostringstream full_source;
-    full_source << "#version 300 es\n";
+    full_source << dialect.version_directive;
     if (type == GL_FRAGMENT_SHADER) {
-        full_source << "precision mediump float;\n"
-                    << "precision mediump int;\n"
-                    << "out vec4 oid_fragColor;\n";
+        full_source << dialect.fragment_preamble;
     }
     full_source << get_texel_format_define() << get_source_channel_define()
-                << "#define PIXEL_LAYOUT " << pixel_layout_ << "\n"
-                << adapted;
+                << "#define PIXEL_LAYOUT " << pixel_layout_ << "\n" << body;
     const auto source_string = full_source.str();
     const auto* src_ptr = source_string.c_str();
     gl_canvas_.glShaderSource(shader, 1, &src_ptr, nullptr);
-#else
-    auto src = std::array{"#version 120\n",
-                          get_texel_format_define(),
-                          get_source_channel_define(),
-                          "#define PIXEL_LAYOUT ",
-                          pixel_layout_.data(),
-                          source};
-
-    gl_canvas_.glShaderSource(shader, 6, src.data(), nullptr);
-#endif
     gl_canvas_.glCompileShader(shader);
 
     auto compiled = GLint{};

--- a/src/visualization/shader.cpp
+++ b/src/visualization/shader.cpp
@@ -26,6 +26,36 @@
 #include "shader.h"
 
 #include <iostream>
+#include <sstream>
+#include <string>
+
+#ifdef __EMSCRIPTEN__
+namespace {
+
+void replace_all(std::string& text,
+                 const std::string_view from,
+                 const std::string_view to) {
+    auto pos = std::size_t{0};
+    while ((pos = text.find(from, pos)) != std::string::npos) {
+        text.replace(pos, from.size(), to);
+        pos += to.size();
+    }
+}
+
+std::string adapt_shader_source_for_gles(const GLuint type, std::string source) {
+    replace_all(source, "attribute ", "in ");
+    if (type == GL_FRAGMENT_SHADER) {
+        replace_all(source, "varying ", "in ");
+        replace_all(source, "gl_FragColor", "oid_fragColor");
+    } else {
+        replace_all(source, "varying ", "out ");
+    }
+    replace_all(source, "texture2D", "texture");
+    return source;
+}
+
+} // namespace
+#endif
 
 namespace oid {
 
@@ -195,6 +225,22 @@ const char* ShaderProgram::get_source_channel_define() const {
 GLuint ShaderProgram::compile(const GLuint type, const GLchar* source) const {
     const auto shader = gl_canvas_.glCreateShader(type);
 
+#ifdef __EMSCRIPTEN__
+    auto adapted = adapt_shader_source_for_gles(type, std::string{source});
+    std::ostringstream full_source;
+    full_source << "#version 300 es\n";
+    if (type == GL_FRAGMENT_SHADER) {
+        full_source << "precision mediump float;\n"
+                    << "precision mediump int;\n"
+                    << "out vec4 oid_fragColor;\n";
+    }
+    full_source << get_texel_format_define() << get_source_channel_define()
+                << "#define PIXEL_LAYOUT " << pixel_layout_ << "\n"
+                << adapted;
+    const auto source_string = full_source.str();
+    const auto* src_ptr = source_string.c_str();
+    gl_canvas_.glShaderSource(shader, 1, &src_ptr, nullptr);
+#else
     auto src = std::array{"#version 120\n",
                           get_texel_format_define(),
                           get_source_channel_define(),
@@ -203,6 +249,7 @@ GLuint ShaderProgram::compile(const GLuint type, const GLchar* source) const {
                           source};
 
     gl_canvas_.glShaderSource(shader, 6, src.data(), nullptr);
+#endif
     gl_canvas_.glCompileShader(shader);
 
     auto compiled = GLint{};
@@ -216,7 +263,7 @@ GLuint ShaderProgram::compile(const GLuint type, const GLchar* source) const {
         std::cerr << "Failed to compile shader_type: " + get_shader_type(type)
                   << std::endl
                   << log << std::endl;
-        return false;
+        return 0;
     }
     return shader;
 }

--- a/src/visualization/shaders/background_fs.cpp
+++ b/src/visualization/shaders/background_fs.cpp
@@ -28,11 +28,11 @@ extern auto const background_frag_shader{R"glsl(
 
 void main()
 {
-    const int tile_size = 10;
+    const float tile_size = 10.0;
     float intensity = mod(floor(gl_FragCoord.x / tile_size) +
-                          floor(gl_FragCoord.y / tile_size), 2);
+                          floor(gl_FragCoord.y / tile_size), 2.0);
     intensity = intensity * 0.2 + 0.4;
-    gl_FragColor = vec4(vec3(intensity), 1);
+    gl_FragColor = vec4(vec3(intensity), 1.0);
 }
 
 )glsl"};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -112,3 +112,25 @@ target_sources(test_message_exchange PRIVATE
 
 add_test(NAME MessageExchangeTests COMMAND test_message_exchange)
 
+# Test for ITransport / TcpTransport
+add_executable(test_transport test_transport.cpp)
+
+target_include_directories(test_transport
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src
+)
+
+target_link_libraries(test_transport
+    PRIVATE
+    Qt6::Network
+    Qt6::Core
+    GTest::gtest_main
+    GTest::gtest
+)
+
+target_sources(test_transport PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ipc/tcp_transport.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ipc/message_exchange.cpp
+)
+
+add_test(NAME TransportTests COMMAND test_transport)
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -158,3 +158,24 @@ target_sources(test_session_state_codec PRIVATE
 
 add_test(NAME SessionStateCodec COMMAND test_session_state_codec)
 
+# Test BufferAssembler
+add_executable(test_buffer_assembler test_buffer_assembler.cpp)
+
+target_include_directories(test_buffer_assembler
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/ipc
+)
+
+target_link_libraries(test_buffer_assembler
+    PRIVATE
+    GTest::gtest_main
+    GTest::gtest
+)
+
+# Add buffer_assembler source file directly for testing
+target_sources(test_buffer_assembler PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ipc/buffer_assembler.cpp
+)
+
+add_test(NAME BufferAssemblerTests COMMAND test_buffer_assembler)
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -130,7 +130,7 @@ target_link_libraries(test_transport
 
 target_sources(test_transport PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/ipc/tcp_transport.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ipc/postmessage_transport.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/postmessage_transport.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/ipc/message_exchange.cpp
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -108,6 +108,7 @@ target_link_libraries(test_message_exchange
 # Add message_exchange source file directly for testing
 target_sources(test_message_exchange PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/ipc/message_exchange.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ipc/tcp_transport.cpp
 )
 
 add_test(NAME MessageExchangeTests COMMAND test_message_exchange)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -130,6 +130,7 @@ target_link_libraries(test_transport
 
 target_sources(test_transport PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/ipc/tcp_transport.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ipc/postmessage_transport.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/ipc/message_exchange.cpp
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -136,3 +136,25 @@ target_sources(test_transport PRIVATE
 
 add_test(NAME TransportTests COMMAND test_transport)
 
+# Test session state JSON codec
+add_executable(test_session_state_codec
+    test_session_state_codec.cpp
+)
+
+target_include_directories(test_session_state_codec
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src
+)
+
+target_link_libraries(test_session_state_codec
+    PRIVATE
+    Qt6::Core
+    GTest::gtest_main
+    GTest::gtest
+)
+
+target_sources(test_session_state_codec PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ui/messaging/session_state_codec.cpp
+)
+
+add_test(NAME SessionStateCodec COMMAND test_session_state_codec)
+

--- a/tests/test_buffer_assembler.cpp
+++ b/tests/test_buffer_assembler.cpp
@@ -65,15 +65,21 @@ TEST(BufferAssemblerTests, ReassemblesRowStripsIntoContiguousBuffer) {
   BufferAssembler a;
   a.begin(make_begin("buf", 8, height, stride, total));
 
-  const auto strip0 = iota_bytes(2 * stride);
-  ASSERT_TRUE(a.chunk("buf", 0, 2, std::span{strip0.data(), strip0.size()}));
+  // Create a single contiguous source buffer
+  const auto full = iota_bytes(total);
 
-  const auto strip1 = iota_bytes(2 * stride);
-  ASSERT_TRUE(a.chunk("buf", 2, 2, std::span{strip1.data(), strip1.size()}));
+  // Feed chunk 0: first 2 rows
+  ASSERT_TRUE(a.chunk("buf", 0, 2,
+                      std::span{full.data(), 2 * static_cast<std::size_t>(stride)}));
+
+  // Feed chunk 1: next 2 rows
+  ASSERT_TRUE(a.chunk("buf", 2, 2,
+                      std::span{full.data() + 2 * static_cast<std::size_t>(stride),
+                                2 * static_cast<std::size_t>(stride)}));
 
   const auto result = a.end("buf");
   ASSERT_TRUE(result.has_value());
-  EXPECT_EQ(result->bytes.size(), total);
+  EXPECT_EQ(result->bytes, full);
   EXPECT_EQ(result->variable_name, "buf");
 }
 

--- a/tests/test_buffer_assembler.cpp
+++ b/tests/test_buffer_assembler.cpp
@@ -1,0 +1,128 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "ipc/buffer_assembler.h"
+
+#include <gtest/gtest.h>
+
+using namespace oid;
+
+namespace {
+
+BufferAssembler::BeginParams make_begin(const std::string& name,
+                                        const int width,
+                                        const int height,
+                                        const int stride,
+                                        const std::size_t total) {
+  return BufferAssembler::BeginParams{.variable_name = name,
+                                      .display_name = name,
+                                      .pixel_layout = "rgba",
+                                      .transpose = false,
+                                      .width = width,
+                                      .height = height,
+                                      .channels = 1,
+                                      .stride = stride,
+                                      .type = 0,
+                                      .total_byte_size = total};
+}
+
+std::vector<std::byte> iota_bytes(const std::size_t n) {
+  std::vector<std::byte> v(n);
+  for (std::size_t i = 0; i < n; ++i) {
+    v[i] = static_cast<std::byte>(i & 0xff);
+  }
+  return v;
+}
+
+}  // namespace
+
+TEST(BufferAssemblerTests, ReassemblesRowStripsIntoContiguousBuffer) {
+  constexpr int stride = 8;
+  constexpr int height = 4;
+  constexpr std::size_t total = stride * height;
+  BufferAssembler a;
+  a.begin(make_begin("buf", 8, height, stride, total));
+
+  const auto strip0 = iota_bytes(2 * stride);
+  ASSERT_TRUE(a.chunk("buf", 0, 2, std::span{strip0.data(), strip0.size()}));
+
+  const auto strip1 = iota_bytes(2 * stride);
+  ASSERT_TRUE(a.chunk("buf", 2, 2, std::span{strip1.data(), strip1.size()}));
+
+  const auto result = a.end("buf");
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->bytes.size(), total);
+  EXPECT_EQ(result->variable_name, "buf");
+}
+
+TEST(BufferAssemblerTests, RejectsChunkBeyondImageHeight) {
+  constexpr int stride = 8;
+  constexpr int height = 2;
+  constexpr std::size_t total = stride * height;
+  BufferAssembler a;
+  a.begin(make_begin("buf", 8, height, stride, total));
+  const auto strip = iota_bytes(2 * stride);
+  // rows [1,3) do not fit in 2-row buffer.
+  EXPECT_FALSE(a.chunk("buf", 1, 2, std::span{strip.data(), strip.size()}));
+}
+
+TEST(BufferAssemblerTests, RejectsWrongSizedChunk) {
+  constexpr int stride = 8;
+  constexpr int height = 2;
+  constexpr std::size_t total = stride * height;
+  BufferAssembler a;
+  a.begin(make_begin("buf", 8, height, stride, total));
+  const auto strip = iota_bytes(stride + 1);  // not multiple stride
+  EXPECT_FALSE(a.chunk("buf", 0, 1, std::span{strip.data(), strip.size()}));
+}
+
+TEST(BufferAssemblerTests, RejectsChunkAndEndForUnknownBuffer) {
+  BufferAssembler a;
+  const auto strip = iota_bytes(8);
+  EXPECT_FALSE(a.chunk("missing", 0, 1, std::span{strip.data(), strip.size()}));
+  EXPECT_FALSE(a.end("missing").has_value());
+}
+
+TEST(BufferAssemblerTests, InterleavedBuffersDoNotCorruptEachOther) {
+  constexpr int stride = 4;
+  constexpr int height = 1;
+  constexpr std::size_t total = stride * height;
+  BufferAssembler a;
+  a.begin(make_begin("a", 4, height, stride, total));
+  a.begin(make_begin("b", 4, height, stride, total));
+  const std::vector<std::byte> da{
+      std::byte{1}, std::byte{2}, std::byte{3}, std::byte{4}};
+  const std::vector<std::byte> db{
+      std::byte{5}, std::byte{6}, std::byte{7}, std::byte{8}};
+  ASSERT_TRUE(a.chunk("a", 0, 1, std::span{da.data(), da.size()}));
+  ASSERT_TRUE(a.chunk("b", 0, 1, std::span{db.data(), db.size()}));
+
+  const auto result_a = a.end("a");
+  const auto result_b = a.end("b");
+  ASSERT_TRUE(result_a.has_value());
+  ASSERT_TRUE(result_b.has_value());
+  EXPECT_EQ(result_a->bytes[0], std::byte{1});
+  EXPECT_EQ(result_b->bytes[0], std::byte{5});
+}

--- a/tests/test_message_exchange.cpp
+++ b/tests/test_message_exchange.cpp
@@ -210,8 +210,8 @@ TEST_F(MessageExchangeTest, MessageComposerSendCoalescesBlocks) {
   composer.send(transport);
   ASSERT_EQ(transport.sends.size(), 1u);
   ASSERT_GE(transport.sends[0].size(), 12u);
-  const auto type =
-      std::bit_cast<MessageType>(transport.sends[0].data());
+  MessageType type{};
+  std::memcpy(&type, transport.sends[0].data(), sizeof(type));
   EXPECT_EQ(type, MessageType::PlotBufferRequest);
 }
 

--- a/tests/test_message_exchange.cpp
+++ b/tests/test_message_exchange.cpp
@@ -36,6 +36,7 @@
 #include <thread>
 
 #include "ipc/message_exchange.h"
+#include "ipc/tcp_transport.h"
 
 using namespace oid;
 
@@ -344,10 +345,13 @@ TEST_F(MessageExchangeTest, RoundTripPrimitive) {
 
   constexpr int value = TEST_VALUE_12345;
   MessageComposer composer;
-  composer.push(value).send(client_socket_.get());
+  composer.push(value);
+  oid::TcpTransport client_transport{*client_socket_};
+  composer.send(client_transport);
   QCoreApplication::processEvents();
 
-  MessageDecoder decoder(server_socket_);
+  oid::TcpTransport server_transport{*server_socket_};
+  MessageDecoder decoder(server_transport);
   int result = 0;
   decoder.read(result);
   EXPECT_EQ(result, value);
@@ -358,10 +362,13 @@ TEST_F(MessageExchangeTest, RoundTripString) {
 
   const auto test_string = std::string(TEST_STRING_ROUND_TRIP);
   MessageComposer composer;
-  composer.push(test_string).send(client_socket_.get());
+  composer.push(test_string);
+  oid::TcpTransport client_transport{*client_socket_};
+  composer.send(client_transport);
   QCoreApplication::processEvents();
 
-  MessageDecoder decoder(server_socket_);
+  oid::TcpTransport server_transport{*server_socket_};
+  MessageDecoder decoder(server_transport);
   std::string result;
   decoder.read(result);
   EXPECT_EQ(result, test_string);
@@ -378,11 +385,13 @@ TEST_F(MessageExchangeTest, RoundTripComplexMessage) {
   composer.push(MessageType::PlotBufferContents)
       .push(test_int_value)
       .push(test_bool_value)
-      .push(test_buffer_name)
-      .send(client_socket_.get());
+      .push(test_buffer_name);
+  oid::TcpTransport client_transport{*client_socket_};
+  composer.send(client_transport);
   QCoreApplication::processEvents();
 
-  MessageDecoder decoder(server_socket_);
+  oid::TcpTransport server_transport{*server_socket_};
+  MessageDecoder decoder(server_transport);
   MessageType type = MessageType::PlotBufferContents;
   int value = 0;
   bool flag = false;

--- a/tests/test_message_exchange.cpp
+++ b/tests/test_message_exchange.cpp
@@ -34,11 +34,22 @@
 #include <span>
 #include <string_view>
 #include <thread>
+#include <vector>
 
 #include "ipc/message_exchange.h"
 #include "ipc/tcp_transport.h"
+#include "ipc/transport.h"
 
 using namespace oid;
+
+struct RecordingTransport final : ITransport {
+  std::vector<std::vector<std::byte>> sends;
+  void send(std::span<const std::byte> data) override {
+    sends.emplace_back(data.begin(), data.end());
+  }
+  std::size_t receive(std::span<std::byte>) override { return 0; }
+  bool has_data() const override { return false; }
+};
 
 namespace {
 // Get or create QCoreApplication instance for all tests
@@ -190,6 +201,18 @@ TEST_F(MessageExchangeTest, MessageComposerPushPrimitive) {
   MessageComposer composer;
   composer.push(TEST_VALUE_42).push(MAX_UCHAR).push(true).push(TEST_VALUE_100);
   composer.clear();
+}
+
+TEST_F(MessageExchangeTest, MessageComposerSendCoalescesBlocks) {
+  RecordingTransport transport;
+  MessageComposer composer;
+  composer.push(MessageType::PlotBufferRequest).push(std::string("TestField"));
+  composer.send(transport);
+  ASSERT_EQ(transport.sends.size(), 1u);
+  ASSERT_GE(transport.sends[0].size(), 12u);
+  const auto type =
+      std::bit_cast<MessageType>(transport.sends[0].data());
+  EXPECT_EQ(type, MessageType::PlotBufferRequest);
 }
 
 TEST_F(MessageExchangeTest, MessageComposerPushString) {

--- a/tests/test_session_state_codec.cpp
+++ b/tests/test_session_state_codec.cpp
@@ -69,10 +69,14 @@ TEST(SessionStateCodec, SerializeIsPrefsOnly) {
     callbacks.getContrastEnabled = [] { return false; };
     callbacks.getLinkViewsEnabled = [] { return false; };
 
-    const SessionStateExtraInputs extra;
+    SessionStateExtraInputs extra;
+    extra.getColorspace = [] { return QStringLiteral("rgba"); };
+    extra.getListPosition = [] { return QStringLiteral("left"); };
+
     const auto json = serialize_session_state_delta(callbacks, extra);
-    EXPECT_FALSE(json.contains("held"));
-    EXPECT_FALSE(json.contains("buffers"));
-    EXPECT_FALSE(json.contains("previous"));
-    EXPECT_TRUE(json.contains("framerate"));
+    EXPECT_TRUE(json.contains("\"framerate\""));
+    EXPECT_TRUE(json.contains("\"colorspace\""));
+    EXPECT_TRUE(json.contains("\"listPosition\""));
+    EXPECT_FALSE(json.contains("\"held\""));
+    EXPECT_FALSE(json.contains("\"buffers\""));
 }

--- a/tests/test_session_state_codec.cpp
+++ b/tests/test_session_state_codec.cpp
@@ -1,0 +1,78 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <QCoreApplication>
+#include <gtest/gtest.h>
+
+#include "ui/messaging/session_state_codec.h"
+
+using namespace oid;
+
+namespace {
+QCoreApplication& GetApplication() {
+    static int argc = 1;
+    static std::string app_name = "test";
+    static char* argv[] = {app_name.data(), nullptr};
+    static QCoreApplication application(argc, argv);
+    return application;
+}
+} // namespace
+
+TEST(SessionStateCodec, ParsesPrefs) {
+    GetApplication();
+    const auto json = QByteArray(
+        R"({"rendering":{"framerate":30},"ui":{"contrastEnabled":true,)"
+        R"("listPosition":"bottom","colorspace":"bgra"}})");
+    SessionStateFields fields;
+    ASSERT_TRUE(parse_session_state_json(json, fields));
+    ASSERT_TRUE(fields.framerate.has_value());
+    EXPECT_DOUBLE_EQ(*fields.framerate, 30.0);
+    ASSERT_TRUE(fields.contrast_enabled.has_value());
+    EXPECT_TRUE(*fields.contrast_enabled);
+    ASSERT_TRUE(fields.list_position.has_value());
+    EXPECT_EQ(*fields.list_position, QStringLiteral("bottom"));
+    ASSERT_TRUE(fields.colorspace.has_value());
+    EXPECT_EQ(*fields.colorspace, QStringLiteral("bgra"));
+}
+
+TEST(SessionStateCodec, SerializeIsPrefsOnly) {
+    GetApplication();
+    SettingsManager::DataCallbacks callbacks;
+    callbacks.getRenderFramerate = [] { return 60.0; };
+    callbacks.getDefaultExportSuffix = [] {
+        return QStringLiteral("Image File (*.png)");
+    };
+    callbacks.getSplitterSizes = [] { return QList<int>{100, 200}; };
+    callbacks.getMinMaxVisible = [] { return true; };
+    callbacks.getContrastEnabled = [] { return false; };
+    callbacks.getLinkViewsEnabled = [] { return false; };
+
+    const SessionStateExtraInputs extra;
+    const auto json = serialize_session_state_delta(callbacks, extra);
+    EXPECT_FALSE(json.contains("held"));
+    EXPECT_FALSE(json.contains("buffers"));
+    EXPECT_FALSE(json.contains("previous"));
+    EXPECT_TRUE(json.contains("framerate"));
+}

--- a/tests/test_transport.cpp
+++ b/tests/test_transport.cpp
@@ -35,6 +35,7 @@
 #include <vector>
 
 #include "ipc/tcp_transport.h"
+#include "ipc/postmessage_transport.h"
 
 namespace {
 
@@ -83,4 +84,25 @@ TEST(TcpTransport, RoundTripBytes) {
     EXPECT_EQ(server_received, sent);
 
     server_thread.join();
+}
+
+TEST(PostMessageTransport, QueuesInboundAndReceive) {
+    oid::PostMessageTransport transport;
+    const std::vector<std::byte> msg{std::byte{0x03}, std::byte{0xAA}};
+    transport.enqueue_inbound(msg);
+
+    EXPECT_TRUE(transport.has_data());
+
+    std::array<std::byte, 2> out{};
+    EXPECT_EQ(transport.receive(out), 2u);
+    EXPECT_EQ(out[0], std::byte{0x03});
+    EXPECT_EQ(out[1], std::byte{0xAA});
+    EXPECT_FALSE(transport.has_data());
+}
+
+TEST(PostMessageTransport, SendIsNoOpOnDesktop) {
+    oid::PostMessageTransport transport;
+    const std::vector<std::byte> msg{std::byte{0x01}};
+    transport.send(msg);
+    EXPECT_FALSE(transport.has_data());
 }

--- a/tests/test_transport.cpp
+++ b/tests/test_transport.cpp
@@ -35,7 +35,7 @@
 #include <vector>
 
 #include "ipc/tcp_transport.h"
-#include "ipc/postmessage_transport.h"
+#include "platform/postmessage_transport.h"
 
 namespace {
 

--- a/tests/test_transport.cpp
+++ b/tests/test_transport.cpp
@@ -1,0 +1,86 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <gtest/gtest.h>
+
+#include <QCoreApplication>
+#include <QHostAddress>
+#include <QTcpServer>
+#include <QTcpSocket>
+
+#include <array>
+#include <thread>
+#include <vector>
+
+#include "ipc/tcp_transport.h"
+
+namespace {
+
+QCoreApplication& app() {
+    static int argc = 1;
+    static std::array<char*, 2> argv = {const_cast<char*>("test"), nullptr};
+    static QCoreApplication application(argc, argv.data());
+    return application;
+}
+
+} // namespace
+
+TEST(TcpTransport, RoundTripBytes) {
+    (void)app();
+    QTcpServer server;
+    ASSERT_TRUE(server.listen(QHostAddress::LocalHost));
+
+    std::vector<std::byte> server_received;
+    std::thread server_thread([&] {
+        ASSERT_TRUE(server.waitForNewConnection(5000));
+        QTcpSocket* peer = server.nextPendingConnection();
+        ASSERT_TRUE(peer->waitForReadyRead(5000));
+        const QByteArray data = peer->readAll();
+        server_received.assign(
+            reinterpret_cast<const std::byte*>(data.constData()),
+            reinterpret_cast<const std::byte*>(data.constData()) + data.size());
+        peer->write(data);
+        peer->waitForBytesWritten(5000);
+        peer->close();
+        delete peer;
+    });
+
+    QTcpSocket client;
+    client.connectToHost(QHostAddress::LocalHost, server.serverPort());
+    ASSERT_TRUE(client.waitForConnected(5000));
+
+    oid::TcpTransport transport(client);
+    const std::vector<std::byte> sent{std::byte{0x03}, std::byte{0x01}};
+    transport.send(sent);
+
+    std::array<std::byte, 2> buf{};
+    const auto n = transport.receive(buf);
+    EXPECT_EQ(n, 2u);
+    EXPECT_EQ(buf[0], std::byte{0x03});
+    EXPECT_EQ(buf[1], std::byte{0x01});
+    EXPECT_EQ(server_received, sent);
+
+    server_thread.join();
+}

--- a/wasm/loader.html
+++ b/wasm/loader.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, height=device-height, user-scalable=0">
+    <title>Open Image Debugger</title>
+    <style>
+      html, body { padding: 0; margin: 0; overflow: hidden; height: 100% }
+      #screen { width: 100%; height: 100%; }
+      #qtspinner { margin: 0; }
+    </style>
+  </head>
+  <body onload="init()">
+    <figure style="overflow:visible;" id="qtspinner">
+      <center style="margin-top:1.5em; line-height:150%">
+        <strong>Open Image Debugger</strong>
+        <div id="qtstatus">Loading...</div>
+      </center>
+    </figure>
+    <div id="screen"></div>
+
+    <script>
+      window.oidSend = function(u8) {
+        window.parent.postMessage({ type: 'oid-ipc', payload: u8 }, '*');
+      };
+      window.addEventListener('message', (ev) => {
+        if (ev.data?.type === 'oid-ipc' && ev.data.payload) {
+          if (window.oidOnMessage) window.oidOnMessage(ev.data.payload);
+        }
+      });
+    </script>
+
+    <script type="text/javascript">
+      async function init() {
+        const spinner = document.querySelector('#qtspinner');
+        const screen = document.querySelector('#screen');
+        const status = document.querySelector('#qtstatus');
+
+        const showUi = (ui) => {
+          [spinner, screen].forEach((element) => element.style.display = 'none');
+          if (screen === ui) screen.style.position = 'default';
+          ui.style.display = 'block';
+        };
+
+        try {
+          showUi(spinner);
+          status.innerHTML = 'Loading...';
+
+          await qtLoad({
+            qt: {
+              onLoaded: () => showUi(screen),
+              onExit: (exitData) => {
+                status.innerHTML = 'Application exit';
+                if (exitData.code !== undefined) status.innerHTML += ` with code ${exitData.code}`;
+                if (exitData.text !== undefined) status.innerHTML += ` (${exitData.text})`;
+                showUi(spinner);
+              },
+              entryFunction: window.oidwindow_entry,
+              containerElements: [screen],
+            },
+          });
+        } catch (e) {
+          console.error(e);
+          status.innerHTML = String(e);
+        }
+      }
+    </script>
+    <script src="oidwindow.js"></script>
+    <script src="qtloader.js"></script>
+  </body>
+</html>

--- a/wasm/loader.html
+++ b/wasm/loader.html
@@ -5,8 +5,13 @@
     <meta name="viewport" content="width=device-width, height=device-height, user-scalable=0">
     <title>Open Image Debugger</title>
     <style>
-      html, body { padding: 0; margin: 0; overflow: hidden; height: 100% }
-      #screen { width: 100%; height: 100%; }
+      html, body { padding: 0; margin: 0; overflow: hidden; width: 100%; height: 100%; }
+      #screen {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+      }
       #qtspinner { margin: 0; }
     </style>
   </head>

--- a/wasm/loader.html
+++ b/wasm/loader.html
@@ -26,11 +26,22 @@
 
     <script>
       window.oidSend = function(u8) {
-        window.parent.postMessage({ type: 'oid-ipc', payload: u8 }, '*');
+        if (typeof window.parent?.postMessage === 'function') {
+          window.parent.postMessage({ type: 'oid-ipc', payload: u8 }, '*');
+        }
       };
       window.addEventListener('message', (ev) => {
         if (ev.data?.type === 'oid-ipc' && ev.data.payload) {
-          if (window.oidOnMessage) window.oidOnMessage(ev.data.payload);
+          const p = ev.data.payload;
+          const arr = p instanceof Uint8Array
+            ? p
+            : new Uint8Array(Array.isArray(p) ? p : Object.values(p));
+          if (window.oidOnMessage) window.oidOnMessage(arr);
+        }
+      });
+      window.addEventListener('oid-viewer-ready', (ev) => {
+        if (typeof window.parent?.postMessage === 'function') {
+          window.parent.postMessage(ev.detail, '*');
         }
       });
     </script>

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@openimagedebugger/viewer-wasm",
+  "version": "0.0.0-dev",
+  "description": "Qt 6.11 WASM build of oidwindow",
+  "files": ["dist"],
+  "license": "MIT"
+}

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -3,5 +3,10 @@
   "version": "0.0.0-dev",
   "description": "Qt 6.11 WASM build of oidwindow",
   "files": ["dist"],
-  "license": "MIT"
+  "license": "MIT",
+  "scripts": {
+    "build": "bash scripts/build-wasm.sh",
+    "pack": "bash scripts/pack.sh",
+    "serve": "bash scripts/serve-wasm.sh"
+  }
 }

--- a/wasm/scripts/build-wasm.sh
+++ b/wasm/scripts/build-wasm.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Build oidwindow for Qt WebAssembly (Emscripten).
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: wasm/scripts/build-wasm.sh [options]
+
+Configure and build the OID WASM viewer (oidwindow).
+
+Environment overrides:
+  EMSDK          Path to emsdk checkout (default: ~/emsdk)
+  QT_WASM_DIR    Qt WASM kit root (default: ~/Qt/6.11.0/wasm_singlethread)
+  QT_HOST_PATH   Qt macOS/desktop host kit (default: ~/Qt/6.11.0/macos)
+  BUILD_DIR      CMake build directory (default: <repo>/build-wasm)
+  BUILD_TYPE     CMake build type (default: Release)
+  JOBS           Parallel build jobs (default: detected CPU count)
+
+Options:
+  -h, --help     Show this help
+  --clean        Remove BUILD_DIR before configuring
+  --configure    Configure only (no compile)
+  --reconfigure  Force CMake reconfigure
+
+Outputs (under BUILD_DIR/src/):
+  oidwindow.wasm  oidwindow.js  oidwindow.html  qtloader.js
+EOF
+}
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+EMSDK="${EMSDK:-$HOME/emsdk}"
+QT_WASM_DIR="${QT_WASM_DIR:-$HOME/Qt/6.11.0/wasm_singlethread}"
+QT_HOST_PATH="${QT_HOST_PATH:-$HOME/Qt/6.11.0/macos}"
+BUILD_DIR="${BUILD_DIR:-$ROOT/build-wasm}"
+BUILD_TYPE="${BUILD_TYPE:-Release}"
+JOBS="${JOBS:-$(sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 4)}"
+
+CLEAN=0
+CONFIGURE_ONLY=0
+RECONFIGURE=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --clean)
+      CLEAN=1
+      shift
+      ;;
+    --configure)
+      CONFIGURE_ONLY=1
+      shift
+      ;;
+    --reconfigure)
+      RECONFIGURE=1
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+QT_CMAKE="$QT_WASM_DIR/bin/qt-cmake"
+EMSDK_ENV="$EMSDK/emsdk_env.sh"
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+[[ -f "$EMSDK_ENV" ]] || die "emsdk not found at $EMSDK (set EMSDK)"
+[[ -x "$QT_CMAKE" ]] || die "qt-cmake not found at $QT_CMAKE (set QT_WASM_DIR)"
+[[ -d "$QT_HOST_PATH" ]] || die "Qt host kit not found at $QT_HOST_PATH (set QT_HOST_PATH)"
+
+# shellcheck source=/dev/null
+source "$EMSDK_ENV"
+export EMSDK
+
+if [[ "$CLEAN" -eq 1 ]]; then
+  echo "Removing $BUILD_DIR"
+  rm -rf "$BUILD_DIR"
+fi
+
+CMAKE_ARGS=(
+  -S "$ROOT"
+  -B "$BUILD_DIR"
+  -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+  -DQT_HOST_PATH="$QT_HOST_PATH"
+  -DBUILD_TESTS=OFF
+)
+
+if [[ "$RECONFIGURE" -eq 1 ]] || [[ ! -f "$BUILD_DIR/CMakeCache.txt" ]]; then
+  echo "Configuring WASM build in $BUILD_DIR"
+  "$QT_CMAKE" "${CMAKE_ARGS[@]}"
+else
+  echo "Using existing CMake cache in $BUILD_DIR (pass --reconfigure to refresh)"
+fi
+
+if [[ "$CONFIGURE_ONLY" -eq 1 ]]; then
+  exit 0
+fi
+
+echo "Building oidwindow ($JOBS jobs)"
+cmake --build "$BUILD_DIR" --target oidwindow -j"$JOBS"
+
+OUT_DIR="$BUILD_DIR/src"
+echo
+echo "WASM build complete:"
+ls -lh "$OUT_DIR"/oidwindow.{wasm,js,html} "$OUT_DIR"/qtloader.js 2>/dev/null || true
+echo
+echo "Serve locally:"
+echo "  cd $OUT_DIR && python3 -m http.server 8765"
+echo "  open http://localhost:8765/oidwindow.html"

--- a/wasm/scripts/pack-viewer-wasm.sh
+++ b/wasm/scripts/pack-viewer-wasm.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Assemble wasm/dist from a successful oidwindow WASM build.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+BUILD_SRC="${BUILD_SRC:-$ROOT/build-wasm/src}"
+DIST="$ROOT/wasm/dist"
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+[[ -f "$BUILD_SRC/oidwindow.wasm" ]] || die "missing $BUILD_SRC/oidwindow.wasm (run wasm/scripts/build-wasm.sh first)"
+
+rm -rf "$DIST"
+mkdir -p "$DIST"
+
+cp "$BUILD_SRC/oidwindow.wasm" "$BUILD_SRC/oidwindow.js" "$DIST/"
+cp "$ROOT/wasm/loader.html" "$DIST/"
+cp "$BUILD_SRC/qtloader.js" "$DIST/"
+
+# Optional Qt assets emitted beside the build output.
+cp "$BUILD_SRC"/qt*.js "$BUILD_SRC"/qt*.wasm "$DIST/" 2>/dev/null || true
+cp "$BUILD_SRC/qtlogo.svg" "$DIST/" 2>/dev/null || true
+
+echo '{"qt":"6.11","emscripten":"4.0.7","oid":"dev"}' > "$DIST/version.json"
+
+echo "Packed viewer WASM artifact to $DIST"
+ls -lh "$DIST"

--- a/wasm/scripts/pack-viewer-wasm.sh
+++ b/wasm/scripts/pack-viewer-wasm.sh
@@ -25,7 +25,8 @@ cp "$BUILD_SRC/qtloader.js" "$DIST/"
 cp "$BUILD_SRC"/qt*.js "$BUILD_SRC"/qt*.wasm "$DIST/" 2>/dev/null || true
 cp "$BUILD_SRC/qtlogo.svg" "$DIST/" 2>/dev/null || true
 
-echo '{"qt":"6.11","emscripten":"4.0.7","oid":"dev"}' > "$DIST/version.json"
+OID_REV="$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo dev)"
+echo "{\"qt\":\"6.11\",\"emscripten\":\"4.0.7\",\"oid\":\"$OID_REV\"}" > "$DIST/version.json"
 
 echo "Packed viewer WASM artifact to $DIST"
 ls -lh "$DIST"

--- a/wasm/scripts/pack-viewer-wasm.sh
+++ b/wasm/scripts/pack-viewer-wasm.sh
@@ -18,6 +18,7 @@ mkdir -p "$DIST"
 
 cp "$BUILD_SRC/oidwindow.wasm" "$BUILD_SRC/oidwindow.js" "$DIST/"
 cp "$ROOT/wasm/loader.html" "$DIST/"
+cp "$ROOT/wasm/test-harness.html" "$DIST/"
 cp "$BUILD_SRC/qtloader.js" "$DIST/"
 
 # Optional Qt assets emitted beside the build output.

--- a/wasm/scripts/pack.sh
+++ b/wasm/scripts/pack.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Pack viewer WASM into wasm/dist and optionally sync to the VS Code extension.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: wasm/scripts/pack.sh [options]
+
+Assemble wasm/dist from a successful oidwindow WASM build. By default also
+copies artifacts into the VS Code extension media/ folder.
+
+Environment overrides:
+  BUILD_SRC         Build output directory (default: <repo>/build-wasm/src)
+  EXTENSION_MEDIA   Extension media directory
+                    (default: <repo>/../openimagedebugger-vscode/media)
+
+Options:
+  -h, --help          Show this help
+  --build             Run wasm/scripts/build-wasm.sh before packing
+  --no-extension      Skip copying to EXTENSION_MEDIA
+  --extension-dir DIR Override extension media destination
+
+Examples:
+  wasm/scripts/pack.sh
+  wasm/scripts/pack.sh --build
+  wasm/scripts/pack.sh --no-extension
+  EXTENSION_MEDIA=~/my-ext/media wasm/scripts/pack.sh
+EOF
+}
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BUILD_SRC="${BUILD_SRC:-$ROOT/build-wasm/src}"
+EXTENSION_MEDIA="${EXTENSION_MEDIA:-$ROOT/../openimagedebugger-vscode/media}"
+
+BUILD=0
+SYNC_EXTENSION=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --build)
+      BUILD=1
+      shift
+      ;;
+    --no-extension)
+      SYNC_EXTENSION=0
+      shift
+      ;;
+    --extension-dir)
+      [[ $# -ge 2 ]] || {
+        echo "error: --extension-dir requires a path" >&2
+        exit 1
+      }
+      EXTENSION_MEDIA="$2"
+      shift 2
+      ;;
+    *)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$BUILD" -eq 1 ]]; then
+  "$SCRIPT_DIR/build-wasm.sh"
+fi
+
+export BUILD_SRC
+"$SCRIPT_DIR/pack-viewer-wasm.sh"
+
+if [[ "$SYNC_EXTENSION" -eq 1 ]]; then
+  mkdir -p "$EXTENSION_MEDIA"
+  rm -rf "${EXTENSION_MEDIA:?}/"*
+  cp -r "$ROOT/wasm/dist/"* "$EXTENSION_MEDIA/"
+  echo
+  echo "Synced viewer WASM to $EXTENSION_MEDIA"
+  ls -lh "$EXTENSION_MEDIA"
+fi

--- a/wasm/scripts/serve-wasm.sh
+++ b/wasm/scripts/serve-wasm.sh
@@ -7,7 +7,7 @@ ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 DIST="$ROOT/wasm/dist"
 
 [[ -f "$DIST/loader.html" ]] || {
-  echo "error: $DIST/loader.html missing — run wasm/scripts/build-wasm.sh && wasm/scripts/pack-viewer-wasm.sh" >&2
+  echo "error: $DIST/loader.html missing — run wasm/scripts/build-wasm.sh && wasm/scripts/pack.sh" >&2
   exit 1
 }
 

--- a/wasm/scripts/serve-wasm.sh
+++ b/wasm/scripts/serve-wasm.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Serve wasm/dist on a single port (kills stale test servers first).
+set -euo pipefail
+
+PORT="${PORT:-8765}"
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+DIST="$ROOT/wasm/dist"
+
+[[ -f "$DIST/loader.html" ]] || {
+  echo "error: $DIST/loader.html missing — run wasm/scripts/build-wasm.sh && wasm/scripts/pack-viewer-wasm.sh" >&2
+  exit 1
+}
+
+if pids=$(lsof -ti ":${PORT}" 2>/dev/null); then
+  echo "Stopping existing server on port ${PORT} (pid: ${pids//$'\n'/ })"
+  kill ${pids} 2>/dev/null || true
+  sleep 0.5
+fi
+
+echo "Serving $DIST at http://localhost:${PORT}/test-harness.html"
+echo "Close all other OID WASM browser tabs before testing."
+cd "$DIST"
+exec python3 -m http.server "$PORT"

--- a/wasm/test-harness.html
+++ b/wasm/test-harness.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>OID WASM browser test</title>
+  <style>
+    html, body { margin: 0; width: 100%; height: 100%; font-family: system-ui, sans-serif; }
+    body { display: flex; flex-direction: column; }
+    #bar { flex: 0 0 auto; padding: 0.5rem 1rem; background: #1e1e1e; color: #ccc; font-size: 0.85rem; }
+    #bar.ok { color: #8f8; }
+    #bar.err { color: #f88; }
+    iframe { flex: 1 1 auto; width: 100%; border: none; display: block; min-height: 0; }
+  </style>
+</head>
+<body>
+  <div id="bar">Waiting for viewer… — close other OID WASM tabs first</div>
+  <iframe id="viewer" src="loader.html"></iframe>
+  <script>
+    const bar = document.getElementById('bar');
+    const viewer = document.getElementById('viewer');
+
+    function pushU32(buf, v) {
+      buf.push(v & 0xff, (v >> 8) & 0xff, (v >> 16) & 0xff, (v >> 24) & 0xff);
+    }
+    function pushI32(buf, v) { pushU32(buf, v | 0); }
+    function pushString(buf, s) {
+      const bytes = new TextEncoder().encode(s);
+      pushU32(buf, bytes.length);
+      for (const b of bytes) buf.push(b);
+    }
+    function buildPlotBufferContents(p) {
+      const parts = [];
+      pushU32(parts, 3); // PlotBufferContents
+      pushString(parts, p.variableName);
+      pushString(parts, p.displayName);
+      pushString(parts, p.pixelLayout);
+      parts.push(p.transpose ? 1 : 0);
+      pushI32(parts, p.width);
+      pushI32(parts, p.height);
+      pushI32(parts, p.channels);
+      pushI32(parts, p.stride);
+      pushI32(parts, p.bufferType);
+      pushU32(parts, p.pixels.length);
+      for (const b of p.pixels) parts.push(b);
+      return new Uint8Array(parts);
+    }
+
+    window.addEventListener('message', (ev) => {
+      if (ev.source !== viewer.contentWindow) return;
+      const msg = ev.data;
+      if (msg?.type === 'oid-control' && msg.event === 'viewer-ready') {
+        bar.textContent = 'viewer-ready — sending 2×2 test image in 300ms…';
+        bar.className = '';
+        setTimeout(() => {
+          const payload = buildPlotBufferContents({
+            variableName: 'test',
+            displayName: 'test',
+            pixelLayout: 'rgba',
+            transpose: false,
+            width: 2,
+            height: 2,
+            channels: 3,
+            stride: 6,
+            bufferType: 0,
+            pixels: new Uint8Array([255, 0, 0, 0, 255, 0, 0, 0, 255, 128, 128, 128]),
+          });
+          viewer.contentWindow.postMessage({ type: 'oid-ipc', payload }, '*');
+          bar.textContent = 'Sent PlotBufferContents (2×2 RGB)';
+          bar.className = 'ok';
+        }, 300);
+      }
+    });
+
+    viewer.addEventListener('error', () => {
+      bar.textContent = 'iframe failed to load';
+      bar.className = 'err';
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Captures approved design for oidwindow WebAssembly on Qt 6.11 with
Emscripten 4.0.7, reusing the existing MessageComposer IPC protocol
instead of Protobuf, scoped to P0-P1 plus an extension smoke test.