### PR TITLE
docs: add download-count badges for extension marketplaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Open Image Debugger: Enabling visualization of in-memory buffers on GDB/LLDB
 
-[![VS Code Marketplace](https://vsmarketplacebadges.dev/version/OpenImageDebugger.openimagedebugger-vscode.svg?label=VS%20Code%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=OpenImageDebugger.openimagedebugger-vscode)
-[![Open VSX](https://img.shields.io/open-vsx/v/openimagedebugger/openimagedebugger-vscode?label=Open%20VSX)](https://open-vsx.org/extension/openimagedebugger/openimagedebugger-vscode)
+[![VS Code Marketplace Downloads](https://vsmarketplacebadges.dev/downloads-short/OpenImageDebugger.openimagedebugger-vscode.svg?label=VS%20Code%20Marketplace%20Downloads)](https://marketplace.visualstudio.com/items?itemName=OpenImageDebugger.openimagedebugger-vscode)
+[![Open VSX Downloads](https://img.shields.io/open-vsx/dt/openimagedebugger/openimagedebugger-vscode?label=Open%20VSX%20Downloads)](https://open-vsx.org/extension/openimagedebugger/openimagedebugger-vscode)
 
 Open Image Debugger is a tool for visualizing in-memory buffers during debug
 sessions, compatible with both GDB and LLDB. It works out of the box with


### PR DESCRIPTION
Adds download-count badges alongside the existing version badges in the README, one per marketplace:

- **VS Code Marketplace** – `vsmarketplacebadges.dev/downloads-short/...` (same provider as its version badge)
- **Open VSX** – `img.shields.io/open-vsx/dt/...` (`dt` = downloads total, same provider as its version badge)

Each badge links to its respective marketplace page and reads live counts, so it populates automatically once rendered. Version badges are unchanged.