### PR TITLE
fix: exclude src/thirdparty from CodeQL analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,32 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2015-2026 OpenImageDebugger contributors
+# (https://github.com/OpenImageDebugger/OpenImageDebugger)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+
+name: "CodeQL config"
+
+# Vendored dependencies live under src/thirdparty (git submodules: asio,
+# Eigen, glfw, googletest, imgui, json, Khronos, nanosvg, stb). They are not
+# our code, so exclude them from CodeQL analysis to keep alerts focused on
+# first-party sources.
+paths-ignore:
+  - src/thirdparty

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -83,6 +83,8 @@ jobs:
       uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # 3.29.5
       with:
         languages: ${{ matrix.language }}
+        # Excludes vendored dependencies under src/thirdparty from analysis.
+        config-file: ./.github/codeql/codeql-config.yml
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
## Summary

Excludes vendored third-party code under `src/thirdparty` from CodeQL analysis so code-scanning alerts stay focused on first-party sources.

## Changes

- **Add** `.github/codeql/codeql-config.yml` — a CodeQL configuration with `paths-ignore: src/thirdparty` (the vendored submodules: asio, Eigen, glfw, googletest, imgui, json, Khronos, nanosvg, stb).
- **Reference** the config from the `github/codeql-action/init` step via `config-file`.

## Notes

For the C/C++ analysis, `src/thirdparty` is still compiled during autobuild (it's linked into the build), but `paths-ignore` filters out any alerts located in those paths — third-party code no longer surfaces code-scanning alerts.
