### PR TITLE
fix: revert "ci: exclude vendored thirdparty code from SonarQube analysis"

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,0 @@
-# SonarQube Cloud analysis configuration.
-#
-# Vendored third-party code lives under src/thirdparty/ (imgui, glfw, asio,
-# json, stb, nanosvg, Eigen, Khronos, googletest). It is not maintained by
-# this project and must not count toward the quality gate, so exclude it
-# from analysis entirely.
-sonar.exclusions=src/thirdparty/**, **/thirdparty/**


### PR DESCRIPTION
This reverts commit dc8c1166be5d43dcd19cf53e0bea1e3d450b8f27.