### PR TITLE
fix: resolve remaining mechanical SonarQube findings (34 fixes, 8 rules)

### DIFF
--- a/resources/oidscripts/debuggers/gdbbridge.py
+++ b/resources/oidscripts/debuggers/gdbbridge.py
@@ -20,7 +20,7 @@ class GdbBridge(BridgeInterface):
     """
     def __init__(self, type_bridge):
         self._type_bridge = type_bridge
-        self._commands = dict(plot=PlotterCommand(self))
+        self._commands = {"plot": PlotterCommand(self)}
         self._event_handler = None  # type: BridgeEventHandlerInterface
 
         self._pending_requests = []

--- a/resources/oidscripts/test.py
+++ b/resources/oidscripts/test.py
@@ -151,7 +151,7 @@ class DummyDebugger(BridgeInterface):
         width = 400
         height = 200
         self._buffers = _gen_buffers(width, height)
-        self._buffer_names = [name for name in self._buffers]
+        self._buffer_names = list(self._buffers)
 
         self._is_running = True
         self._incoming_request_queue = []

--- a/src/host/ui/stage_manager.cpp
+++ b/src/host/ui/stage_manager.cpp
@@ -30,6 +30,8 @@
 #include <unordered_set>
 #include <utility>
 
+#include "host/ui/transparent_string_hash.h"
+
 namespace oid::host {
 
 namespace {
@@ -69,7 +71,8 @@ oid::Stage* StageManager::stage_for(std::size_t i) {
 }
 
 void StageManager::sync() {
-    std::unordered_set<std::string> live_names;
+    std::unordered_set<std::string, TransparentStringHash, std::equal_to<>>
+        live_names;
     live_names.reserve(model_.size());
 
     for (std::size_t i = 0; i < model_.size(); ++i) {

--- a/src/host/ui/stage_manager.h
+++ b/src/host/ui/stage_manager.h
@@ -33,6 +33,7 @@
 #include <unordered_map>
 
 #include "host/ui/buffer_model.h"
+#include "host/ui/transparent_string_hash.h"
 #include "visualization/render_canvas.h"
 #include "visualization/stage.h"
 
@@ -85,7 +86,11 @@ class StageManager {
 
     std::shared_ptr<RenderCanvas> canvas_;
     const BufferModel& model_;
-    std::unordered_map<std::string, Entry> by_name_;
+    std::unordered_map<std::string,
+                       Entry,
+                       TransparentStringHash,
+                       std::equal_to<>>
+        by_name_;
 };
 
 } // namespace oid::host

--- a/src/host/ui/svg_icon_cache.cpp
+++ b/src/host/ui/svg_icon_cache.cpp
@@ -43,7 +43,8 @@ namespace oid::host {
 namespace {
 
 // Maps an IconId to its embedded SVG source (headers generated from
-// src/resources/icons/*.svg, one "<name>_svg.h" per icon). Returns
+// the .svg files under src/resources/icons, one "<name>_svg.h" per
+// icon). Returns
 // {data, size}; every IconId has a matching array, so there is no
 // "not found" case.
 std::pair<const unsigned char*, std::size_t> svg_source_for(IconId id) {

--- a/src/host/ui/thumbnail_cache.cpp
+++ b/src/host/ui/thumbnail_cache.cpp
@@ -28,6 +28,7 @@
 #include <unordered_set>
 
 #include "host/glfw_canvas.h"
+#include "host/ui/transparent_string_hash.h"
 #include "platform/gl_dialect.h"
 #include "visualization/stage.h"
 
@@ -135,8 +136,9 @@ GLuint ThumbnailCache::texture_for(const std::string& name,
 }
 
 void ThumbnailCache::evict_missing(const std::vector<std::string>& live_names) {
-    const std::unordered_set<std::string> live(live_names.begin(),
-                                               live_names.end());
+    const std::
+        unordered_set<std::string, TransparentStringHash, std::equal_to<>>
+            live(live_names.begin(), live_names.end());
     std::erase_if(entries_, [&live, this](const auto& kv) {
         if (!live.contains(kv.first)) {
             if (kv.second.tex != 0) {

--- a/src/host/ui/thumbnail_cache.h
+++ b/src/host/ui/thumbnail_cache.h
@@ -33,6 +33,8 @@
 
 #include <GL/gl.h>
 
+#include "host/ui/transparent_string_hash.h"
+
 namespace oid {
 class Stage;
 } // namespace oid
@@ -106,7 +108,11 @@ class ThumbnailCache {
     };
 
     GlfwCanvas& canvas_;
-    std::unordered_map<std::string, Entry> entries_;
+    std::unordered_map<std::string,
+                       Entry,
+                       TransparentStringHash,
+                       std::equal_to<>>
+        entries_;
     bool rendered_this_frame_{false};
     // Offscreen render size (Qt parity: the legacy Qt frontend's
     // ICON_WIDTH_BASE/ICON_HEIGHT_BASE == 100x75, see tag legacy-qt, scaled

--- a/src/host/ui/transparent_string_hash.h
+++ b/src/host/ui/transparent_string_hash.h
@@ -1,0 +1,49 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef HOST_UI_TRANSPARENT_STRING_HASH_H_
+#define HOST_UI_TRANSPARENT_STRING_HASH_H_
+
+#include <cstddef>
+#include <functional>
+#include <string_view>
+
+namespace oid::host {
+
+// Transparent hash for std::string-keyed unordered containers: paired with
+// std::equal_to<>, it enables heterogeneous lookup (std::string_view or
+// const char*) without constructing a temporary std::string.
+struct TransparentStringHash {
+    using is_transparent = void;
+
+    [[nodiscard]] std::size_t
+    operator()(const std::string_view sv) const noexcept {
+        return std::hash<std::string_view>{}(sv);
+    }
+};
+
+} // namespace oid::host
+
+#endif // HOST_UI_TRANSPARENT_STRING_HASH_H_

--- a/src/host/ui/ui_state.cpp
+++ b/src/host/ui/ui_state.cpp
@@ -30,6 +30,7 @@
 
 #include "host/ui/symbol_filter.h"
 #include "host/ui/text_input.h"
+#include "host/ui/transparent_string_hash.h"
 
 namespace oid::host {
 
@@ -74,7 +75,11 @@ std::vector<std::size_t> UiState::filtered_indices() const {
     // display_name keep their original relative (index) order, so
     // popping from the front of each name's queue in match order pairs
     // each match with the correct, not-yet-consumed model index.
-    std::unordered_map<std::string, std::deque<std::size_t>> by_name;
+    std::unordered_map<std::string,
+                       std::deque<std::size_t>,
+                       TransparentStringHash,
+                       std::equal_to<>>
+        by_name;
     for (std::size_t i = 0; i < candidates.size(); ++i) {
         by_name[candidates[i]].push_back(i);
     }

--- a/src/math/linear_algebra.cpp
+++ b/src/math/linear_algebra.cpp
@@ -113,8 +113,14 @@ void mat4::set_from_st(const float scaleX,
     data[13] = y;
     data[14] = z;
 
-    data[1] = data[2] = data[3] = data[4] = 0.0f;
-    data[6] = data[7] = data[8] = data[9] = 0.0f;
+    data[1] = 0.0f;
+    data[2] = 0.0f;
+    data[3] = 0.0f;
+    data[4] = 0.0f;
+    data[6] = 0.0f;
+    data[7] = 0.0f;
+    data[8] = 0.0f;
+    data[9] = 0.0f;
     data[11] = 0.0f;
     data[15] = 1.0f;
 }
@@ -195,9 +201,17 @@ void mat4::set_ortho_projection(const float right,
     data[10] = -2.0f / (far - near);
     data[14] = -(far + near) / (far - near);
 
-    data[1] = data[2] = data[3] = data[4] = 0.0f;
-    data[6] = data[7] = data[8] = data[9] = 0.0f;
-    data[11] = data[12] = data[13] = 0.0f;
+    data[1] = 0.0f;
+    data[2] = 0.0f;
+    data[3] = 0.0f;
+    data[4] = 0.0f;
+    data[6] = 0.0f;
+    data[7] = 0.0f;
+    data[8] = 0.0f;
+    data[9] = 0.0f;
+    data[11] = 0.0f;
+    data[12] = 0.0f;
+    data[13] = 0.0f;
     data[15] = 1.0f;
 }
 

--- a/src/system/process/process_win32.cpp
+++ b/src/system/process/process_win32.cpp
@@ -28,18 +28,19 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
-#include <windows.h>
+#include <Windows.h>
 
 namespace oid {
 
 namespace {
 
-std::wstring utf8_to_wide(const std::string& text) {
+std::wstring utf8_to_wide(const std::string_view text) {
     if (text.empty()) {
         return {};
     }
@@ -78,7 +79,7 @@ std::wstring quote_windows_arg(const std::wstring& arg) {
     quoted.push_back(L'"');
     for (const wchar_t ch : arg) {
         if (ch == L'"') {
-            quoted.append(L"\\\"");
+            quoted.append(LR"(\")");
         } else {
             quoted.push_back(ch);
         }

--- a/src/visualization/components/camera.cpp
+++ b/src/visualization/components/camera.cpp
@@ -433,7 +433,8 @@ vec4 Camera::get_position() const {
 }
 
 void Camera::recenter_camera() {
-    camera_pos_x_ = camera_pos_y_ = 0.0f;
+    camera_pos_x_ = 0.0f;
+    camera_pos_y_ = 0.0f;
 
     set_initial_zoom();
     update_object_pose();

--- a/tests/test_asio_transport.cpp
+++ b/tests/test_asio_transport.cpp
@@ -46,7 +46,7 @@ TEST(AsioTransport, RoundTripBytes) {
     const unsigned short port = acceptor.local_endpoint().port();
 
     asio::ip::tcp::socket server_sock(server_ctx);
-    std::thread server([&acceptor, &server_sock] {
+    std::jthread server([&acceptor, &server_sock] {
         acceptor.accept(server_sock);
         // Echo 4 bytes back after receiving 4.
         std::array<std::byte, 4> buf{};
@@ -74,7 +74,7 @@ TEST(AsioTransport, HasDataFalseBeforeSend) {
         asio::ip::tcp::endpoint(asio::ip::make_address("127.0.0.1"), 0));
     const unsigned short port = acceptor.local_endpoint().port();
     asio::ip::tcp::socket server_sock(server_ctx);
-    std::thread server(
+    std::jthread server(
         [&acceptor, &server_sock] { acceptor.accept(server_sock); });
     AsioTransport client("127.0.0.1", port);
     server.join();
@@ -88,7 +88,7 @@ TEST(AsioCodec, RoundTripPlotBufferRequest) {
         asio::ip::tcp::endpoint(asio::ip::make_address("127.0.0.1"), 0));
     const unsigned short port = acceptor.local_endpoint().port();
     asio::ip::tcp::socket raw_server(server_ctx);
-    std::thread server(
+    std::jthread server(
         [&acceptor, &raw_server] { acceptor.accept(raw_server); });
 
     AsioTransport client("127.0.0.1", port);
@@ -130,7 +130,7 @@ TEST(AsioCodec, RoundTripPlotBufferRequest) {
 
 TEST(AsioTransport, ReceiveTimesOutOnSilentPeer) {
     AsioAcceptor acceptor;
-    std::thread server([&acceptor] {
+    std::jthread server([&acceptor] {
         auto t = acceptor.accept(std::chrono::seconds{5});
         std::this_thread::sleep_for(std::chrono::milliseconds{300});
     });
@@ -145,7 +145,7 @@ TEST(AsioAcceptor, AcceptThenRoundTrip) {
     AsioAcceptor acceptor;
     const unsigned short port = acceptor.port();
     std::optional<AsioTransport> server_side;
-    std::thread server([&server_side, &acceptor] {
+    std::jthread server([&server_side, &acceptor] {
         server_side.emplace(acceptor.accept(std::chrono::seconds{5}));
     });
     AsioTransport client("127.0.0.1", port);
@@ -183,7 +183,7 @@ TEST(AsioTransport, IsConnectedTrueWhileOpenNoData) {
     AsioAcceptor acceptor;
     const unsigned short port = acceptor.port();
     std::optional<AsioTransport> server_side;
-    std::thread server([&server_side, &acceptor] {
+    std::jthread server([&server_side, &acceptor] {
         server_side.emplace(acceptor.accept(std::chrono::seconds{5}));
     });
     AsioTransport client("127.0.0.1", port);
@@ -195,7 +195,7 @@ TEST(AsioTransport, IsConnectedFalseAfterPeerClose) {
     AsioAcceptor acceptor;
     const unsigned short port = acceptor.port();
     std::optional<AsioTransport> server_side;
-    std::thread server([&server_side, &acceptor] {
+    std::jthread server([&server_side, &acceptor] {
         server_side.emplace(acceptor.accept(std::chrono::seconds{5}));
     });
     AsioTransport client("127.0.0.1", port);

--- a/tests/test_message_exchange.cpp
+++ b/tests/test_message_exchange.cpp
@@ -84,7 +84,7 @@ class MessageExchangeTest : public ::testing::Test {
     // the acceptor's io_context without owning it.
     void ConnectSockets() {
         acceptor_.emplace();
-        std::thread server_thread([this] {
+        std::jthread server_thread([this] {
             server_transport_.emplace(
                 acceptor_->accept(std::chrono::seconds{5}));
         });


### PR DESCRIPTION
## Summary

Second round of SonarQube cleanup: resolves **34 mechanical findings across 8 rules**, one commit per rule/group, all behavior-preserving. Together with 6 `void*` findings (S5008) marked Accepted in SonarCloud — the wrapper signatures deliberately mirror the underlying OpenGL/ImGui C APIs — this clears all remaining non-structural findings on `main`.

## Changes

| Commit | Rules | Change | Sites |
|--------|-------|--------|-------|
| unchain assignments | S1121 | `a = b = c = 0.0f` → one assignment per statement | 15 (`linear_algebra.cpp`, `camera.cpp`) |
| jthread | S6168 | `std::thread` → `std::jthread` in tests; all explicit `join()` calls kept | 8 (2 test files) |
| transparent hashing | S6045 | new `transparent_string_hash.h` + `std::equal_to<>` on string-keyed containers; zero call-site changes | 5 (`stage_manager`, `thumbnail_cache`, `ui_state`) |
| process_win32 | S6009, S3628, S3806 | `std::string_view` param, raw string literal, `<Windows.h>` include case | 3 |
| comment fix | S1103 | remove misleading `/*` sequence inside a `//` comment | 1 (`svg_icon_cache.cpp`) |
| Python idioms | S7498, S7500 | `dict(...)` → literal, identity comprehension → `list()` | 2 (`oidscripts`) |

## Correctness notes

- **S6045:** `std::hash<std::string_view>` is standard-guaranteed to hash equal character sequences identically to `std::hash<std::string>`, and no call site changed — behavior is bit-identical.
- **S6168:** every explicit `join()` is preserved; `jthread` auto-join only matters on early exception paths (previously `std::terminate`).
- **process_win32.cpp** is Windows-only and verified by inspection locally; the Windows CI build is the gate.

## Testing

- `cmake --build` (Release) + `ctest` → **26/26 passing** after every commit.
- WebAssembly viewer target compiles all touched sources under emscripten; downstream checks green.

## Remaining open findings (intentionally out of scope)

Structural refactors only: cognitive complexity (S3776), nesting (S134), parameter counts (S107), `GlfwCanvas` size (S1448/S1820), mixed access (S5414), and TODO comments (S1135).
