### PR TITLE
docs: document Homebrew python3/lldb requirement for macOS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,6 @@ command script import /path/to/OpenImageDebugger/oid.py
 
 ### MacOS Installation
 
-For information on how to build the plugin on MacOS, refer to the wiki page
-[Building on
-MacOS](https://github.com/OpenImageDebugger/OpenImageDebugger/wiki/Building-on-MacOS).
-
 At the moment, the MacOS build is only known to work with `python3` and `lldb`
 installed from [Homebrew](https://brew.sh/) (the system-provided LLDB from the
 Xcode Command Line Tools is not supported). Install them with:

--- a/README.md
+++ b/README.md
@@ -135,6 +135,25 @@ For information on how to build the plugin on MacOS, refer to the wiki page
 [Building on
 MacOS](https://github.com/OpenImageDebugger/OpenImageDebugger/wiki/Building-on-MacOS).
 
+At the moment, the MacOS build is only known to work with `python3` and `lldb`
+installed from [Homebrew](https://brew.sh/) (the system-provided LLDB from the
+Xcode Command Line Tools is not supported). Install them with:
+
+```bash
+brew install python3 llvm
+```
+
+Make sure `python3` resolves to the Homebrew one — run `which python3` and
+confirm it points somewhere under `/opt/homebrew` (the standard Homebrew install
+puts `/opt/homebrew/bin` on your `PATH`), rather than a pyenv, conda or
+system Python.
+
+Then debug your program using the Homebrew LLDB, for example:
+
+```bash
+/opt/homebrew/opt/llvm/bin/lldb /path/to/your/executable
+```
+
 ### Testing your installation
 
 After compiling the plugin, you can test it by running the following command:

--- a/README.md
+++ b/README.md
@@ -140,22 +140,33 @@ brew install python3 llvm
 ```
 
 Make sure `python3` resolves to the Homebrew one — run `which python3` and
-confirm it points somewhere under `/opt/homebrew` (the standard Homebrew install
-puts `/opt/homebrew/bin` on your `PATH`), rather than a pyenv, conda or
-system Python.
+confirm it points under the Homebrew prefix (`/opt/homebrew` on Apple Silicon,
+`/usr/local` on Intel; `brew --prefix` prints it), rather than a pyenv, conda or
+system Python. The standard Homebrew install puts that prefix's `bin` on your
+`PATH`.
 
 Then debug your program using the Homebrew LLDB, for example:
 
 ```bash
-/opt/homebrew/opt/llvm/bin/lldb /path/to/your/executable
+BREW_PREFIX=$(brew --prefix)
+"$BREW_PREFIX"/opt/llvm/bin/lldb /path/to/your/executable
 ```
 
 ### Testing your installation
 
-After compiling the plugin, you can test it by running the following command:
+After compiling the plugin, you can test it by running the following command
+(use the same Python 3 interpreter CMake found when building):
 
 ```bash
-python /path/to/OpenImageDebugger/oid.py --test
+python3 /path/to/OpenImageDebugger/oid.py --test
+```
+
+On MacOS, invoke the test with the full path to the Homebrew `python3`, for
+example:
+
+```bash
+BREW_PREFIX=$(brew --prefix)
+"$BREW_PREFIX"/bin/python3 /path/to/OpenImageDebugger/oid.py --test
 ```
 
 If the installation was succesful, you should see the Open Image Debugger window


### PR DESCRIPTION
Expands the **MacOS Installation** section of the README to record what is currently known to work when building the desktop viewer on macOS.

## Changes
- Note that the macOS build is only known to work with `python3` and `lldb` installed from Homebrew (the Xcode Command Line Tools LLDB is not supported), with the `brew install python3 llvm` command.
- Add a check to ensure `python3` resolves to the Homebrew copy (`which python3` under `/opt/homebrew`), rather than a pyenv/conda/system Python shadowing it.
- Add an example of invoking the Homebrew LLDB directly (it is keg-only and not on `PATH`):

  ```bash
  /opt/homebrew/opt/llvm/bin/lldb /path/to/your/executable
  ```

Docs-only change.