### PR TITLE
fix(host): skip window position get/set on Wayland

### DIFF
--- a/src/host/glfw_host_backend.cpp
+++ b/src/host/glfw_host_backend.cpp
@@ -126,17 +126,38 @@ std::pair<int, int> GlfwHostBackend::window_size() const {
     return {w, h};
 }
 
+namespace {
+
+// Wayland deliberately hides a window's global position from the client, so
+// its GLFW backend implements neither glfwGetWindowPos nor glfwSetWindowPos:
+// calling them does nothing and raises GLFW_FEATURE_UNIMPLEMENTED (error
+// 65548, "The platform does not provide the window position"). Skip those
+// calls there so we don't spam the error callback and can't act on a bogus
+// {0,0} readback. The Emscripten GLFW shim has no glfwGetPlatform and no
+// movable OS window, so treat it as position-less too. Must be called only
+// after glfwInit() (glfwGetPlatform requires it) -- guaranteed here since a
+// non-null window_ implies a successful initialize().
+bool platform_supports_window_position() {
+#if defined(__EMSCRIPTEN__)
+    return false;
+#else
+    return glfwGetPlatform() != GLFW_PLATFORM_WAYLAND;
+#endif
+}
+
+} // namespace
+
 std::pair<int, int> GlfwHostBackend::window_position() const {
     int x = 0;
     int y = 0;
-    if (window_ != nullptr) {
+    if (window_ != nullptr && platform_supports_window_position()) {
         glfwGetWindowPos(window_, &x, &y);
     }
     return {x, y};
 }
 
 void GlfwHostBackend::set_window_position(int x, int y) {
-    if (window_ != nullptr) {
+    if (window_ != nullptr && platform_supports_window_position()) {
         glfwSetWindowPos(window_, x, y);
     }
 }


### PR DESCRIPTION
## Problem

Running the viewer under a Wayland session floods stderr with:

```
[GLFW] error 65548: The platform does not provide the window position
```

`GlfwHostBackend` persists and restores the window's on-screen position across sessions, calling `glfwGetWindowPos` (on save) and `glfwSetWindowPos` (on restore). Wayland's GLFW backend implements **neither** — the Wayland protocol deliberately hides a window's global position from the client — so every save/restore raises `GLFW_FEATURE_UNIMPLEMENTED` (65548) and does nothing. The position was never actually persisted on Wayland anyway.

## Fix

A file-local `platform_supports_window_position()` helper gates both calls:

- **Wayland** (`glfwGetPlatform() == GLFW_PLATFORM_WAYLAND`): skipped — no more error spam, and we no longer act on a bogus `{0,0}` readback.
- **X11 / macOS / Windows**: unchanged — position still saved and restored.
- **Emscripten**: the check is `#if`'d out (the shim has no `glfwGetPlatform` and no movable OS window), treating the canvas as position-less.

## Behavioral note

On Wayland the window position is no longer saved/restored — unavoidable, since the compositor owns window placement. `window_position()` returns `{0,0}` there.

## Verification

- Native: `glfw_geometry_test` compiles and passes (3/3).
- Emscripten: the WASM target compiles and links cleanly.