### PR TITLE
ci: exclude vendored thirdparty code from SonarQube analysis - take 2

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,7 @@
+# SonarQube Cloud analysis configuration.
+#
+# Vendored third-party code lives under src/thirdparty/ (imgui, glfw, asio,
+# json, stb, nanosvg, Eigen, Khronos, googletest). It is not maintained by
+# this project and must not count toward the quality gate, so exclude it
+# from analysis entirely.
+sonar.exclusions=src/thirdparty/**, **/thirdparty/**


### PR DESCRIPTION
Vendored dependencies under src/thirdparty/ are not maintained by this project; excluding them keeps their findings out of the quality gate.