### PR TITLE
ci: add OpenSSF Scorecard supply-chain analysis

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,103 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2015-2026 OpenImageDebugger contributors
+# (https://github.com/OpenImageDebugger/OpenImageDebugger)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: "OpenSSF Scorecard supply-chain security analysis"
+
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '30 5 * * 1'
+  push:
+    branches: [ "main" ]
+  pull_request:
+  # Allow the analysis to be triggered manually from the Actions tab.
+  workflow_dispatch:
+
+# Declare minimal default permissions; the analysis job grants what it needs.
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-26.04
+    # `publish_results: true` only works when run from the default branch.
+    if: github.event.repository.default_branch == github.ref_name
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+      # Needed to check out and scan the repository (a job-level permissions
+      # block replaces the workflow default, so this must be restated here).
+      contents: read
+      # Needed by the Maintained check to read workflow run history.
+      actions: read
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) "write" PAT token. Uncomment the `repo_token` line below to
+          # enable the Branch-Protection check on this public repository. Create the
+          # PAT following the steps in
+          # https://github.com/ossf/scorecard-action?tab=readme-ov-file#authentication-with-fine-grained-pat-optional.
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+          # Publish results to the OpenSSF REST API so the repository can display the
+          # Scorecard badge and be viewed at https://scorecard.dev.
+          # See https://github.com/ossf/scorecard-action#publishing-results.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable
+      # uploads of run results in SARIF format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning
+      # dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # 3.29.5
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![VS Code Marketplace Downloads](https://vsmarketplacebadges.dev/downloads-short/OpenImageDebugger.openimagedebugger-vscode.svg?label=VS%20Code%20Marketplace%20Downloads&color=007ACC)](https://marketplace.visualstudio.com/items?itemName=OpenImageDebugger.openimagedebugger-vscode)
 [![Open VSX Downloads](https://img.shields.io/open-vsx/dt/openimagedebugger/openimagedebugger-vscode?label=Open%20VSX%20Downloads&color=a60ee5)](https://open-vsx.org/extension/openimagedebugger/openimagedebugger-vscode)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/OpenImageDebugger/OpenImageDebugger/badge)](https://scorecard.dev/viewer/?uri=github.com/OpenImageDebugger/OpenImageDebugger)
 
 Open Image Debugger is a tool for visualizing in-memory buffers during debug
 sessions, compatible with both GDB and LLDB. It works out of the box with


### PR DESCRIPTION
## What

Adds an [OpenSSF Scorecard](https://scorecard.dev) workflow that continuously scores the repository's supply-chain security posture, and surfaces the result as a README badge.

## Details

- **`.github/workflows/scorecard.yml`** — runs `ossf/scorecard-action` and publishes results to the OpenSSF API (`publish_results: true`), which makes the repo appear on the [Scorecard viewer](https://scorecard.dev/viewer/?uri=github.com/OpenImageDebugger/OpenImageDebugger) and powers the badge.
  - Triggers: weekly `schedule`, `push` to `main`, `branch_protection_rule` changes, and manual `workflow_dispatch`.
  - Default `permissions: read-all`; only `security-events: write` + `id-token: write` are granted to the job (least privilege).
  - All actions pinned to full commit SHAs with version comments, matching the existing workflow convention.
- **README** — adds the OpenSSF Scorecard badge alongside the marketplace badges.

## Notes

- Results only publish from the default branch, so the badge/viewer populate after this merges and the first `main` run completes.
- The Branch-Protection check is scored via the default `GITHUB_TOKEN`, which can't read full branch-protection settings on public repos. To score it fully, a fine-grained PAT can be added later as the `SCORECARD_TOKEN` secret and the `repo_token` line uncommented (left commented for now).