### PR TITLE
docs: tint extension download badges with marketplace brand colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Open Image Debugger: Enabling visualization of in-memory buffers on GDB/LLDB
 
-[![VS Code Marketplace Downloads](https://vsmarketplacebadges.dev/downloads-short/OpenImageDebugger.openimagedebugger-vscode.svg?label=VS%20Code%20Marketplace%20Downloads)](https://marketplace.visualstudio.com/items?itemName=OpenImageDebugger.openimagedebugger-vscode)
-[![Open VSX Downloads](https://img.shields.io/open-vsx/dt/openimagedebugger/openimagedebugger-vscode?label=Open%20VSX%20Downloads)](https://open-vsx.org/extension/openimagedebugger/openimagedebugger-vscode)
+[![VS Code Marketplace Downloads](https://vsmarketplacebadges.dev/downloads-short/OpenImageDebugger.openimagedebugger-vscode.svg?label=VS%20Code%20Marketplace%20Downloads&color=007ACC)](https://marketplace.visualstudio.com/items?itemName=OpenImageDebugger.openimagedebugger-vscode)
+[![Open VSX Downloads](https://img.shields.io/open-vsx/dt/openimagedebugger/openimagedebugger-vscode?label=Open%20VSX%20Downloads&color=a60ee5)](https://open-vsx.org/extension/openimagedebugger/openimagedebugger-vscode)
 
 Open Image Debugger is a tool for visualizing in-memory buffers during debug
 sessions, compatible with both GDB and LLDB. It works out of the box with


### PR DESCRIPTION
Tints the two extension download badges with each marketplace's brand color instead of embedding a logo.

- **VS Code Marketplace** badge → value colored VS Code blue (`#007ACC`).
- **Open VSX** badge → value colored Open VSX purple (`#a60ee5`).
- No logos/base64 — just a `color=` param, so the badge URLs stay short and readable.
- Providers/labels unchanged: VS Code on `vsmarketplacebadges.dev`, Open VSX on `img.shields.io`.