### PR TITLE
ci: exclude vendored thirdparty code from SonarQube analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,7 @@
+# SonarQube Cloud analysis configuration.
+#
+# Vendored third-party code lives under src/thirdparty/ (imgui, glfw, asio,
+# json, stb, nanosvg, Eigen, Khronos, googletest). It is not maintained by
+# this project and must not count toward the quality gate, so exclude it
+# from analysis entirely.
+sonar.exclusions=src/thirdparty/**, **/thirdparty/**


### PR DESCRIPTION
Vendored dependencies under `src/thirdparty/` (imgui, glfw, asio, json, stb, nanosvg, Eigen, Khronos, googletest) are not maintained by this project, so their findings should not count toward the quality gate.

This adds a repo-root `sonar-project.properties` with:

```
sonar.exclusions=src/thirdparty/**, **/thirdparty/**
```

which SonarQube Cloud Automatic Analysis honors, removing vendored code from analysis (and thus from the quality gate).