### PR TITLE
refactor: modernize first-party code to C++20 (49 SonarQube findings, 9 rules)

### DIFF
--- a/src/host/glfw_host_backend.cpp
+++ b/src/host/glfw_host_backend.cpp
@@ -154,10 +154,9 @@ std::vector<GlfwHostBackend::MonitorRect> GlfwHostBackend::monitors() const {
 
 bool GlfwHostBackend::window_visible_on(
     int x, int y, int w, int h, const std::vector<MonitorRect>& monitors) {
-    return std::any_of(
-        monitors.begin(), monitors.end(), [x, y, w, h](const MonitorRect& m) {
-            return x < m.x + m.w && x + w > m.x && y < m.y + m.h && y + h > m.y;
-        });
+    return std::ranges::any_of(monitors, [x, y, w, h](const MonitorRect& m) {
+        return x < m.x + m.w && x + w > m.x && y < m.y + m.h && y + h > m.y;
+    });
 }
 
 } // namespace oid::host

--- a/src/host/ipc/ipc_client.cpp
+++ b/src/host/ipc/ipc_client.cpp
@@ -52,29 +52,30 @@ void IpcClient::poll() {
 }
 
 void IpcClient::dispatch(oid::MessageType header) {
+    using enum oid::MessageType;
     switch (header) {
-    case oid::MessageType::SetAvailableSymbols:
+    case SetAvailableSymbols:
         handle_set_available_symbols();
         break;
-    case oid::MessageType::GetObservedSymbols:
+    case GetObservedSymbols:
         handle_get_observed_symbols();
         break;
-    case oid::MessageType::PlotBufferContents:
+    case PlotBufferContents:
         handle_plot_buffer_contents();
         break;
-    case oid::MessageType::PlotBufferBegin:
+    case PlotBufferBegin:
         handle_plot_buffer_begin();
         break;
-    case oid::MessageType::PlotBufferChunk:
+    case PlotBufferChunk:
         handle_plot_buffer_chunk();
         break;
-    case oid::MessageType::PlotBufferEnd:
+    case PlotBufferEnd:
         handle_plot_buffer_end();
         break;
-    case oid::MessageType::ApplySessionState:
+    case ApplySessionState:
         handle_apply_session_state();
         break;
-    case oid::MessageType::ExportSelectedBuffer:
+    case ExportSelectedBuffer:
         handle_export_selected_buffer();
         break;
     default:

--- a/src/host/ipc/ipc_client.cpp
+++ b/src/host/ipc/ipc_client.cpp
@@ -100,10 +100,10 @@ void IpcClient::handle_set_available_symbols() {
         if (b.expiry_epoch_s <= now) {
             continue;
         }
-        if (!avail.count(b.variable_name)) {
+        if (!avail.contains(b.variable_name)) {
             continue;
         }
-        if (restore_requested_.count(b.variable_name)) {
+        if (restore_requested_.contains(b.variable_name)) {
             continue;
         }
         if (model_has(b.variable_name)) {

--- a/src/host/settings/session_buffers.cpp
+++ b/src/host/settings/session_buffers.cpp
@@ -37,7 +37,7 @@ std::vector<PreviousBuffer> merge_previous_buffers(
     std::set<std::string, std::less<>> loaded{current_loaded.begin(),
                                               current_loaded.end()};
     for (const auto& name : current_loaded) {
-        out.push_back({name, now_s + ttl_s}); // fresh expiry
+        out.emplace_back(name, now_s + ttl_s); // fresh expiry
     }
     for (const auto& b : prior) {
         if (loaded.contains(b.variable_name)) {

--- a/src/host/settings/session_buffers.cpp
+++ b/src/host/settings/session_buffers.cpp
@@ -40,10 +40,10 @@ std::vector<PreviousBuffer> merge_previous_buffers(
         out.push_back({name, now_s + ttl_s}); // fresh expiry
     }
     for (const auto& b : prior) {
-        if (loaded.count(b.variable_name)) {
+        if (loaded.contains(b.variable_name)) {
             continue; // already added fresh
         }
-        if (seen_this_session.count(b.variable_name)) {
+        if (seen_this_session.contains(b.variable_name)) {
             continue; // user-deleted this run
         }
         if (b.expiry_epoch_s <= now_s) {

--- a/src/host/settings/settings_store.cpp
+++ b/src/host/settings/settings_store.cpp
@@ -142,9 +142,9 @@ AppSettings settings_from_json(std::string_view json) {
                     !entry.at("expiry").is_number_integer()) {
                     continue; // skip malformed entry, keep the rest
                 }
-                out.previous_buffers.push_back(
-                    PreviousBuffer{entry.at("name").get<std::string>(),
-                                   entry.at("expiry").get<std::int64_t>()});
+                out.previous_buffers.emplace_back(
+                    entry.at("name").get<std::string>(),
+                    entry.at("expiry").get<std::int64_t>());
             }
         }
 

--- a/src/host/settings/settings_store.cpp
+++ b/src/host/settings/settings_store.cpp
@@ -26,6 +26,7 @@
 #include "host/settings/settings_store.h"
 
 #include <atomic>
+#include <format>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -202,9 +203,8 @@ void SettingsStore::save(const AppSettings& s) const {
 #else
         const auto pid = static_cast<long>(getpid());
 #endif
-        const std::filesystem::path tmp =
-            file_.string() + "." + std::to_string(pid) + "." +
-            std::to_string(tmp_counter.fetch_add(1)) + ".tmp";
+        const std::filesystem::path tmp = std::format(
+            "{}.{}.{}.tmp", file_.string(), pid, tmp_counter.fetch_add(1));
         {
             std::ofstream os{tmp, std::ios::binary | std::ios::trunc};
             os << json;

--- a/src/host/ui/buffer_model.h
+++ b/src/host/ui/buffer_model.h
@@ -132,24 +132,25 @@ class MockBufferModel : public BufferModel {
 // Human-readable type+channel label used by the buffer-list panel, e.g.
 // "uint8x3", "float32x1".
 inline std::string type_label(const oid::BufferType type, const int channels) {
+    using enum oid::BufferType;
     std::string base;
     switch (type) {
-    case oid::BufferType::UnsignedByte:
+    case UnsignedByte:
         base = "uint8";
         break;
-    case oid::BufferType::UnsignedShort:
+    case UnsignedShort:
         base = "uint16";
         break;
-    case oid::BufferType::Short:
+    case Short:
         base = "int16";
         break;
-    case oid::BufferType::Int32:
+    case Int32:
         base = "int32";
         break;
-    case oid::BufferType::Float32:
+    case Float32:
         base = "float32";
         break;
-    case oid::BufferType::Float64:
+    case Float64:
         base = "float64";
         break;
     }

--- a/src/host/ui/buffer_model.h
+++ b/src/host/ui/buffer_model.h
@@ -29,6 +29,7 @@
 #include <bit>
 #include <cstddef>
 #include <cstdint>
+#include <format>
 #include <memory>
 #include <string>
 #include <utility>
@@ -154,7 +155,7 @@ inline std::string type_label(const oid::BufferType type, const int channels) {
         base = "float64";
         break;
     }
-    return base + "x" + std::to_string(channels);
+    return std::format("{}x{}", base, channels);
 }
 
 // Builds the fixed set of mock buffers used by chrome development/tests:

--- a/src/host/ui/panels/buffer_list_panel.cpp
+++ b/src/host/ui/panels/buffer_list_panel.cpp
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <format>
 #include <string>
 
 #include <imgui.h>
@@ -46,9 +47,11 @@ namespace oid::host {
 namespace {
 
 std::string row_label(const BufferRecord& rec) {
-    return rec.display_name + "\n[" + std::to_string(rec.width) + "x" +
-           std::to_string(rec.height) + "]\n" +
-           type_label(rec.type, rec.channels);
+    return std::format("{}\n[{}x{}]\n{}",
+                       rec.display_name,
+                       rec.width,
+                       rec.height,
+                       type_label(rec.type, rec.channels));
 }
 
 // Up/Down move the selection through the buffer list while it is

--- a/src/host/ui/panels/status_bar.cpp
+++ b/src/host/ui/panels/status_bar.cpp
@@ -27,6 +27,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <format>
 #include <iomanip>
 #include <optional>
 #include <sstream>
@@ -130,12 +131,14 @@ void draw_status_bar(const UiState& ui,
             }
         }
 
-        line = rec.display_name + "   [" + std::to_string(rec.width) + "x" +
-               std::to_string(rec.height) + "]   " +
-               type_label(rec.type, rec.channels);
+        line = std::format("{}   [{}x{}]   {}",
+                           rec.display_name,
+                           rec.width,
+                           rec.height,
+                           type_label(rec.type, rec.channels));
         if (zoom_pct >= 0.0f) {
-            line += "   zoom: " +
-                    std::to_string(static_cast<int>(zoom_pct + 0.5f)) + "%";
+            line +=
+                std::format("   zoom: {}%", static_cast<int>(zoom_pct + 0.5f));
         }
 
         // Pixel value under the (last-hovered) cursor — Qt parity with

--- a/src/host/ui/panels/toolbar_panel.cpp
+++ b/src/host/ui/panels/toolbar_panel.cpp
@@ -90,24 +90,25 @@ enum class PixelFormat {
 // apply_format() (see tag legacy-qt) exactly, including its
 // display-channel-mode / pixel-layout pairing.
 void apply_format(oid::Buffer& b, int sel) {
+    using enum PixelFormat;
     switch (sel) {
-    case static_cast<int>(PixelFormat::kBgra):
+    case static_cast<int>(kBgra):
         b.set_display_channel_mode(-1);
         b.set_pixel_layout("bgra");
         break;
-    case static_cast<int>(PixelFormat::kRgba):
+    case static_cast<int>(kRgba):
         b.set_display_channel_mode(-1);
         b.set_pixel_layout("rgba");
         break;
-    case static_cast<int>(PixelFormat::kChannel0):
+    case static_cast<int>(kChannel0):
         b.set_display_channel_mode(1);
         b.set_pixel_layout("rrra");
         break;
-    case static_cast<int>(PixelFormat::kChannel1):
+    case static_cast<int>(kChannel1):
         b.set_display_channel_mode(1);
         b.set_pixel_layout("ggga");
         break;
-    case static_cast<int>(PixelFormat::kChannel2):
+    case static_cast<int>(kChannel2):
         b.set_display_channel_mode(1);
         b.set_pixel_layout("bbba");
         break;
@@ -123,20 +124,19 @@ void apply_format(oid::Buffer& b, int sel) {
 // buffer's actual format instead of carrying over a stale index or
 // requiring extra per-buffer bookkeeping.
 int current_format_index(const oid::Buffer& b) {
+    using enum PixelFormat;
     const std::string layout = b.get_pixel_layout();
     if (b.get_display_channel_mode() == 1) {
         if (layout == "ggga") {
-            return static_cast<int>(PixelFormat::kChannel1);
+            return static_cast<int>(kChannel1);
         }
         if (layout == "bbba") {
-            return static_cast<int>(PixelFormat::kChannel2);
+            return static_cast<int>(kChannel2);
         }
-        return static_cast<int>(
-            PixelFormat::kChannel0); // "rrra", or any other single-channel
-                                     // layout
+        return static_cast<int>(kChannel0); // "rrra", or any other
+                                            // single-channel layout
     }
-    return static_cast<int>(layout == "rgba" ? PixelFormat::kRgba
-                                             : PixelFormat::kBgra);
+    return static_cast<int>(layout == "rgba" ? kRgba : kBgra);
 }
 
 } // namespace

--- a/src/host/ui/stage_manager.cpp
+++ b/src/host/ui/stage_manager.cpp
@@ -112,7 +112,7 @@ void StageManager::sync() {
     // destroys the Stage (and the span into its now-gone BufferRecord)
     // before any dangling reference could be observed.
     for (auto it = by_name_.begin(); it != by_name_.end();) {
-        if (live_names.find(it->first) == live_names.end()) {
+        if (!live_names.contains(it->first)) {
             it = by_name_.erase(it);
         } else {
             ++it;

--- a/src/host/ui/stage_manager.cpp
+++ b/src/host/ui/stage_manager.cpp
@@ -111,13 +111,9 @@ void StageManager::sync() {
     // Drop Stages for buffers no longer present in the model. Erasing here
     // destroys the Stage (and the span into its now-gone BufferRecord)
     // before any dangling reference could be observed.
-    for (auto it = by_name_.begin(); it != by_name_.end();) {
-        if (!live_names.contains(it->first)) {
-            it = by_name_.erase(it);
-        } else {
-            ++it;
-        }
-    }
+    std::erase_if(by_name_, [&live_names](const auto& kv) {
+        return !live_names.contains(kv.first);
+    });
 }
 
 } // namespace oid::host

--- a/src/host/ui/svg_icon_cache.cpp
+++ b/src/host/ui/svg_icon_cache.cpp
@@ -47,23 +47,24 @@ namespace {
 // {data, size}; every IconId has a matching array, so there is no
 // "not found" case.
 std::pair<const unsigned char*, std::size_t> svg_source_for(IconId id) {
+    using enum IconId;
     switch (id) {
-    case IconId::ChannelRed:
+    case ChannelRed:
         return {icons::kLabelRedChannelSvg, sizeof(icons::kLabelRedChannelSvg)};
-    case IconId::ChannelGreen:
+    case ChannelGreen:
         return {icons::kLabelGreenChannelSvg,
                 sizeof(icons::kLabelGreenChannelSvg)};
-    case IconId::ChannelBlue:
+    case ChannelBlue:
         return {icons::kLabelBlueChannelSvg,
                 sizeof(icons::kLabelBlueChannelSvg)};
-    case IconId::ChannelAlpha:
+    case ChannelAlpha:
         return {icons::kLabelAlphaChannelSvg,
                 sizeof(icons::kLabelAlphaChannelSvg)};
-    case IconId::LowerUpperBound:
+    case LowerUpperBound:
         return {icons::kLowerUpperBoundSvg, sizeof(icons::kLowerUpperBoundSvg)};
-    case IconId::GoToX:
+    case GoToX:
         return {icons::kXSvg, sizeof(icons::kXSvg)};
-    case IconId::GoToY:
+    case GoToY:
         return {icons::kYSvg, sizeof(icons::kYSvg)};
     }
     return {nullptr, 0};

--- a/src/host/ui/symbol_filter.cpp
+++ b/src/host/ui/symbol_filter.cpp
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <ranges>
 #include <string_view>
 
 namespace oid::host {
@@ -46,18 +47,13 @@ bool contains_ci(std::string_view haystack, std::string_view needle) {
         return true;
     }
 
-    return std::search(haystack.begin(),
-                       haystack.end(),
-                       needle.begin(),
-                       needle.end(),
-                       ci_char_equal) != haystack.end();
+    return !std::ranges::search(haystack, needle, ci_char_equal).empty();
 }
 
 bool ci_less(std::string_view a, std::string_view b) {
-    return std::lexicographical_compare(
-        a.begin(), a.end(), b.begin(), b.end(), [](char lhs, char rhs) {
-            return ascii_tolower(lhs) < ascii_tolower(rhs);
-        });
+    return std::ranges::lexicographical_compare(a, b, [](char lhs, char rhs) {
+        return ascii_tolower(lhs) < ascii_tolower(rhs);
+    });
 }
 
 } // namespace
@@ -74,7 +70,7 @@ filter_symbols(const std::vector<std::string>& candidates,
         }
     }
 
-    std::stable_sort(result.begin(), result.end(), ci_less);
+    std::ranges::stable_sort(result, ci_less);
 
     return result;
 }

--- a/src/host/ui/thumbnail_cache.cpp
+++ b/src/host/ui/thumbnail_cache.cpp
@@ -138,7 +138,7 @@ void ThumbnailCache::evict_missing(const std::vector<std::string>& live_names) {
     const std::unordered_set<std::string> live(live_names.begin(),
                                                live_names.end());
     for (auto it = entries_.begin(); it != entries_.end();) {
-        if (live.find(it->first) == live.end()) {
+        if (!live.contains(it->first)) {
             if (it->second.tex != 0) {
                 canvas_.glDeleteTextures(1, &it->second.tex);
             }

--- a/src/host/ui/thumbnail_cache.cpp
+++ b/src/host/ui/thumbnail_cache.cpp
@@ -137,16 +137,15 @@ GLuint ThumbnailCache::texture_for(const std::string& name,
 void ThumbnailCache::evict_missing(const std::vector<std::string>& live_names) {
     const std::unordered_set<std::string> live(live_names.begin(),
                                                live_names.end());
-    for (auto it = entries_.begin(); it != entries_.end();) {
-        if (!live.contains(it->first)) {
-            if (it->second.tex != 0) {
-                canvas_.glDeleteTextures(1, &it->second.tex);
+    std::erase_if(entries_, [&live, this](const auto& kv) {
+        if (!live.contains(kv.first)) {
+            if (kv.second.tex != 0) {
+                canvas_.glDeleteTextures(1, &kv.second.tex);
             }
-            it = entries_.erase(it);
-        } else {
-            ++it;
+            return true;
         }
-    }
+        return false;
+    });
 }
 
 } // namespace oid::host

--- a/src/ipc/message_exchange.h
+++ b/src/ipc/message_exchange.h
@@ -29,6 +29,7 @@
 #include <bit>
 #include <cstddef>
 #include <deque>
+#include <format>
 #include <memory>
 #include <source_location>
 #include <span>
@@ -79,9 +80,10 @@ class SocketTimeoutError final : public std::runtime_error {
     explicit SocketTimeoutError(
         const char* operation,
         const std::source_location& loc = std::source_location::current())
-        : std::runtime_error(std::string{"Socket "} + operation +
-                             " timeout at " + loc.file_name() + ":" +
-                             std::to_string(loc.line())) {}
+        : std::runtime_error(std::format("Socket {} timeout at {}:{}",
+                                         operation,
+                                         loc.file_name(),
+                                         loc.line())) {}
 };
 
 // Helper function for error reporting with source location

--- a/src/ipc/raw_data_decode.h
+++ b/src/ipc/raw_data_decode.h
@@ -46,18 +46,19 @@ std::vector<std::byte>
 make_float_buffer_from_double(const std::vector<std::byte>& buff_double);
 
 [[nodiscard]] constexpr std::size_t type_size(const BufferType type) noexcept {
+    using enum BufferType;
     switch (type) {
-    case BufferType::Int32:
+    case Int32:
         return sizeof(std::int32_t);
-    case BufferType::Short:
+    case Short:
         [[fallthrough]];
-    case BufferType::UnsignedShort:
+    case UnsignedShort:
         return sizeof(std::int16_t);
-    case BufferType::Float32:
+    case Float32:
         return sizeof(float);
-    case BufferType::Float64:
+    case Float64:
         return sizeof(double);
-    case BufferType::UnsignedByte:
+    case UnsignedByte:
         [[fallthrough]];
     default:
         // All enum values are handled above, this should never be reached

--- a/src/visualization/components/buffer.cpp
+++ b/src/visualization/components/buffer.cpp
@@ -64,23 +64,24 @@ void format_pixel_value(std::stringstream& message,
                         const BufferType type,
                         const std::span<const std::byte> buffer,
                         const int pos) {
+    using enum BufferType;
     switch (type) {
-    case BufferType::Float32:
+    case Float32:
         message << std::bit_cast<const float*>(buffer.data())[pos];
         break;
-    case BufferType::Float64:
+    case Float64:
         message << std::bit_cast<const double*>(buffer.data())[pos];
         break;
-    case BufferType::UnsignedByte:
+    case UnsignedByte:
         message << static_cast<short>(static_cast<uint8_t>(buffer[pos]));
         break;
-    case BufferType::Short:
+    case Short:
         message << std::bit_cast<const short*>(buffer.data())[pos];
         break;
-    case BufferType::UnsignedShort:
+    case UnsignedShort:
         message << std::bit_cast<const unsigned short*>(buffer.data())[pos];
         break;
-    case BufferType::Int32:
+    case Int32:
         message << std::bit_cast<const int*>(buffer.data())[pos];
         break;
     }
@@ -166,24 +167,25 @@ void Buffer::set_icon_drawing_mode(const bool is_enabled) const {
 void Buffer::update_min_color_value(float* lowest,
                                     const int i,
                                     const int c) const {
-    if (type == BufferType::Float32 || type == BufferType::Float64) {
+    using enum BufferType;
+    if (type == Float32 || type == Float64) {
         lowest[c] = (std::min)(lowest[c],
                                std::bit_cast<const float*>(
                                    buffer_.data())[channels * i + c]);
-    } else if (type == BufferType::UnsignedByte) {
+    } else if (type == UnsignedByte) {
         lowest[c] = (std::min)(lowest[c],
                                static_cast<float>(static_cast<uint8_t>(
                                    buffer_[channels * i + c])));
-    } else if (type == BufferType::Short) {
+    } else if (type == Short) {
         lowest[c] = (std::min)(lowest[c],
                                static_cast<float>(std::bit_cast<const short*>(
                                    buffer_.data())[channels * i + c]));
-    } else if (type == BufferType::UnsignedShort) {
+    } else if (type == UnsignedShort) {
         lowest[c] =
             (std::min)(lowest[c],
                        static_cast<float>(std::bit_cast<const unsigned short*>(
                            buffer_.data())[channels * i + c]));
-    } else if (type == BufferType::Int32) {
+    } else if (type == Int32) {
         lowest[c] = (std::min)(lowest[c],
                                static_cast<float>(std::bit_cast<const int*>(
                                    buffer_.data())[channels * i + c]));
@@ -218,24 +220,25 @@ void Buffer::recompute_min_color_values() {
 void Buffer::update_max_color_value(float* upper,
                                     const int i,
                                     const int c) const {
-    if (type == BufferType::Float32 || type == BufferType::Float64) {
+    using enum BufferType;
+    if (type == Float32 || type == Float64) {
         upper[c] = (std::max)(upper[c],
                               std::bit_cast<const float*>(
                                   buffer_.data())[channels * i + c]);
-    } else if (type == BufferType::UnsignedByte) {
+    } else if (type == UnsignedByte) {
         upper[c] = (std::max)(upper[c],
                               static_cast<float>(static_cast<uint8_t>(
                                   buffer_[channels * i + c])));
-    } else if (type == BufferType::Short) {
+    } else if (type == Short) {
         upper[c] = (std::max)(upper[c],
                               static_cast<float>(std::bit_cast<const short*>(
                                   buffer_.data())[channels * i + c]));
-    } else if (type == BufferType::UnsignedShort) {
+    } else if (type == UnsignedShort) {
         upper[c] =
             (std::max)(upper[c],
                        static_cast<float>(std::bit_cast<const unsigned short*>(
                            buffer_.data())[channels * i + c]));
-    } else if (type == BufferType::Int32) {
+    } else if (type == Int32) {
         upper[c] = (std::max)(upper[c],
                               static_cast<float>(std::bit_cast<const int*>(
                                   buffer_.data())[channels * i + c]));
@@ -274,6 +277,7 @@ void Buffer::reset_contrast_brightness_parameters() {
 }
 
 void Buffer::compute_contrast_brightness_parameters() {
+    using enum BufferType;
     const auto lowest = min_buffer_values();
     const auto upper = max_buffer_values();
 
@@ -283,19 +287,19 @@ void Buffer::compute_contrast_brightness_parameters() {
 
     for (int c = 0; c < channels; ++c) {
         auto maxIntensity = 1.0f;
-        if (type == BufferType::UnsignedByte) {
+        if (type == UnsignedByte) {
             maxIntensity = 255.0f;
-        } else if (type == BufferType::Short) {
+        } else if (type == Short) {
             // All non-real values have max color 255
             maxIntensity =
                 static_cast<float>((std::numeric_limits<short>::max)());
-        } else if (type == BufferType::UnsignedShort) {
+        } else if (type == UnsignedShort) {
             maxIntensity = static_cast<float>(
                 (std::numeric_limits<unsigned short>::max)());
-        } else if (type == BufferType::Int32) {
+        } else if (type == Int32) {
             maxIntensity =
                 static_cast<float>((std::numeric_limits<int>::max)());
-        } else if (type == BufferType::Float32 || type == BufferType::Float64) {
+        } else if (type == Float32 || type == Float64) {
             maxIntensity = 1.0f;
         }
         const auto upp_minus_low = upper[c] - lowest[c];

--- a/src/visualization/components/buffer_values.cpp
+++ b/src/visualization/components/buffer_values.cpp
@@ -28,7 +28,7 @@
 #include <algorithm>
 #include <array>
 #include <bit>
-#include <cstdio>
+#include <format>
 #include <string>
 
 #include <GL/glcorearb.h>
@@ -70,24 +70,37 @@ inline void pix2str(const PixelFormatParams& params) {
 
     if (type == Float32 || type == Float64) {
         const float fpix = std::bit_cast<const float*>(buffer)[pixel_pos];
-        snprintf(pix_label, label_length, "%.*f", float_precision, fpix);
+        const auto result = std::format_to_n(
+            pix_label, label_length - 1, "{:.{}f}", fpix, float_precision);
+        *result.out = '\0';
     } else if (type == UnsignedByte) {
-        snprintf(pix_label,
-                 label_length,
-                 "%d",
-                 static_cast<uint8_t>(buffer[pixel_pos]));
+        const auto result =
+            std::format_to_n(pix_label,
+                             label_length - 1,
+                             "{}",
+                             static_cast<uint8_t>(buffer[pixel_pos]));
+        *result.out = '\0';
     } else if (type == Short) {
         const short fpix = std::bit_cast<const short*>(buffer)[pixel_pos];
-        snprintf(pix_label, label_length, "%d", fpix);
+        const auto result =
+            std::format_to_n(pix_label, label_length - 1, "{}", fpix);
+        *result.out = '\0';
     } else if (type == UnsignedShort) {
         const unsigned short fpix =
             std::bit_cast<const unsigned short*>(buffer)[pixel_pos];
-        snprintf(pix_label, label_length, "%d", fpix);
+        const auto result =
+            std::format_to_n(pix_label, label_length - 1, "{}", fpix);
+        *result.out = '\0';
     } else if (type == Int32) {
         const int fpix = std::bit_cast<const int*>(buffer)[pixel_pos];
-        const auto written = snprintf(pix_label, label_length, "%d", fpix);
-        if (written > 0 && static_cast<size_t>(written) > 7) {
-            snprintf(pix_label, label_length, "%.3e", static_cast<float>(fpix));
+        auto result = std::format_to_n(pix_label, label_length - 1, "{}", fpix);
+        *result.out = '\0';
+        if (result.size > 7) {
+            result = std::format_to_n(pix_label,
+                                      label_length - 1,
+                                      "{:.3e}",
+                                      static_cast<float>(fpix));
+            *result.out = '\0';
         }
     }
 }

--- a/src/visualization/components/buffer_values.cpp
+++ b/src/visualization/components/buffer_values.cpp
@@ -58,6 +58,7 @@ int BufferValues::render_index() const {
 }
 
 inline void pix2str(const PixelFormatParams& params) {
+    using enum BufferType;
     const auto type = params.type;
     const auto buffer = params.buffer;
     const auto pos = params.pos;
@@ -67,22 +68,22 @@ inline void pix2str(const PixelFormatParams& params) {
     const auto float_precision = params.float_precision;
     const auto pixel_pos = pos + channel;
 
-    if (type == BufferType::Float32 || type == BufferType::Float64) {
+    if (type == Float32 || type == Float64) {
         const float fpix = std::bit_cast<const float*>(buffer)[pixel_pos];
         snprintf(pix_label, label_length, "%.*f", float_precision, fpix);
-    } else if (type == BufferType::UnsignedByte) {
+    } else if (type == UnsignedByte) {
         snprintf(pix_label,
                  label_length,
                  "%d",
                  static_cast<uint8_t>(buffer[pixel_pos]));
-    } else if (type == BufferType::Short) {
+    } else if (type == Short) {
         const short fpix = std::bit_cast<const short*>(buffer)[pixel_pos];
         snprintf(pix_label, label_length, "%d", fpix);
-    } else if (type == BufferType::UnsignedShort) {
+    } else if (type == UnsignedShort) {
         const unsigned short fpix =
             std::bit_cast<const unsigned short*>(buffer)[pixel_pos];
         snprintf(pix_label, label_length, "%d", fpix);
-    } else if (type == BufferType::Int32) {
+    } else if (type == Int32) {
         const int fpix = std::bit_cast<const int*>(buffer)[pixel_pos];
         const auto written = snprintf(pix_label, label_length, "%d", fpix);
         if (written > 0 && static_cast<size_t>(written) > 7) {

--- a/src/visualization/components/camera.cpp
+++ b/src/visualization/components/camera.cpp
@@ -201,27 +201,28 @@ void Camera::handle_key_events() {
 }
 
 EventProcessCode Camera::key_press_event(int) {
-    using Key = KeyboardState::Key;
+    using enum EventProcessCode;
+    using enum KeyboardState::Key;
 
     const auto screen_center = vec4{0.0f, 0.0f, 0.0f, 1.0f};
-    auto event_intercepted = EventProcessCode::IGNORED;
+    auto event_intercepted = IGNORED;
 
     if (KeyboardState::is_modifier_key_pressed(
             KeyboardState::ModifierKey::Control)) {
-        if (KeyboardState::is_key_pressed(Key::Plus)) {
+        if (KeyboardState::is_key_pressed(Plus)) {
             scale_at(screen_center, 1.0f);
 
-            event_intercepted = EventProcessCode::INTERCEPTED;
-        } else if (KeyboardState::is_key_pressed(Key::Minus)) {
+            event_intercepted = INTERCEPTED;
+        } else if (KeyboardState::is_key_pressed(Minus)) {
             scale_at(screen_center, -1.0f);
 
-            event_intercepted = EventProcessCode::INTERCEPTED;
-        } else if (KeyboardState::is_key_pressed(Key::Left) ||
-                   KeyboardState::is_key_pressed(Key::Right) ||
-                   KeyboardState::is_key_pressed(Key::Up) ||
-                   KeyboardState::is_key_pressed(Key::Down)) {
+            event_intercepted = INTERCEPTED;
+        } else if (KeyboardState::is_key_pressed(Left) ||
+                   KeyboardState::is_key_pressed(Right) ||
+                   KeyboardState::is_key_pressed(Up) ||
+                   KeyboardState::is_key_pressed(Down)) {
             // Prevent the arrow keys to propagate
-            event_intercepted = EventProcessCode::INTERCEPTED;
+            event_intercepted = INTERCEPTED;
         }
     }
 

--- a/src/visualization/events.cpp
+++ b/src/visualization/events.cpp
@@ -36,13 +36,14 @@
 namespace oid {
 
 bool KeyboardState::is_modifier_key_pressed(const ModifierKey key) {
+    using enum ModifierKey;
     const ImGuiIO& io = ImGui::GetIO();
     switch (key) {
-    case ModifierKey::Alt:
+    case Alt:
         return io.KeyAlt;
-    case ModifierKey::Control:
+    case Control:
         return io.KeyCtrl;
-    case ModifierKey::Shift:
+    case Shift:
         return io.KeyShift;
     default:
         return false;
@@ -50,6 +51,7 @@ bool KeyboardState::is_modifier_key_pressed(const ModifierKey key) {
 }
 
 bool KeyboardState::is_key_pressed(const Key key) {
+    using enum Key;
     // Suppress camera key input while a text field (e.g. the symbol search box)
     // holds the keyboard: the bare arrow keys now pan the canvas, so without
     // this guard navigating the autocomplete with Up/Down would also pan. When
@@ -58,19 +60,19 @@ bool KeyboardState::is_key_pressed(const Key key) {
         return false;
     }
     switch (key) {
-    case Key::Left:
+    case Left:
         return ImGui::IsKeyDown(ImGuiKey_LeftArrow);
-    case Key::Right:
+    case Right:
         return ImGui::IsKeyDown(ImGuiKey_RightArrow);
-    case Key::Up:
+    case Up:
         return ImGui::IsKeyDown(ImGuiKey_UpArrow);
-    case Key::Down:
+    case Down:
         return ImGui::IsKeyDown(ImGuiKey_DownArrow);
-    case Key::Plus:
+    case Plus:
         // US layout: '+' is Shift+'='; also accept the keypad '+'.
         return ImGui::IsKeyDown(ImGuiKey_Equal) ||
                ImGui::IsKeyDown(ImGuiKey_KeypadAdd);
-    case Key::Minus:
+    case Minus:
         return ImGui::IsKeyDown(ImGuiKey_Minus) ||
                ImGui::IsKeyDown(ImGuiKey_KeypadSubtract);
     default:

--- a/src/visualization/game_object.cpp
+++ b/src/visualization/game_object.cpp
@@ -102,14 +102,15 @@ void GameObject::mouse_move_event(const int mouse_x, const int mouse_y) const {
 }
 
 EventProcessCode GameObject::key_press_event(int key_code) const {
-    auto event_intercepted = EventProcessCode::IGNORED;
+    using enum EventProcessCode;
+    auto event_intercepted = IGNORED;
 
     for (const auto& comp : all_components_ | std::views::values) {
         const auto event_intercepted_component =
             comp->key_press_event(key_code);
 
-        if (event_intercepted_component == EventProcessCode::INTERCEPTED) {
-            event_intercepted = EventProcessCode::INTERCEPTED;
+        if (event_intercepted_component == INTERCEPTED) {
+            event_intercepted = INTERCEPTED;
         }
     }
 

--- a/src/visualization/shader.cpp
+++ b/src/visualization/shader.cpp
@@ -192,14 +192,15 @@ void ShaderProgram::use() const {
 }
 
 const char* ShaderProgram::get_texel_format_define() const {
+    using enum TexelChannels;
     switch (texel_format_) {
-    case TexelChannels::FormatR:
+    case FormatR:
         return "#define FORMAT_R\n";
-    case TexelChannels::FormatRG:
+    case FormatRG:
         return "#define FORMAT_RG\n";
-    case TexelChannels::FormatRGB:
+    case FormatRGB:
         return "#define FORMAT_RGB\n";
-    case TexelChannels::FormatRGBA:
+    case FormatRGBA:
         return "#define FORMAT_RGBA\n";
     default:
         return "";

--- a/src/visualization/stage.cpp
+++ b/src/visualization/stage.cpp
@@ -261,14 +261,15 @@ void Stage::mouse_move_event(const int mouse_x, const int mouse_y) const {
 }
 
 EventProcessCode Stage::key_press_event(const int key_code) const {
-    auto event_intercepted = EventProcessCode::IGNORED;
+    using enum EventProcessCode;
+    auto event_intercepted = IGNORED;
 
     for (const auto& game_obj : all_game_objects | std::views::values) {
         const auto event_intercepted_game_obj =
             game_obj->key_press_event(key_code);
 
-        if (event_intercepted_game_obj == EventProcessCode::INTERCEPTED) {
-            event_intercepted = EventProcessCode::INTERCEPTED;
+        if (event_intercepted_game_obj == INTERCEPTED) {
+            event_intercepted = INTERCEPTED;
         }
     }
 

--- a/tests/host/ui/export_dialog_test.cpp
+++ b/tests/host/ui/export_dialog_test.cpp
@@ -31,7 +31,7 @@
 
 #include "host/ui/export_dialog.h"
 
-#include <cstdio>
+#include <format>
 
 #include <gtest/gtest.h>
 
@@ -93,7 +93,9 @@ TEST(ExportDialog, FormatSwapReplacesExtensionWhenPathNotUserEdited) {
 
 TEST(ExportDialog, FormatSwapAppendsExtensionWhenPathHasNeither) {
     ExportDialogState st;
-    std::snprintf(st.path_buf.data(), st.path_buf.size(), "%s", "/exp/noext");
+    const auto res = std::format_to_n(
+        st.path_buf.data(), st.path_buf.size() - 1, "{}", "/exp/noext");
+    *res.out = '\0';
     st.format = OutputType::OctaveMatrix;
     apply_format_extension(st);
     EXPECT_STREQ(st.path_buf.data(), "/exp/noext.oct");
@@ -102,8 +104,9 @@ TEST(ExportDialog, FormatSwapAppendsExtensionWhenPathHasNeither) {
 TEST(ExportDialog, FormatSwapRespectsUserEditedPath) {
     ExportDialogState st;
     open_export_dialog(st, "buf", "/exp");
-    std::snprintf(
-        st.path_buf.data(), st.path_buf.size(), "%s", "/exp/custom.name");
+    const auto res = std::format_to_n(
+        st.path_buf.data(), st.path_buf.size() - 1, "{}", "/exp/custom.name");
+    *res.out = '\0';
     st.user_edited_path = true;
 
     st.format = OutputType::OctaveMatrix;
@@ -116,8 +119,9 @@ TEST(ExportDialog, OpenResetsFormatAndUserEditedFlagFromPriorOpen) {
     open_export_dialog(st, "first", "/exp");
     st.format = OutputType::OctaveMatrix;
     apply_format_extension(st);
-    std::snprintf(
-        st.path_buf.data(), st.path_buf.size(), "%s", "/exp/custom.name");
+    const auto res = std::format_to_n(
+        st.path_buf.data(), st.path_buf.size() - 1, "{}", "/exp/custom.name");
+    *res.out = '\0';
     st.user_edited_path = true;
 
     open_export_dialog(st, "second", "/exp");

--- a/tests/support/scratch_dir.h
+++ b/tests/support/scratch_dir.h
@@ -27,8 +27,8 @@
 #define TESTS_SUPPORT_SCRATCH_DIR_H_
 
 #include <filesystem>
+#include <format>
 #include <random>
-#include <sstream>
 #include <stdexcept>
 
 #include <gtest/gtest.h>
@@ -50,9 +50,9 @@ inline std::filesystem::path scratch_dir() {
     const fs::path base{::testing::TempDir()};
     std::random_device rd;
     for (int attempt = 0; attempt < 16; ++attempt) {
-        std::ostringstream name;
-        name << "oid_scratch_" << std::hex << rd() << rd();
-        const fs::path dir = base / name.str();
+        const std::string name =
+            std::format("oid_scratch_{:x}{:x}", rd(), rd());
+        const fs::path dir = base / name;
         if (fs::create_directory(dir)) { // atomic; false if name taken
             fs::permissions(
                 dir, fs::perms::owner_all, fs::perm_options::replace);

--- a/tests/test_raw_data_decode.cpp
+++ b/tests/test_raw_data_decode.cpp
@@ -43,75 +43,75 @@ constexpr double TEST_VALUE_5 = 5.0;
 } // namespace
 
 TEST(RawDataDecodeTest, TypeSizeUnsignedByte) {
-  EXPECT_EQ(type_size(BufferType::UnsignedByte), sizeof(std::uint8_t));
+    EXPECT_EQ(type_size(BufferType::UnsignedByte), sizeof(std::uint8_t));
 }
 
 TEST(RawDataDecodeTest, TypeSizeUnsignedShort) {
-  EXPECT_EQ(type_size(BufferType::UnsignedShort), sizeof(std::int16_t));
+    EXPECT_EQ(type_size(BufferType::UnsignedShort), sizeof(std::int16_t));
 }
 
 TEST(RawDataDecodeTest, TypeSizeShort) {
-  EXPECT_EQ(type_size(BufferType::Short), sizeof(std::int16_t));
+    EXPECT_EQ(type_size(BufferType::Short), sizeof(std::int16_t));
 }
 
 TEST(RawDataDecodeTest, TypeSizeInt32) {
-  EXPECT_EQ(type_size(BufferType::Int32), sizeof(std::int32_t));
+    EXPECT_EQ(type_size(BufferType::Int32), sizeof(std::int32_t));
 }
 
 TEST(RawDataDecodeTest, TypeSizeFloat32) {
-  EXPECT_EQ(type_size(BufferType::Float32), sizeof(float));
+    EXPECT_EQ(type_size(BufferType::Float32), sizeof(float));
 }
 
 TEST(RawDataDecodeTest, TypeSizeFloat64) {
-  EXPECT_EQ(type_size(BufferType::Float64), sizeof(double));
+    EXPECT_EQ(type_size(BufferType::Float64), sizeof(double));
 }
 
 TEST(RawDataDecodeTest, MakeFloatBufferFromDouble_Empty) {
-  std::vector<std::byte> empty;
-  auto result = make_float_buffer_from_double(empty);
-  EXPECT_TRUE(result.empty());
+    std::vector<std::byte> empty;
+    auto result = make_float_buffer_from_double(empty);
+    EXPECT_TRUE(result.empty());
 }
 
 namespace {
 void TestSingleDoubleValue(double value) {
-  std::vector<std::byte> double_buffer(sizeof(double));
-  std::memcpy(double_buffer.data(), &value, sizeof(double));
-  const auto float_buffer = make_float_buffer_from_double(double_buffer);
-  EXPECT_EQ(float_buffer.size(), sizeof(float));
-  float result = 0.0f;
-  std::memcpy(&result, float_buffer.data(), sizeof(float));
-  EXPECT_FLOAT_EQ(result, static_cast<float>(value));
+    std::vector<std::byte> double_buffer(sizeof(double));
+    std::memcpy(double_buffer.data(), &value, sizeof(double));
+    const auto float_buffer = make_float_buffer_from_double(double_buffer);
+    EXPECT_EQ(float_buffer.size(), sizeof(float));
+    float result = 0.0f;
+    std::memcpy(&result, float_buffer.data(), sizeof(float));
+    EXPECT_FLOAT_EQ(result, static_cast<float>(value));
 }
 } // namespace
 
 TEST(RawDataDecodeTest, MakeFloatBufferFromDouble_SingleValue) {
-  TestSingleDoubleValue(TEST_PI);
+    TestSingleDoubleValue(TEST_PI);
 }
 
 TEST(RawDataDecodeTest, MakeFloatBufferFromDouble_MultipleValues) {
-  const std::vector<double> values = {TEST_VALUE_1, TEST_VALUE_2_5, TEST_PI,
-                                      TEST_VALUE_4, TEST_VALUE_5};
-  std::vector<std::byte> double_buffer(values.size() * sizeof(double));
-  std::memcpy(double_buffer.data(), values.data(), double_buffer.size());
-  const auto float_buffer = make_float_buffer_from_double(double_buffer);
+    const std::vector<double> values = {
+        TEST_VALUE_1, TEST_VALUE_2_5, TEST_PI, TEST_VALUE_4, TEST_VALUE_5};
+    std::vector<std::byte> double_buffer(values.size() * sizeof(double));
+    std::memcpy(double_buffer.data(), values.data(), double_buffer.size());
+    const auto float_buffer = make_float_buffer_from_double(double_buffer);
 
-  EXPECT_EQ(float_buffer.size(), values.size() * sizeof(float));
-  for (auto i = 0U; i < values.size(); ++i) {
-    float result = 0.0f;
-    std::memcpy(&result, float_buffer.data() + i * sizeof(float),
-                sizeof(float));
-    EXPECT_FLOAT_EQ(result, static_cast<float>(values[i]));
-  }
+    EXPECT_EQ(float_buffer.size(), values.size() * sizeof(float));
+    for (auto i = 0U; i < values.size(); ++i) {
+        float result = 0.0f;
+        std::memcpy(
+            &result, float_buffer.data() + i * sizeof(float), sizeof(float));
+        EXPECT_FLOAT_EQ(result, static_cast<float>(values[i]));
+    }
 }
 
 TEST(RawDataDecodeTest, MakeFloatBufferFromDouble_LargeValue) {
-  TestSingleDoubleValue(TEST_LARGE_VALUE);
+    TestSingleDoubleValue(TEST_LARGE_VALUE);
 }
 
 TEST(RawDataDecodeTest, MakeFloatBufferFromDouble_NegativeValue) {
-  TestSingleDoubleValue(TEST_NEGATIVE_VALUE);
+    TestSingleDoubleValue(TEST_NEGATIVE_VALUE);
 }
 
 TEST(RawDataDecodeTest, MakeFloatBufferFromDouble_Zero) {
-  TestSingleDoubleValue(0.0);
+    TestSingleDoubleValue(0.0);
 }

--- a/tests/test_raw_data_decode.cpp
+++ b/tests/test_raw_data_decode.cpp
@@ -25,6 +25,7 @@
 
 #include <cstring>
 #include <gtest/gtest.h>
+#include <numbers>
 #include <vector>
 
 #include "ipc/raw_data_decode.h"
@@ -32,7 +33,7 @@
 using namespace oid;
 
 namespace {
-constexpr double TEST_PI = 3.14159;
+constexpr double TEST_PI = std::numbers::pi;
 constexpr double TEST_LARGE_VALUE = 1e10;
 constexpr double TEST_NEGATIVE_VALUE = -42.5;
 constexpr double TEST_VALUE_1 = 1.0;


### PR DESCRIPTION
## Summary

Modernizes first-party C++ to C++20 idioms, resolving **49 SonarQube findings across 9 rules** on `main`. Each rule is a single, self-contained commit; the changes are mechanical and **behavior-preserving** (no functional change intended). The existing test suite (26 tests) is the regression net and stays green throughout.

## Rules addressed

| Commit | Rule | Change | Sites |
|--------|------|--------|-------|
| `contains()` for membership | S6171 | `count()`/`find()!=end()` → `.contains()` | 6 |
| `emplace_back` | S6003 | `push_back({…})` → `emplace_back(…)` | 2 |
| `std::erase_if` | S6165 | manual erase loops → `std::erase_if` | 2 |
| `std::ranges` overloads | S6197 | `any_of`/`search`/`lexicographical_compare`/`stable_sort` → `std::ranges::` | 4 |
| `std::numbers::pi` | S6164 | magic constant → `std::numbers::pi` | 1 |
| `using enum` | S6177 | drop redundant enum qualifiers via `using enum` | 18 (20 scopes / 12 files) |
| `std::format` | S6185 | `+`-concatenation / `to_string` → `std::format` | 6 |
| `std::format_to_n` | S6494 | `snprintf` → `std::format_to_n` | 9 |
| `std::format` (hex) | S6495 | `ostringstream`/`std::hex` → `std::format("{:x}")` | 1 |

A separate `style:` commit reindents one pre-existing test file to match `tests/.clang-format` (whitespace/reflow only, token stream verified identical) — kept out of the semantic commits.

## Approach & correctness notes

- **One commit per rule**, ordered idiom-first, then the `std::format` family after confirming toolchain support.
- **`std::format` conversions are byte-for-byte output-equivalent** — field order, literal punctuation, spacing, and newlines preserved.
- **`std::format_to_n`** does not null-terminate: every site writes at most `capacity - 1` chars and appends the terminator explicitly, matching the previous `snprintf` bounds. The float site's dynamic-precision argument order is adjusted for `"{:.{}f}"`; the Int32 scientific-notation fallback is preserved.
- **`using enum`** declarations are strictly function/switch-local; each unqualified enumerator resolves to the intended enum (verified for the multi-enum scopes).
- **`std::ranges::search` polarity** and the `erase_if` predicate side effect (texture deletion) are preserved; the predicate lambdas use explicit captures.
- `<format>` added where used; `<cstdio>`/`<sstream>` removed where their last use was replaced; `<sstream>`/`<iomanip>` retained where still needed.

## Testing

- `cmake --build` (Release) + `ctest` → **26/26 passing**, no new warnings.
- Group B (`std::format`/`std::format_to_n`) confirmed to compile and run under both AppleClang libc++ and an emscripten/libc++ 4.0.7 C++20 toolchain (relevant to the WebAssembly viewer build).

## Out of scope

- Pre-existing findings on touched files that this PR does not modify (e.g. transparent-hasher suggestions for `std::string`-keyed containers, unused-include hints) are intentionally left for separate changes.
