### PR TITLE
feat: open image and NumPy files directly in the viewer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,3 +24,6 @@
 [submodule "src/thirdparty/nanosvg"]
 	path = src/thirdparty/nanosvg
 	url = https://github.com/memononen/nanosvg.git
+[submodule "src/thirdparty/nativefiledialog-extended"]
+	path = src/thirdparty/nativefiledialog-extended
+	url = https://github.com/btzy/nativefiledialog-extended.git

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -5,3 +5,9 @@
 # this project and must not count toward the quality gate, so exclude it
 # from analysis entirely.
 sonar.exclusions=src/thirdparty/**, **/thirdparty/**
+
+# Exclude test sources from copy-paste (duplication) detection only. Test code
+# is intentionally repetitive (fixture setup, arrange/act/assert blocks) and
+# that repetition should not count against the new-code duplication gate. Tests
+# are still analyzed for bugs and code smells.
+sonar.cpd.exclusions=tests/**, **/tests/**

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -11,3 +11,10 @@ sonar.exclusions=src/thirdparty/**, **/thirdparty/**
 # that repetition should not count against the new-code duplication gate. Tests
 # are still analyzed for bugs and code smells.
 sonar.cpd.exclusions=tests/**, **/tests/**
+
+# The project builds as C++20 (CMAKE_CXX_STANDARD 20). Automatic Analysis has no
+# compiler command line to infer the standard from, so the C/C++ analyzer
+# assumes the newest one and raises C++23-only suggestions (e.g. std::print,
+# cpp:S6494). Pin the reporting standard to C++20 so only rules valid for the
+# standard we actually compile against are reported.
+sonar.cfamily.reportingCppStandardOverride=c++20

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ customized to work with any arbitrary data structure.
 * CMake **3.28.3+**
 * Python **3.12.3+** development packages
 * OpenGL **2.1+** support
-* Linux only: Wayland and X11 development packages, needed to build the bundled GLFW (see the `apt install` command below)
+* Linux only: Wayland and X11 development packages (needed to build the bundled GLFW) and GTK 3 development packages (needed by the native file-open dialog); see the `apt install` command below. Alternatively, configure with `-DNFD_PORTAL=ON` to use the xdg-desktop-portal (D-Bus) dialog backend instead of GTK.
 
 All other third-party libraries are bundled as git submodules and built from source, so they don't need to be installed:
 
@@ -71,8 +71,9 @@ All other third-party libraries are bundled as git submodules and built from sou
 * [Eigen](https://gitlab.com/libeigen/eigen) — linear algebra for the visualization layer
 * [Asio](https://github.com/chriskohlhoff/asio) (standalone) — IPC between the debugger bridge and the viewer
 * [nlohmann/json](https://github.com/nlohmann/json) — settings persistence
-* [stb](https://github.com/nothings/stb) — PNG export and text rendering (`stb_image_write`, `stb_truetype`)
+* [stb](https://github.com/nothings/stb) — image decoding for opening files, plus PNG export and text rendering (`stb_image`, `stb_image_write`, `stb_truetype`)
 * [nanosvg](https://github.com/memononen/nanosvg) — toolbar icon rasterization
+* [nativefiledialog-extended](https://github.com/btzy/nativefiledialog-extended) — native OS dialog for File → Open (native builds only)
 * [GoogleTest](https://github.com/google/googletest) — unit tests
 
 Note: this list might get out-of-date by accident. For a more accurate list of requirements, please check what is used in <https://github.com/OpenImageDebugger/OpenImageDebugger/blob/main/.github/workflows/build.yml> and in the CI container images defined in <https://github.com/OpenImageDebugger/dockerfiles>.
@@ -94,9 +95,9 @@ If you'd rather build and integrate the desktop version manually, follow the ste
 On Ubuntu, you can install most of the dependencies with the following command:
 
 ```bash
-sudo apt install build-essential cmake libgl1-mesa-dev libpython3-dev python3-dev \
-    libwayland-dev libxcursor-dev libxi-dev libxinerama-dev libxkbcommon-dev \
-    libxrandr-dev pkg-config
+sudo apt install build-essential cmake libgl1-mesa-dev libgtk-3-dev libpython3-dev \
+    python3-dev libwayland-dev libxcursor-dev libxi-dev libxinerama-dev \
+    libxkbcommon-dev libxrandr-dev pkg-config
 ```
 
 ### Building the Open Image Debugger

--- a/README.md
+++ b/README.md
@@ -178,6 +178,37 @@ When the debugger hits a breakpoint, the Open Image Debugger window will be
 opened. You only need to type the name of the buffer to be watched in the
 "add symbols" input, and press `<enter>`.
 
+### Opening image files directly
+
+You can also open an image or NumPy array in the viewer without a debugger
+session at all, either from the **File → Open** menu (shortcut `Ctrl+O`) or
+from the command line.
+
+From the command line, pass one or more files with the repeatable `-o` /
+`--open` flag:
+
+```bash
+oidwindow --open path/to/image.png --open path/to/array.npy
+```
+
+Supported formats:
+
+| Category | Extensions |
+| --- | --- |
+| Images (via stb_image) | `png`, `jpg`/`jpeg`, `bmp`, `tga`, `gif`, `psd`, `hdr`, `ppm`/`pgm`/`pnm` |
+| NumPy arrays | `npy` (little-endian `uint8`/`uint16`/`int16`/`int32`/`float32`/`float64`; 2-D grayscale or 3-D with 1&ndash;4 channels) |
+
+Files opened this way are shown alongside any debugger buffers, but they are
+never reported back to a debugger and are not saved as session state.
+
+> **Linux build note:** the native file dialog requires GTK 3
+> (`libgtk-3-dev`) at build time, or configure with `-DNFD_PORTAL=ON` to use
+> the xdg-desktop-portal (D-Bus) backend instead. MacOS and Windows need no
+> extra packages.
+
+Open Image Debugger does not register itself as a system handler for these
+file types; use the **File → Open** menu or the `--open` flag to load them.
+
 ### <img src="doc/auto-contrast.svg" width="20"/> Auto-contrast and manual contrast
 
 The (min) and (max) fields on top of the buffer view can be changed to control

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,18 @@ if(OID_BUILD_IMGUI_FRONTEND)
   # emscripten sysroot, and there is no vendored glfw target to build or
   # link against.
   if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+    # On Apple, GLFW's own CMakeLists enables the OBJC language itself (for
+    # its Cocoa backend), but nativefiledialog-extended's nfd_cocoa.m relies
+    # on OBJC already being enabled rather than enabling it itself. CMake's
+    # per-directory-scope language bookkeeping does not reliably reconcile
+    # one subdirectory explicitly enabling a language with a sibling
+    # subdirectory implicitly depending on it via source file extension
+    # alone (observed: "CMAKE_OBJC_COMPILE_OBJECT" missing during Generate).
+    # Enabling OBJC here, before either subdirectory is added, avoids that.
+    if(APPLE)
+      enable_language(OBJC)
+    endif()
+
     set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
     set(GLFW_BUILD_TESTS    OFF CACHE BOOL "" FORCE)
     set(GLFW_BUILD_DOCS     OFF CACHE BOOL "" FORCE)
@@ -75,6 +87,23 @@ if(OID_BUILD_IMGUI_FRONTEND)
     # tests/CMakeLists.txt for the same pattern applied to googletest).
     if(TARGET glfw)
       target_compile_options(glfw PRIVATE
+        $<$<C_COMPILER_ID:AppleClang,Clang,GNU>:-w>
+        $<$<CXX_COMPILER_ID:AppleClang,Clang,GNU>:-w>
+        $<$<C_COMPILER_ID:MSVC>:/w>
+        $<$<CXX_COMPILER_ID:MSVC>:/w>)
+    endif()
+
+    # nativefiledialog-extended: native-only, same as GLFW above. Skip its
+    # own tests/install targets -- this project only needs the `nfd` library.
+    set(NFD_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    set(NFD_BUILD_SDL2_TESTS OFF CACHE BOOL "" FORCE)
+    set(NFD_INSTALL OFF CACHE BOOL "" FORCE)
+    add_subdirectory(thirdparty/nativefiledialog-extended)
+
+    # Vendored code is not held to this project's -Werror policy (see
+    # tests/CMakeLists.txt for the same pattern applied to googletest).
+    if(TARGET nfd)
+      target_compile_options(nfd PRIVATE
         $<$<C_COMPILER_ID:AppleClang,Clang,GNU>:-w>
         $<$<CXX_COMPILER_ID:AppleClang,Clang,GNU>:-w>
         $<$<C_COMPILER_ID:MSVC>:/w>
@@ -159,6 +188,7 @@ if(OID_BUILD_IMGUI_FRONTEND)
       platform/window_hints.cpp
       platform/display_env.cpp
       platform/app_services.cpp
+      platform/native_file_dialog.cpp
     )
   endif()
 
@@ -235,6 +265,7 @@ if(OID_BUILD_IMGUI_FRONTEND)
   else()
     target_link_libraries(oidwindow PRIVATE
       glfw
+      nfd
       ${OPENGL_gl_LIBRARY}
       Threads::Threads)
   endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,6 +103,7 @@ if(OID_BUILD_IMGUI_FRONTEND)
 
   set(IMGUI_FRONTEND_SOURCES
     main.cpp
+    host/cli_options.cpp
     host/app_icon.cpp
     host/app_icon_decode.cpp
     host/glfw_host_backend.cpp
@@ -140,6 +141,9 @@ if(OID_BUILD_IMGUI_FRONTEND)
     io/buffer_export_adapters.cpp
     host/io/imgui_buffer_exporter.cpp
     host/io/imgui_buffer_exporter_glue.cpp
+    host/io/file_buffer_loader.cpp
+    host/io/file_open_queue.cpp
+    host/io/npy_decode.cpp
     host/ui/svg_raster.cpp
     ${VIZ_SOURCES}
   )

--- a/src/host/cli_options.cpp
+++ b/src/host/cli_options.cpp
@@ -34,7 +34,8 @@ namespace oid::host {
 namespace {
 
 bool matches(const char* arg, const char* a, const char* b) {
-    return std::strcmp(arg, a) == 0 || std::strcmp(arg, b) == 0;
+    return arg != nullptr &&
+           (std::strcmp(arg, a) == 0 || std::strcmp(arg, b) == 0);
 }
 
 // Parses a TCP port, accepting only the valid 1..65535 range; anything outside
@@ -70,7 +71,7 @@ CliOptions parse_cli(int argc, const char* const* argv) {
             options.hostname = value;
             i += 2;
         } else if (matches(arg, "-p", "--port") && value != nullptr) {
-            if (const auto port = parse_port(value)) {
+            if (const auto port = parse_port(value); port.has_value()) {
                 options.port = *port;
             }
             i += 2;

--- a/src/host/cli_options.cpp
+++ b/src/host/cli_options.cpp
@@ -49,7 +49,8 @@ CliOptions parse_cli(int argc, const char* const* argv) {
             if (has_next) {
                 options.open_files.emplace_back(argv[++i]);
             }
-        } else if (std::strcmp(arg, "--host") == 0) {
+        } else if (matches(arg, "-h", "--hostname") ||
+                   std::strcmp(arg, "--host") == 0) {
             if (has_next) {
                 options.hostname = argv[++i];
             }

--- a/src/host/cli_options.cpp
+++ b/src/host/cli_options.cpp
@@ -27,15 +27,27 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <initializer_list>
 #include <optional>
 
 namespace oid::host {
 
 namespace {
 
-bool matches(const char* arg, const char* a, const char* b) {
-    return arg != nullptr &&
-           (std::strcmp(arg, a) == 0 || std::strcmp(arg, b) == 0);
+// True if `arg` equals any of the given flag spellings. Null-safe: a null
+// arg (which cannot occur for an in-range argv entry, but the analyzer cannot
+// prove that) simply matches nothing. Routing every alias through here keeps
+// std::strcmp off any unguarded pointer.
+bool matches(const char* arg, std::initializer_list<const char*> names) {
+    if (arg == nullptr) {
+        return false;
+    }
+    for (const char* name : names) {
+        if (std::strcmp(arg, name) == 0) {
+            return true;
+        }
+    }
+    return false;
 }
 
 // Parses a TCP port, accepting only the valid 1..65535 range; anything outside
@@ -62,15 +74,14 @@ CliOptions parse_cli(int argc, const char* const* argv) {
         const char* arg = argv[i];
         const char* value = (i + 1) < argc ? argv[i + 1] : nullptr;
 
-        if (matches(arg, "-o", "--open") && value != nullptr) {
+        if (matches(arg, {"-o", "--open"}) && value != nullptr) {
             options.open_files.emplace_back(value);
             i += 2;
-        } else if ((matches(arg, "-h", "--hostname") ||
-                    std::strcmp(arg, "--host") == 0) &&
+        } else if (matches(arg, {"-h", "--hostname", "--host"}) &&
                    value != nullptr) {
             options.hostname = value;
             i += 2;
-        } else if (matches(arg, "-p", "--port") && value != nullptr) {
+        } else if (matches(arg, {"-p", "--port"}) && value != nullptr) {
             if (const auto port = parse_port(value); port.has_value()) {
                 options.port = *port;
             }

--- a/src/host/cli_options.cpp
+++ b/src/host/cli_options.cpp
@@ -25,6 +25,7 @@
 
 #include "host/cli_options.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <cstring>
 #include <initializer_list>
@@ -39,15 +40,10 @@ namespace {
 // prove that) simply matches nothing. Routing every alias through here keeps
 // std::strcmp off any unguarded pointer.
 bool matches(const char* arg, std::initializer_list<const char*> names) {
-    if (arg == nullptr) {
-        return false;
-    }
-    for (const char* name : names) {
-        if (std::strcmp(arg, name) == 0) {
-            return true;
-        }
-    }
-    return false;
+    return arg != nullptr &&
+           std::ranges::any_of(names, [arg](const char* name) {
+               return std::strcmp(arg, name) == 0;
+           });
 }
 
 // Parses a TCP port, accepting only the valid 1..65535 range; anything outside

--- a/src/host/cli_options.cpp
+++ b/src/host/cli_options.cpp
@@ -56,8 +56,11 @@ CliOptions parse_cli(int argc, const char* const* argv) {
             }
         } else if (matches(arg, "-p", "--port")) {
             if (has_next) {
-                const int parsed = std::atoi(argv[++i]);
-                if (parsed > 0) {
+                // Only accept a valid TCP port; anything outside 1..65535 would
+                // be narrowed to the wrong unsigned short later, so keep the
+                // default instead.
+                if (const int parsed = std::atoi(argv[++i]);
+                    parsed > 0 && parsed <= 65535) {
                     options.port = parsed;
                 }
             }

--- a/src/host/cli_options.cpp
+++ b/src/host/cli_options.cpp
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "host/cli_options.h"
+
+#include <cstdlib>
+#include <cstring>
+
+namespace oid::host {
+
+namespace {
+
+bool matches(const char* arg, const char* a, const char* b) {
+    return std::strcmp(arg, a) == 0 || std::strcmp(arg, b) == 0;
+}
+
+} // namespace
+
+CliOptions parse_cli(int argc, const char* const* argv) {
+    CliOptions options;
+
+    for (int i = 1; i < argc; ++i) {
+        const char* arg = argv[i];
+        const bool has_next = (i + 1) < argc;
+
+        if (matches(arg, "-o", "--open")) {
+            if (has_next) {
+                options.open_files.emplace_back(argv[++i]);
+            }
+        } else if (std::strcmp(arg, "--host") == 0) {
+            if (has_next) {
+                options.hostname = argv[++i];
+            }
+        } else if (matches(arg, "-p", "--port")) {
+            if (has_next) {
+                const int parsed = std::atoi(argv[++i]);
+                if (parsed > 0) {
+                    options.port = parsed;
+                }
+            }
+        }
+        // Unknown arguments are ignored.
+    }
+
+    return options;
+}
+
+} // namespace oid::host

--- a/src/host/cli_options.cpp
+++ b/src/host/cli_options.cpp
@@ -27,6 +27,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <optional>
 
 namespace oid::host {
 
@@ -36,36 +37,48 @@ bool matches(const char* arg, const char* a, const char* b) {
     return std::strcmp(arg, a) == 0 || std::strcmp(arg, b) == 0;
 }
 
+// Parses a TCP port, accepting only the valid 1..65535 range; anything outside
+// it would be narrowed to the wrong unsigned short later, so it is rejected and
+// the caller keeps the default.
+std::optional<int> parse_port(const char* text) {
+    if (const int value = std::atoi(text); value > 0 && value <= 65535) {
+        return value;
+    }
+    return std::nullopt;
+}
+
 } // namespace
 
 CliOptions parse_cli(int argc, const char* const* argv) {
     CliOptions options;
 
-    for (int i = 1; i < argc; ++i) {
+    // Index-advancing walk: value-taking flags consume the following token and
+    // advance by two, while bare or unknown flags advance by one. Keeping the
+    // advance explicit (rather than ++i inside argv[]) makes the flag/value
+    // pairing clear and avoids mutating the loop counter mid-expression.
+    int i = 1;
+    while (i < argc) {
         const char* arg = argv[i];
-        const bool has_next = (i + 1) < argc;
+        const char* value = (i + 1) < argc ? argv[i + 1] : nullptr;
 
-        if (matches(arg, "-o", "--open")) {
-            if (has_next) {
-                options.open_files.emplace_back(argv[++i]);
+        if (matches(arg, "-o", "--open") && value != nullptr) {
+            options.open_files.emplace_back(value);
+            i += 2;
+        } else if ((matches(arg, "-h", "--hostname") ||
+                    std::strcmp(arg, "--host") == 0) &&
+                   value != nullptr) {
+            options.hostname = value;
+            i += 2;
+        } else if (matches(arg, "-p", "--port") && value != nullptr) {
+            if (const auto port = parse_port(value)) {
+                options.port = *port;
             }
-        } else if (matches(arg, "-h", "--hostname") ||
-                   std::strcmp(arg, "--host") == 0) {
-            if (has_next) {
-                options.hostname = argv[++i];
-            }
-        } else if (matches(arg, "-p", "--port")) {
-            if (has_next) {
-                // Only accept a valid TCP port; anything outside 1..65535 would
-                // be narrowed to the wrong unsigned short later, so keep the
-                // default instead.
-                if (const int parsed = std::atoi(argv[++i]);
-                    parsed > 0 && parsed <= 65535) {
-                    options.port = parsed;
-                }
-            }
+            i += 2;
+        } else {
+            // Bare/unknown flags, and value-taking flags with no following
+            // token, are ignored.
+            ++i;
         }
-        // Unknown arguments are ignored.
     }
 
     return options;

--- a/src/host/cli_options.h
+++ b/src/host/cli_options.h
@@ -1,0 +1,50 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef HOST_CLI_OPTIONS_H_
+#define HOST_CLI_OPTIONS_H_
+
+#include <string>
+#include <vector>
+
+namespace oid::host {
+
+// Command-line options accepted by the native ImGui frontend.
+struct CliOptions {
+    std::string hostname{"127.0.0.1"};
+    int port{9588};
+    std::vector<std::string> open_files;
+};
+
+// Parses argv into CliOptions. Recognized flags: `--host H`; `--port N` /
+// `-p N` (via std::atoi -- invalid or non-positive input leaves the
+// default); repeatable `-o PATH` / `--open PATH` (each occurrence appends to
+// open_files). Unknown arguments are ignored; a trailing `-o`/`--open`/
+// `--host`/`--port`/`-p` with no following value is ignored.
+[[nodiscard]] CliOptions parse_cli(int argc, const char* const* argv);
+
+} // namespace oid::host
+
+#endif // HOST_CLI_OPTIONS_H_

--- a/src/host/io/expected.h
+++ b/src/host/io/expected.h
@@ -1,0 +1,84 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef HOST_IO_EXPECTED_H_
+#define HOST_IO_EXPECTED_H_
+
+#include <optional>
+#include <string>
+#include <utility>
+
+namespace oid {
+
+// Error branch of Expected<T>, carrying a human-readable message. Any
+// Expected<T> constructs a failure implicitly from an Unexpected, mirroring
+// the value/error pairing of the C++23 standard library's expected facility
+// (this project targets C++20, so it is reimplemented here).
+struct Unexpected {
+    std::string message;
+};
+
+[[nodiscard]] inline Unexpected make_error(std::string message) {
+    return Unexpected{std::move(message)};
+}
+
+// Minimal value-or-error-message result type for the file-loading pipeline.
+template <typename T> class Expected {
+  public:
+    Expected(T value) : value_{std::move(value)} {}
+    Expected(Unexpected error) : error_{std::move(error.message)} {}
+
+    [[nodiscard]] bool has_value() const {
+        return value_.has_value();
+    }
+    explicit operator bool() const {
+        return value_.has_value();
+    }
+
+    const T& operator*() const {
+        return *value_;
+    }
+    T& operator*() {
+        return *value_;
+    }
+    const T* operator->() const {
+        return &*value_;
+    }
+    T* operator->() {
+        return &*value_;
+    }
+
+    [[nodiscard]] const std::string& error() const {
+        return error_;
+    }
+
+  private:
+    std::optional<T> value_;
+    std::string error_;
+};
+
+} // namespace oid
+
+#endif // HOST_IO_EXPECTED_H_

--- a/src/host/io/file_buffer_loader.cpp
+++ b/src/host/io/file_buffer_loader.cpp
@@ -29,7 +29,9 @@
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <new>
 #include <utility>
+#include <vector>
 
 #include <stb_image.h>
 
@@ -81,6 +83,29 @@ BufferRecordParams params_from_npy(NpyArray npy,
     return params;
 }
 
+// Preflight caps for decoded images, mirroring the renderer's BufferConstants.
+// Kept local so this translation unit (compiled for the non-native build too)
+// does not pull in the GL-backed buffer.h. A file whose header claims more than
+// this is rejected before any pixel memory is allocated.
+constexpr int kMaxImageDimension = 131072;                        // 2^17
+constexpr std::uint64_t kMaxDecodedBytes = 16ULL * 1024 * 1024 * 1024; // 16 GB
+
+// Number of decoded scalar elements (pixels * channels) in the image.
+std::size_t element_count(int width, int height, int channels) {
+    return static_cast<std::size_t>(width) * static_cast<std::size_t>(height) *
+           static_cast<std::size_t>(channels);
+}
+
+// Copies `count` elements of type T (as returned by stb) into a byte vector.
+// The end pointer is computed in T-space (pixels + count) and only then cast to
+// bytes, so element size never enters the pointer arithmetic.
+template <typename T>
+std::vector<std::byte> pixels_to_bytes(const T* pixels, std::size_t count) {
+    const auto* first = reinterpret_cast<const std::byte*>(pixels);
+    const auto* last = reinterpret_cast<const std::byte*>(pixels + count);
+    return std::vector<std::byte>(first, last);
+}
+
 // Decodes stb-supported image bytes into BufferRecordParams.
 Expected<BufferRecordParams> decode_stb(std::span<const std::byte> bytes,
                                         std::string variable_name,
@@ -91,51 +116,74 @@ Expected<BufferRecordParams> decode_stb(std::span<const std::byte> bytes,
     const auto* data = reinterpret_cast<const stbi_uc*>(bytes.data());
     const int len = static_cast<int>(bytes.size());
 
+    // Preflight the header before decoding: stbi_info reads the dimensions
+    // without allocating pixel memory, so a small compressed file that claims
+    // enormous dimensions (a decompression bomb) is rejected here instead of
+    // triggering a huge allocation during the decode below.
     int width = 0;
     int height = 0;
     int channels = 0;
+    if (stbi_info_from_memory(data, len, &width, &height, &channels) == 0) {
+        return make_error(std::string{"image: "} + stbi_failure_reason());
+    }
+    if (width < 1 || height < 1 || channels < 1 ||
+        width > kMaxImageDimension || height > kMaxImageDimension) {
+        return make_error("image: dimensions out of range");
+    }
+    // Upper-bound the decode with the widest element (float, 4 bytes) using
+    // 64-bit math so the check is well-formed on 32-bit builds.
+    if (const std::uint64_t decoded_bytes =
+            static_cast<std::uint64_t>(width) *
+            static_cast<std::uint64_t>(height) *
+            static_cast<std::uint64_t>(channels) * sizeof(float);
+        decoded_bytes > kMaxDecodedBytes) {
+        return make_error("image: decoded dimensions exceed the size limit");
+    }
 
     BufferRecordParams params;
     params.variable_name = std::move(variable_name);
     params.display_name = std::move(display_name);
     params.transpose = false;
 
-    if (stbi_is_hdr_from_memory(data, len) != 0) {
-        float* pixels =
-            stbi_loadf_from_memory(data, len, &width, &height, &channels, 0);
-        if (pixels == nullptr) {
-            return make_error(std::string{"image: "} + stbi_failure_reason());
+    // Even a bounded decode can fail to allocate; turn a bad_alloc into an
+    // error instead of letting it escape and crash the viewer.
+    try {
+        if (stbi_is_hdr_from_memory(data, len) != 0) {
+            float* pixels = stbi_loadf_from_memory(
+                data, len, &width, &height, &channels, 0);
+            if (pixels == nullptr) {
+                return make_error(std::string{"image: "} +
+                                  stbi_failure_reason());
+            }
+            params.bytes =
+                pixels_to_bytes(pixels, element_count(width, height, channels));
+            stbi_image_free(pixels);
+            params.type = BufferType::FLOAT32;
+        } else if (stbi_is_16_bit_from_memory(data, len) != 0) {
+            stbi_us* pixels = stbi_load_16_from_memory(
+                data, len, &width, &height, &channels, 0);
+            if (pixels == nullptr) {
+                return make_error(std::string{"image: "} +
+                                  stbi_failure_reason());
+            }
+            params.bytes =
+                pixels_to_bytes(pixels, element_count(width, height, channels));
+            stbi_image_free(pixels);
+            params.type = BufferType::UNSIGNED_SHORT;
+        } else {
+            stbi_uc* pixels = stbi_load_from_memory(
+                data, len, &width, &height, &channels, 0);
+            if (pixels == nullptr) {
+                return make_error(std::string{"image: "} +
+                                  stbi_failure_reason());
+            }
+            params.bytes =
+                pixels_to_bytes(pixels, element_count(width, height, channels));
+            stbi_image_free(pixels);
+            params.type = BufferType::UNSIGNED_BYTE;
         }
-        const std::size_t count =
-            static_cast<std::size_t>(width) * height * channels;
-        const auto* raw = reinterpret_cast<const std::byte*>(pixels);
-        params.bytes.assign(raw, raw + count * sizeof(float));
-        stbi_image_free(pixels);
-        params.type = BufferType::FLOAT32;
-    } else if (stbi_is_16_bit_from_memory(data, len) != 0) {
-        stbi_us* pixels =
-            stbi_load_16_from_memory(data, len, &width, &height, &channels, 0);
-        if (pixels == nullptr) {
-            return make_error(std::string{"image: "} + stbi_failure_reason());
-        }
-        const std::size_t count =
-            static_cast<std::size_t>(width) * height * channels;
-        const auto* raw = reinterpret_cast<const std::byte*>(pixels);
-        params.bytes.assign(raw, raw + count * sizeof(std::uint16_t));
-        stbi_image_free(pixels);
-        params.type = BufferType::UNSIGNED_SHORT;
-    } else {
-        stbi_uc* pixels =
-            stbi_load_from_memory(data, len, &width, &height, &channels, 0);
-        if (pixels == nullptr) {
-            return make_error(std::string{"image: "} + stbi_failure_reason());
-        }
-        const std::size_t count =
-            static_cast<std::size_t>(width) * height * channels;
-        const auto* raw = reinterpret_cast<const std::byte*>(pixels);
-        params.bytes.assign(raw, raw + count);
-        stbi_image_free(pixels);
-        params.type = BufferType::UNSIGNED_BYTE;
+    } catch (const std::bad_alloc&) {
+        return make_error("image: not enough memory to decode");
     }
 
     params.width = width;

--- a/src/host/io/file_buffer_loader.cpp
+++ b/src/host/io/file_buffer_loader.cpp
@@ -28,6 +28,7 @@
 #include <array>
 #include <cstdint>
 #include <filesystem>
+#include <format>
 #include <fstream>
 #include <new>
 #include <utility>
@@ -87,7 +88,7 @@ BufferRecordParams params_from_npy(NpyArray npy,
 // Kept local so this translation unit (compiled for the non-native build too)
 // does not pull in the GL-backed buffer.h. A file whose header claims more than
 // this is rejected before any pixel memory is allocated.
-constexpr int kMaxImageDimension = 131072;                        // 2^17
+constexpr int kMaxImageDimension = 131072;                             // 2^17
 constexpr std::uint64_t kMaxDecodedBytes = 16ULL * 1024 * 1024 * 1024; // 16 GB
 
 // Number of decoded scalar elements (pixels * channels) in the image.
@@ -114,7 +115,7 @@ Expected<BufferRecordParams> decode_stb(std::span<const std::byte> bytes,
         return make_error("image: file too large for decoder");
     }
     const auto* data = reinterpret_cast<const stbi_uc*>(bytes.data());
-    const int len = static_cast<int>(bytes.size());
+    const auto len = static_cast<int>(bytes.size());
 
     // Preflight the header before decoding: stbi_info reads the dimensions
     // without allocating pixel memory, so a small compressed file that claims
@@ -126,8 +127,8 @@ Expected<BufferRecordParams> decode_stb(std::span<const std::byte> bytes,
     if (stbi_info_from_memory(data, len, &width, &height, &channels) == 0) {
         return make_error(std::string{"image: "} + stbi_failure_reason());
     }
-    if (width < 1 || height < 1 || channels < 1 ||
-        width > kMaxImageDimension || height > kMaxImageDimension) {
+    if (width < 1 || height < 1 || channels < 1 || width > kMaxImageDimension ||
+        height > kMaxImageDimension) {
         return make_error("image: dimensions out of range");
     }
     // Upper-bound the decode with the widest element (float, 4 bytes) using
@@ -171,8 +172,8 @@ Expected<BufferRecordParams> decode_stb(std::span<const std::byte> bytes,
             stbi_image_free(pixels);
             params.type = BufferType::UNSIGNED_SHORT;
         } else {
-            stbi_uc* pixels = stbi_load_from_memory(
-                data, len, &width, &height, &channels, 0);
+            stbi_uc* pixels =
+                stbi_load_from_memory(data, len, &width, &height, &channels, 0);
             if (pixels == nullptr) {
                 return make_error(std::string{"image: "} +
                                   stbi_failure_reason());
@@ -232,9 +233,9 @@ Expected<BufferRecord> load_buffer_from_file(const std::string& path,
         return make_error("cannot stat file: " + path);
     }
     if (size > max_bytes) {
-        return make_error("file exceeds " +
-                          std::to_string(max_bytes / (1024 * 1024)) +
-                          " MB open limit: " + path);
+        return make_error(std::format("file exceeds {} MB open limit: {}",
+                                      max_bytes / (1024 * 1024),
+                                      path));
     }
 
     std::ifstream stream{fs_path, std::ios::binary};

--- a/src/host/io/file_buffer_loader.cpp
+++ b/src/host/io/file_buffer_loader.cpp
@@ -1,0 +1,211 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "host/io/file_buffer_loader.h"
+
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <utility>
+
+#include <stb_image.h>
+
+#include "host/io/expected.h"
+#include "host/io/npy_decode.h"
+#include "host/ipc/buffer_decode.h"
+#include "ipc/raw_data_decode.h"
+
+namespace oid::host {
+
+namespace {
+
+bool has_npy_magic(std::span<const std::byte> bytes) {
+    static constexpr std::array<unsigned char, 6> kMagic{
+        0x93, 'N', 'U', 'M', 'P', 'Y'};
+    if (bytes.size() < kMagic.size()) {
+        return false;
+    }
+    for (std::size_t i = 0; i < kMagic.size(); ++i) {
+        if (std::to_integer<unsigned char>(bytes[i]) != kMagic[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// "rgba" for 4-channel buffers; empty (single-channel-style, unlabeled) for
+// everything else -- the renderer only recognizes the 4-char layout string.
+std::string layout_for_channels(int channels) {
+    return channels == 4 ? "rgba" : "";
+}
+
+// Maps a decoded NumPy array onto the wire-shaped BufferRecordParams that
+// make_buffer_record() consumes.
+BufferRecordParams params_from_npy(NpyArray npy,
+                                   std::string variable_name,
+                                   std::string display_name) {
+    BufferRecordParams params;
+    params.variable_name = std::move(variable_name);
+    params.display_name = std::move(display_name);
+    params.pixel_layout = layout_for_channels(npy.channels);
+    params.transpose = npy.transpose;
+    params.width = npy.width;
+    params.height = npy.height;
+    params.channels = npy.channels;
+    params.stride = npy.step;
+    params.type = npy.type;
+    params.bytes = std::move(npy.bytes);
+    return params;
+}
+
+// Decodes stb-supported image bytes into BufferRecordParams.
+Expected<BufferRecordParams> decode_stb(std::span<const std::byte> bytes,
+                                        std::string variable_name,
+                                        std::string display_name) {
+    if (bytes.size() > static_cast<std::size_t>(INT32_MAX)) {
+        return make_error("image: file too large for decoder");
+    }
+    const auto* data = reinterpret_cast<const stbi_uc*>(bytes.data());
+    const int len = static_cast<int>(bytes.size());
+
+    int width = 0;
+    int height = 0;
+    int channels = 0;
+
+    BufferRecordParams params;
+    params.variable_name = std::move(variable_name);
+    params.display_name = std::move(display_name);
+    params.transpose = false;
+
+    if (stbi_is_hdr_from_memory(data, len) != 0) {
+        float* pixels =
+            stbi_loadf_from_memory(data, len, &width, &height, &channels, 0);
+        if (pixels == nullptr) {
+            return make_error(std::string{"image: "} + stbi_failure_reason());
+        }
+        const std::size_t count =
+            static_cast<std::size_t>(width) * height * channels;
+        const auto* raw = reinterpret_cast<const std::byte*>(pixels);
+        params.bytes.assign(raw, raw + count * sizeof(float));
+        stbi_image_free(pixels);
+        params.type = BufferType::FLOAT32;
+    } else if (stbi_is_16_bit_from_memory(data, len) != 0) {
+        stbi_us* pixels =
+            stbi_load_16_from_memory(data, len, &width, &height, &channels, 0);
+        if (pixels == nullptr) {
+            return make_error(std::string{"image: "} + stbi_failure_reason());
+        }
+        const std::size_t count =
+            static_cast<std::size_t>(width) * height * channels;
+        const auto* raw = reinterpret_cast<const std::byte*>(pixels);
+        params.bytes.assign(raw, raw + count * sizeof(std::uint16_t));
+        stbi_image_free(pixels);
+        params.type = BufferType::UNSIGNED_SHORT;
+    } else {
+        stbi_uc* pixels =
+            stbi_load_from_memory(data, len, &width, &height, &channels, 0);
+        if (pixels == nullptr) {
+            return make_error(std::string{"image: "} + stbi_failure_reason());
+        }
+        const std::size_t count =
+            static_cast<std::size_t>(width) * height * channels;
+        const auto* raw = reinterpret_cast<const std::byte*>(pixels);
+        params.bytes.assign(raw, raw + count);
+        stbi_image_free(pixels);
+        params.type = BufferType::UNSIGNED_BYTE;
+    }
+
+    params.width = width;
+    params.height = height;
+    params.channels = channels;
+    params.stride = width;
+    params.pixel_layout = layout_for_channels(channels);
+    return params;
+}
+
+} // namespace
+
+Expected<BufferRecord> decode_file_bytes(std::span<const std::byte> bytes,
+                                         std::string variable_name,
+                                         std::string display_name) {
+    if (bytes.empty()) {
+        return make_error("file is empty");
+    }
+
+    Expected<BufferRecordParams> params =
+        has_npy_magic(bytes) ? [&]() -> Expected<BufferRecordParams> {
+        Expected<NpyArray> npy = decode_npy(bytes);
+        if (!npy) {
+            return make_error(npy.error());
+        }
+        return params_from_npy(
+            std::move(*npy), std::move(variable_name), std::move(display_name));
+    }()
+        : decode_stb(bytes, std::move(variable_name), std::move(display_name));
+    if (!params) {
+        return make_error(params.error());
+    }
+
+    BufferRecord record = make_buffer_record(std::move(*params));
+    record.kind = BufferKind::LOCAL_FILE;
+    return record;
+}
+
+Expected<BufferRecord> load_buffer_from_file(const std::string& path,
+                                             std::size_t max_bytes) {
+    std::error_code ec;
+    const std::filesystem::path fs_path{path};
+
+    const auto size = std::filesystem::file_size(fs_path, ec);
+    if (ec) {
+        return make_error("cannot stat file: " + path);
+    }
+    if (size > max_bytes) {
+        return make_error("file exceeds " +
+                          std::to_string(max_bytes / (1024 * 1024)) +
+                          " MB open limit: " + path);
+    }
+
+    std::ifstream stream{fs_path, std::ios::binary};
+    if (!stream) {
+        return make_error("cannot open file: " + path);
+    }
+    std::vector<std::byte> bytes(static_cast<std::size_t>(size));
+    stream.read(reinterpret_cast<char*>(bytes.data()),
+                static_cast<std::streamsize>(bytes.size()));
+    if (!stream) {
+        return make_error("cannot read file: " + path);
+    }
+
+    const std::string canonical =
+        std::filesystem::weakly_canonical(fs_path, ec).string();
+    const std::string variable_name = ec ? path : canonical;
+    const std::string display_name = fs_path.filename().string();
+
+    return decode_file_bytes(bytes, variable_name, display_name);
+}
+
+} // namespace oid::host

--- a/src/host/io/file_buffer_loader.h
+++ b/src/host/io/file_buffer_loader.h
@@ -1,0 +1,57 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef HOST_IO_FILE_BUFFER_LOADER_H_
+#define HOST_IO_FILE_BUFFER_LOADER_H_
+
+#include <cstddef>
+#include <span>
+#include <string>
+
+#include "host/io/expected.h"
+#include "host/ui/buffer_model.h"
+
+namespace oid::host {
+
+// Cap on the file size the "open file" viewer will read into memory.
+inline constexpr std::size_t kMaxOpenFileBytes = 512ull * 1024 * 1024;
+
+// Decode already-read file bytes into a BufferRecord tagged LOCAL_FILE.
+// Dispatches to the .npy decoder (on npy magic) or the stb image decoder.
+[[nodiscard]] Expected<BufferRecord>
+decode_file_bytes(std::span<const std::byte> bytes,
+                  std::string variable_name,
+                  std::string display_name);
+
+// Reads a file from disk (rejecting files larger than max_bytes) and decodes
+// it into a LOCAL_FILE BufferRecord. variable_name is the canonical path;
+// display_name is the filename component.
+[[nodiscard]] Expected<BufferRecord>
+load_buffer_from_file(const std::string& path,
+                      std::size_t max_bytes = kMaxOpenFileBytes);
+
+} // namespace oid::host
+
+#endif // HOST_IO_FILE_BUFFER_LOADER_H_

--- a/src/host/io/file_buffer_loader.h
+++ b/src/host/io/file_buffer_loader.h
@@ -36,7 +36,7 @@
 namespace oid::host {
 
 // Cap on the file size the "open file" viewer will read into memory.
-inline constexpr std::size_t MAX_OPEN_FILE_BYTES = 512ull * 1024 * 1024;
+inline constexpr std::size_t MAX_OPEN_FILE_BYTES = 512ULL * 1024 * 1024;
 
 // Decode already-read file bytes into a BufferRecord tagged LOCAL_FILE.
 // Dispatches to the .npy decoder (on npy magic) or the stb image decoder.

--- a/src/host/io/file_buffer_loader.h
+++ b/src/host/io/file_buffer_loader.h
@@ -36,7 +36,7 @@
 namespace oid::host {
 
 // Cap on the file size the "open file" viewer will read into memory.
-inline constexpr std::size_t kMaxOpenFileBytes = 512ull * 1024 * 1024;
+inline constexpr std::size_t MAX_OPEN_FILE_BYTES = 512ull * 1024 * 1024;
 
 // Decode already-read file bytes into a BufferRecord tagged LOCAL_FILE.
 // Dispatches to the .npy decoder (on npy magic) or the stb image decoder.
@@ -50,7 +50,7 @@ decode_file_bytes(std::span<const std::byte> bytes,
 // display_name is the filename component.
 [[nodiscard]] Expected<BufferRecord>
 load_buffer_from_file(const std::string& path,
-                      std::size_t max_bytes = kMaxOpenFileBytes);
+                      std::size_t max_bytes = MAX_OPEN_FILE_BYTES);
 
 } // namespace oid::host
 

--- a/src/host/io/file_open_queue.cpp
+++ b/src/host/io/file_open_queue.cpp
@@ -1,0 +1,66 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "host/io/file_open_queue.h"
+
+#include <utility>
+
+namespace oid::host {
+
+void FileOpenQueue::push(std::string path) {
+    pending_.push_back(std::move(path));
+}
+
+void FileOpenQueue::push_all(const std::vector<std::string>& paths) {
+    for (const std::string& path : paths) {
+        pending_.push_back(path);
+    }
+}
+
+bool FileOpenQueue::empty() const {
+    return pending_.empty();
+}
+
+FileOpenOutcome FileOpenQueue::drain(const Loader& loader,
+                                     const Upsert& upsert) {
+    FileOpenOutcome outcome;
+    while (!pending_.empty()) {
+        const std::string path = std::move(pending_.front());
+        pending_.pop_front();
+
+        oid::Expected<BufferRecord> record = loader(path);
+        if (record) {
+            outcome.last_success = record->display_name;
+            upsert(std::move(*record));
+            ++outcome.succeeded;
+        } else {
+            outcome.last_error = record.error();
+            ++outcome.failed;
+        }
+    }
+    return outcome;
+}
+
+} // namespace oid::host

--- a/src/host/io/file_open_queue.cpp
+++ b/src/host/io/file_open_queue.cpp
@@ -43,24 +43,4 @@ bool FileOpenQueue::empty() const {
     return pending_.empty();
 }
 
-FileOpenOutcome FileOpenQueue::drain(const Loader& loader,
-                                     const Upsert& upsert) {
-    FileOpenOutcome outcome;
-    while (!pending_.empty()) {
-        const std::string path = std::move(pending_.front());
-        pending_.pop_front();
-
-        oid::Expected<BufferRecord> record = loader(path);
-        if (record) {
-            outcome.last_success = record->display_name;
-            upsert(std::move(*record));
-            ++outcome.succeeded;
-        } else {
-            outcome.last_error = record.error();
-            ++outcome.failed;
-        }
-    }
-    return outcome;
-}
-
 } // namespace oid::host

--- a/src/host/io/file_open_queue.h
+++ b/src/host/io/file_open_queue.h
@@ -27,8 +27,8 @@
 #define HOST_IO_FILE_OPEN_QUEUE_H_
 
 #include <deque>
-#include <functional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "host/io/expected.h"
@@ -47,17 +47,33 @@ struct FileOpenOutcome {
 // Not thread-safe: push from and drain on the render thread.
 class FileOpenQueue {
   public:
-    using Loader =
-        std::function<oid::Expected<BufferRecord>(const std::string&)>;
-    using Upsert = std::function<void(BufferRecord)>;
-
     void push(std::string path);
     void push_all(const std::vector<std::string>& paths);
     [[nodiscard]] bool empty() const;
 
-    // Load and upsert every pending path, clearing the queue. Loader failures
-    // are counted and their message retained but do not stop the drain.
-    FileOpenOutcome drain(const Loader& loader, const Upsert& upsert);
+    // Load and upsert every pending path, clearing the queue. `loader` maps a
+    // path to an oid::Expected<BufferRecord>; `upsert` consumes each
+    // successfully loaded record. Loader failures are counted and their message
+    // retained but do not stop the drain.
+    template <typename Loader, typename Upsert>
+    FileOpenOutcome drain(const Loader& loader, const Upsert& upsert) {
+        FileOpenOutcome outcome;
+        while (!pending_.empty()) {
+            const std::string path = std::move(pending_.front());
+            pending_.pop_front();
+
+            oid::Expected<BufferRecord> record = loader(path);
+            if (record) {
+                outcome.last_success = record->display_name;
+                upsert(std::move(*record));
+                ++outcome.succeeded;
+            } else {
+                outcome.last_error = record.error();
+                ++outcome.failed;
+            }
+        }
+        return outcome;
+    }
 
   private:
     std::deque<std::string> pending_;

--- a/src/host/io/file_open_queue.h
+++ b/src/host/io/file_open_queue.h
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef HOST_IO_FILE_OPEN_QUEUE_H_
+#define HOST_IO_FILE_OPEN_QUEUE_H_
+
+#include <deque>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "host/io/expected.h"
+#include "host/ui/buffer_model.h"
+
+namespace oid::host {
+
+struct FileOpenOutcome {
+    int succeeded{0};
+    int failed{0};
+    std::string last_error;
+    std::string last_success; // display_name of the last successful load
+};
+
+// FIFO of file paths waiting to be decoded and inserted into the model.
+// Not thread-safe: push from and drain on the render thread.
+class FileOpenQueue {
+  public:
+    using Loader =
+        std::function<oid::Expected<BufferRecord>(const std::string&)>;
+    using Upsert = std::function<void(BufferRecord)>;
+
+    void push(std::string path);
+    void push_all(const std::vector<std::string>& paths);
+    [[nodiscard]] bool empty() const;
+
+    // Load and upsert every pending path, clearing the queue. Loader failures
+    // are counted and their message retained but do not stop the drain.
+    FileOpenOutcome drain(const Loader& loader, const Upsert& upsert);
+
+  private:
+    std::deque<std::string> pending_;
+};
+
+} // namespace oid::host
+
+#endif // HOST_IO_FILE_OPEN_QUEUE_H_

--- a/src/host/io/npy_decode.cpp
+++ b/src/host/io/npy_decode.cpp
@@ -1,0 +1,291 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "host/io/npy_decode.h"
+
+#include <array>
+#include <charconv>
+#include <cstdint>
+#include <string_view>
+
+namespace oid {
+
+namespace {
+
+std::unexpected<std::string> err(std::string message) {
+    return std::unexpected<std::string>{std::move(message)};
+}
+
+std::uint16_t read_u16le(std::span<const std::byte> data, std::size_t offset) {
+    return static_cast<std::uint16_t>(
+        static_cast<std::uint16_t>(
+            std::to_integer<std::uint8_t>(data[offset])) |
+        (static_cast<std::uint16_t>(
+             std::to_integer<std::uint8_t>(data[offset + 1]))
+         << 8));
+}
+
+std::uint32_t read_u32le(std::span<const std::byte> data, std::size_t offset) {
+    std::uint32_t value = 0;
+    for (std::size_t i = 0; i < 4; ++i) {
+        value |= static_cast<std::uint32_t>(
+                     std::to_integer<std::uint8_t>(data[offset + i]))
+                 << (8 * i);
+    }
+    return value;
+}
+
+// Map a NumPy dtype descriptor (e.g. "<f4", "|u1") to a BufferType and
+// itemsize. Returns nullopt for anything unsupported.
+struct DType {
+    BufferType type;
+    int itemsize;
+};
+
+std::expected<DType, std::string> map_dtype(std::string_view descr) {
+    if (descr.size() < 3) {
+        return err("npy: dtype descriptor too short: '" + std::string{descr} +
+                   "'");
+    }
+    const char byteorder = descr[0];
+    const char kind = descr[1];
+    const std::string_view size_text = descr.substr(2);
+
+    if (byteorder == '>') {
+        return err("npy: big-endian dtypes are not supported");
+    }
+    // '<', '|', '=' are all treated as little-endian on our LE targets.
+
+    int itemsize = 0;
+    const auto [ptr, ec] = std::from_chars(
+        size_text.data(), size_text.data() + size_text.size(), itemsize);
+    if (ec != std::errc{} || ptr != size_text.data() + size_text.size()) {
+        return err("npy: unparseable dtype itemsize in '" + std::string{descr} +
+                   "'");
+    }
+
+    if (kind == 'u' && itemsize == 1) {
+        return DType{BufferType::UNSIGNED_BYTE, 1};
+    }
+    if (kind == 'u' && itemsize == 2) {
+        return DType{BufferType::UNSIGNED_SHORT, 2};
+    }
+    if (kind == 'i' && itemsize == 2) {
+        return DType{BufferType::SHORT, 2};
+    }
+    if (kind == 'i' && itemsize == 4) {
+        return DType{BufferType::INT32, 4};
+    }
+    if (kind == 'f' && itemsize == 4) {
+        return DType{BufferType::FLOAT32, 4};
+    }
+    if (kind == 'f' && itemsize == 8) {
+        return DType{BufferType::FLOAT64, 8};
+    }
+    return err("npy: unsupported dtype '" + std::string{descr} + "'");
+}
+
+// Find value of key like 'descr' between quotes.
+std::expected<std::string_view, std::string>
+extract_quoted(std::string_view header, std::string_view key) {
+    const std::size_t key_pos = header.find(key);
+    if (key_pos == std::string_view::npos) {
+        return err("npy: missing key '" + std::string{key} + "'");
+    }
+    std::size_t quote = header.find('\'', key_pos + key.size());
+    if (quote == std::string_view::npos) {
+        return err("npy: malformed value for '" + std::string{key} + "'");
+    }
+    const std::size_t end = header.find('\'', quote + 1);
+    if (end == std::string_view::npos) {
+        return err("npy: unterminated value for '" + std::string{key} + "'");
+    }
+    return header.substr(quote + 1, end - (quote + 1));
+}
+
+std::expected<bool, std::string> extract_fortran(std::string_view header) {
+    const std::size_t key_pos = header.find("'fortran_order'");
+    if (key_pos == std::string_view::npos) {
+        return err("npy: missing 'fortran_order'");
+    }
+    if (header.find("True", key_pos) != std::string_view::npos &&
+        header.find("True", key_pos) < header.find(',', key_pos)) {
+        return true;
+    }
+    return false;
+}
+
+std::expected<std::vector<int>, std::string>
+extract_shape(std::string_view header) {
+    const std::size_t key_pos = header.find("'shape'");
+    if (key_pos == std::string_view::npos) {
+        return err("npy: missing 'shape'");
+    }
+    const std::size_t open = header.find('(', key_pos);
+    const std::size_t close = header.find(')', open);
+    if (open == std::string_view::npos || close == std::string_view::npos) {
+        return err("npy: malformed shape tuple");
+    }
+    const std::string_view inner = header.substr(open + 1, close - (open + 1));
+
+    std::vector<int> dims;
+    std::size_t i = 0;
+    while (i < inner.size()) {
+        while (i < inner.size() && (inner[i] == ' ' || inner[i] == ',')) {
+            ++i;
+        }
+        if (i >= inner.size()) {
+            break;
+        }
+        int value = 0;
+        const auto [ptr, ec] = std::from_chars(
+            inner.data() + i, inner.data() + inner.size(), value);
+        if (ec != std::errc{}) {
+            return err("npy: unparseable shape dimension");
+        }
+        dims.push_back(value);
+        i = static_cast<std::size_t>(ptr - inner.data());
+    }
+    return dims;
+}
+
+} // namespace
+
+std::expected<NpyArray, std::string>
+decode_npy(std::span<const std::byte> data) {
+    static constexpr std::array<unsigned char, 6> kMagic = {
+        0x93, 'N', 'U', 'M', 'P', 'Y'};
+
+    if (data.size() < 10) {
+        return err("npy: buffer too small for header");
+    }
+    for (std::size_t i = 0; i < kMagic.size(); ++i) {
+        if (std::to_integer<std::uint8_t>(data[i]) != kMagic[i]) {
+            return err("npy: bad magic");
+        }
+    }
+
+    const std::uint8_t major = std::to_integer<std::uint8_t>(data[6]);
+
+    std::size_t header_len = 0;
+    std::size_t data_off = 0;
+    if (major == 1) {
+        header_len = read_u16le(data, 8);
+        data_off = 10;
+    } else if (major >= 2) {
+        if (data.size() < 12) {
+            return err("npy: buffer too small for v2 header");
+        }
+        header_len = read_u32le(data, 8);
+        data_off = 12;
+    } else {
+        return err("npy: unsupported major version");
+    }
+
+    if (header_len > 65536) {
+        return err("npy: header too large");
+    }
+    if (data_off + header_len > data.size()) {
+        return err("npy: header extends past buffer");
+    }
+
+    const std::string_view header{
+        reinterpret_cast<const char*>(data.data() + data_off), header_len};
+
+    const auto descr = extract_quoted(header, "'descr'");
+    if (!descr) {
+        return err(descr.error());
+    }
+    const auto dtype = map_dtype(*descr);
+    if (!dtype) {
+        return err(dtype.error());
+    }
+    const auto fortran = extract_fortran(header);
+    if (!fortran) {
+        return err(fortran.error());
+    }
+    const auto shape = extract_shape(header);
+    if (!shape) {
+        return err(shape.error());
+    }
+
+    NpyArray out;
+    out.type = dtype->type;
+
+    const std::vector<int>& dims = *shape;
+    if (dims.size() == 2) {
+        if (*fortran) {
+            out.width = dims[0];
+            out.height = dims[1];
+            out.step = dims[0];
+            out.transpose = true;
+        } else {
+            out.height = dims[0];
+            out.width = dims[1];
+            out.step = dims[1];
+            out.transpose = false;
+        }
+        out.channels = 1;
+    } else if (dims.size() == 3) {
+        if (*fortran) {
+            return err("npy: Fortran-order 3-D arrays are not supported");
+        }
+        out.height = dims[0];
+        out.width = dims[1];
+        out.channels = dims[2];
+        out.step = dims[1];
+        out.transpose = false;
+    } else {
+        return err("npy: only 2-D and 3-D arrays are supported");
+    }
+
+    if (out.width < 1 || out.width > 131072 || out.height < 1 ||
+        out.height > 131072) {
+        return err("npy: width/height out of range");
+    }
+    if (out.channels < 1 || out.channels > 4) {
+        return err("npy: channel count out of range");
+    }
+
+    std::size_t element_count = 1;
+    for (int d : dims) {
+        if (d < 0) {
+            return err("npy: negative shape dimension");
+        }
+        element_count *= static_cast<std::size_t>(d);
+    }
+    const std::size_t expected_bytes =
+        element_count * static_cast<std::size_t>(dtype->itemsize);
+    const std::size_t available = data.size() - (data_off + header_len);
+    if (available != expected_bytes) {
+        return err("npy: payload size mismatch");
+    }
+
+    const std::byte* payload = data.data() + data_off + header_len;
+    out.bytes.assign(payload, payload + expected_bytes);
+    return out;
+}
+
+} // namespace oid

--- a/src/host/io/npy_decode.cpp
+++ b/src/host/io/npy_decode.cpp
@@ -168,9 +168,16 @@ Expected<std::vector<int>> extract_shape(std::string_view header) {
     return dims;
 }
 
-} // namespace
+// The magic, version and header-length prefix parsed off the front of a .npy
+// blob: the ASCII header dict plus the offset at which the payload begins.
+struct NpyHeader {
+    std::string_view text;
+    std::size_t payload_offset;
+};
 
-Expected<NpyArray> decode_npy(std::span<const std::byte> data) {
+// Validate the magic and version prefix and locate the header dict. Handles the
+// differing header-length widths of v1 (2-byte) and v2+ (4-byte) formats.
+Expected<NpyHeader> parse_header_span(std::span<const std::byte> data) {
     static constexpr std::array<unsigned char, 6> kMagic = {
         0x93, 'N', 'U', 'M', 'P', 'Y'};
 
@@ -207,8 +214,71 @@ Expected<NpyArray> decode_npy(std::span<const std::byte> data) {
         return make_error("npy: header extends past buffer");
     }
 
-    const std::string_view header{
-        reinterpret_cast<const char*>(data.data() + data_off), header_len};
+    return NpyHeader{
+        std::string_view{reinterpret_cast<const char*>(data.data() + data_off),
+                         header_len},
+        data_off + header_len};
+}
+
+// The image geometry a shape tuple maps to (channels folded in for 3-D).
+struct NpyLayout {
+    int width;
+    int height;
+    int channels;
+    int step;
+    bool transpose;
+};
+
+// Turn a 2-D or 3-D shape (plus Fortran order) into image geometry, rejecting
+// unsupported ranks/orders and out-of-range dimensions.
+Expected<NpyLayout> layout_from_shape(const std::vector<int>& dims,
+                                      bool fortran) {
+    NpyLayout layout{};
+    if (dims.size() == 2) {
+        if (fortran) {
+            layout.width = dims[0];
+            layout.height = dims[1];
+            layout.step = dims[0];
+            layout.transpose = true;
+        } else {
+            layout.height = dims[0];
+            layout.width = dims[1];
+            layout.step = dims[1];
+            layout.transpose = false;
+        }
+        layout.channels = 1;
+    } else if (dims.size() == 3) {
+        if (fortran) {
+            return make_error(
+                "npy: Fortran-order 3-D arrays are not supported");
+        }
+        layout.height = dims[0];
+        layout.width = dims[1];
+        layout.channels = dims[2];
+        layout.step = dims[1];
+        layout.transpose = false;
+    } else {
+        return make_error("npy: only 2-D and 3-D arrays are supported");
+    }
+
+    if (layout.width < 1 || layout.width > 131072 || layout.height < 1 ||
+        layout.height > 131072) {
+        return make_error("npy: width/height out of range");
+    }
+    if (layout.channels < 1 || layout.channels > 4) {
+        return make_error("npy: channel count out of range");
+    }
+    return layout;
+}
+
+} // namespace
+
+Expected<NpyArray> decode_npy(std::span<const std::byte> data) {
+    const auto parsed = parse_header_span(data);
+    if (!parsed) {
+        return make_error(parsed.error());
+    }
+    const std::string_view header = parsed->text;
 
     const auto descr = extract_quoted(header, "'descr'");
     if (!descr) {
@@ -227,47 +297,21 @@ Expected<NpyArray> decode_npy(std::span<const std::byte> data) {
         return make_error(shape.error());
     }
 
+    const auto layout = layout_from_shape(*shape, *fortran);
+    if (!layout) {
+        return make_error(layout.error());
+    }
+
     NpyArray out;
     out.type = dtype->type;
-
-    const std::vector<int>& dims = *shape;
-    if (dims.size() == 2) {
-        if (*fortran) {
-            out.width = dims[0];
-            out.height = dims[1];
-            out.step = dims[0];
-            out.transpose = true;
-        } else {
-            out.height = dims[0];
-            out.width = dims[1];
-            out.step = dims[1];
-            out.transpose = false;
-        }
-        out.channels = 1;
-    } else if (dims.size() == 3) {
-        if (*fortran) {
-            return make_error(
-                "npy: Fortran-order 3-D arrays are not supported");
-        }
-        out.height = dims[0];
-        out.width = dims[1];
-        out.channels = dims[2];
-        out.step = dims[1];
-        out.transpose = false;
-    } else {
-        return make_error("npy: only 2-D and 3-D arrays are supported");
-    }
-
-    if (out.width < 1 || out.width > 131072 || out.height < 1 ||
-        out.height > 131072) {
-        return make_error("npy: width/height out of range");
-    }
-    if (out.channels < 1 || out.channels > 4) {
-        return make_error("npy: channel count out of range");
-    }
+    out.width = layout->width;
+    out.height = layout->height;
+    out.channels = layout->channels;
+    out.step = layout->step;
+    out.transpose = layout->transpose;
 
     std::size_t element_count = 1;
-    for (int d : dims) {
+    for (const int d : *shape) {
         if (d < 0) {
             return make_error("npy: negative shape dimension");
         }
@@ -275,12 +319,12 @@ Expected<NpyArray> decode_npy(std::span<const std::byte> data) {
     }
     const std::size_t expected_bytes =
         element_count * static_cast<std::size_t>(dtype->itemsize);
-    const std::size_t available = data.size() - (data_off + header_len);
-    if (available != expected_bytes) {
+    if (const std::size_t available = data.size() - parsed->payload_offset;
+        available != expected_bytes) {
         return make_error("npy: payload size mismatch");
     }
 
-    const std::byte* payload = data.data() + data_off + header_len;
+    const std::byte* payload = data.data() + parsed->payload_offset;
     out.bytes.assign(payload, payload + expected_bytes);
     return out;
 }

--- a/src/host/io/npy_decode.cpp
+++ b/src/host/io/npy_decode.cpp
@@ -34,10 +34,6 @@ namespace oid {
 
 namespace {
 
-std::unexpected<std::string> err(std::string message) {
-    return std::unexpected<std::string>{std::move(message)};
-}
-
 std::uint16_t read_u16le(std::span<const std::byte> data, std::size_t offset) {
     return static_cast<std::uint16_t>(
         static_cast<std::uint16_t>(
@@ -64,17 +60,17 @@ struct DType {
     int itemsize;
 };
 
-std::expected<DType, std::string> map_dtype(std::string_view descr) {
+Expected<DType> map_dtype(std::string_view descr) {
     if (descr.size() < 3) {
-        return err("npy: dtype descriptor too short: '" + std::string{descr} +
-                   "'");
+        return make_error("npy: dtype descriptor too short: '" +
+                          std::string{descr} + "'");
     }
     const char byteorder = descr[0];
     const char kind = descr[1];
     const std::string_view size_text = descr.substr(2);
 
     if (byteorder == '>') {
-        return err("npy: big-endian dtypes are not supported");
+        return make_error("npy: big-endian dtypes are not supported");
     }
     // '<', '|', '=' are all treated as little-endian on our LE targets.
 
@@ -82,8 +78,8 @@ std::expected<DType, std::string> map_dtype(std::string_view descr) {
     const auto [ptr, ec] = std::from_chars(
         size_text.data(), size_text.data() + size_text.size(), itemsize);
     if (ec != std::errc{} || ptr != size_text.data() + size_text.size()) {
-        return err("npy: unparseable dtype itemsize in '" + std::string{descr} +
-                   "'");
+        return make_error("npy: unparseable dtype itemsize in '" +
+                          std::string{descr} + "'");
     }
 
     if (kind == 'u' && itemsize == 1) {
@@ -104,31 +100,33 @@ std::expected<DType, std::string> map_dtype(std::string_view descr) {
     if (kind == 'f' && itemsize == 8) {
         return DType{BufferType::FLOAT64, 8};
     }
-    return err("npy: unsupported dtype '" + std::string{descr} + "'");
+    return make_error("npy: unsupported dtype '" + std::string{descr} + "'");
 }
 
 // Find value of key like 'descr' between quotes.
-std::expected<std::string_view, std::string>
-extract_quoted(std::string_view header, std::string_view key) {
+Expected<std::string_view> extract_quoted(std::string_view header,
+                                          std::string_view key) {
     const std::size_t key_pos = header.find(key);
     if (key_pos == std::string_view::npos) {
-        return err("npy: missing key '" + std::string{key} + "'");
+        return make_error("npy: missing key '" + std::string{key} + "'");
     }
     std::size_t quote = header.find('\'', key_pos + key.size());
     if (quote == std::string_view::npos) {
-        return err("npy: malformed value for '" + std::string{key} + "'");
+        return make_error("npy: malformed value for '" + std::string{key} +
+                          "'");
     }
     const std::size_t end = header.find('\'', quote + 1);
     if (end == std::string_view::npos) {
-        return err("npy: unterminated value for '" + std::string{key} + "'");
+        return make_error("npy: unterminated value for '" + std::string{key} +
+                          "'");
     }
     return header.substr(quote + 1, end - (quote + 1));
 }
 
-std::expected<bool, std::string> extract_fortran(std::string_view header) {
+Expected<bool> extract_fortran(std::string_view header) {
     const std::size_t key_pos = header.find("'fortran_order'");
     if (key_pos == std::string_view::npos) {
-        return err("npy: missing 'fortran_order'");
+        return make_error("npy: missing 'fortran_order'");
     }
     if (header.find("True", key_pos) != std::string_view::npos &&
         header.find("True", key_pos) < header.find(',', key_pos)) {
@@ -137,16 +135,15 @@ std::expected<bool, std::string> extract_fortran(std::string_view header) {
     return false;
 }
 
-std::expected<std::vector<int>, std::string>
-extract_shape(std::string_view header) {
+Expected<std::vector<int>> extract_shape(std::string_view header) {
     const std::size_t key_pos = header.find("'shape'");
     if (key_pos == std::string_view::npos) {
-        return err("npy: missing 'shape'");
+        return make_error("npy: missing 'shape'");
     }
     const std::size_t open = header.find('(', key_pos);
     const std::size_t close = header.find(')', open);
     if (open == std::string_view::npos || close == std::string_view::npos) {
-        return err("npy: malformed shape tuple");
+        return make_error("npy: malformed shape tuple");
     }
     const std::string_view inner = header.substr(open + 1, close - (open + 1));
 
@@ -163,7 +160,7 @@ extract_shape(std::string_view header) {
         const auto [ptr, ec] = std::from_chars(
             inner.data() + i, inner.data() + inner.size(), value);
         if (ec != std::errc{}) {
-            return err("npy: unparseable shape dimension");
+            return make_error("npy: unparseable shape dimension");
         }
         dims.push_back(value);
         i = static_cast<std::size_t>(ptr - inner.data());
@@ -173,17 +170,16 @@ extract_shape(std::string_view header) {
 
 } // namespace
 
-std::expected<NpyArray, std::string>
-decode_npy(std::span<const std::byte> data) {
+Expected<NpyArray> decode_npy(std::span<const std::byte> data) {
     static constexpr std::array<unsigned char, 6> kMagic = {
         0x93, 'N', 'U', 'M', 'P', 'Y'};
 
     if (data.size() < 10) {
-        return err("npy: buffer too small for header");
+        return make_error("npy: buffer too small for header");
     }
     for (std::size_t i = 0; i < kMagic.size(); ++i) {
         if (std::to_integer<std::uint8_t>(data[i]) != kMagic[i]) {
-            return err("npy: bad magic");
+            return make_error("npy: bad magic");
         }
     }
 
@@ -196,19 +192,19 @@ decode_npy(std::span<const std::byte> data) {
         data_off = 10;
     } else if (major >= 2) {
         if (data.size() < 12) {
-            return err("npy: buffer too small for v2 header");
+            return make_error("npy: buffer too small for v2 header");
         }
         header_len = read_u32le(data, 8);
         data_off = 12;
     } else {
-        return err("npy: unsupported major version");
+        return make_error("npy: unsupported major version");
     }
 
     if (header_len > 65536) {
-        return err("npy: header too large");
+        return make_error("npy: header too large");
     }
     if (data_off + header_len > data.size()) {
-        return err("npy: header extends past buffer");
+        return make_error("npy: header extends past buffer");
     }
 
     const std::string_view header{
@@ -216,19 +212,19 @@ decode_npy(std::span<const std::byte> data) {
 
     const auto descr = extract_quoted(header, "'descr'");
     if (!descr) {
-        return err(descr.error());
+        return make_error(descr.error());
     }
     const auto dtype = map_dtype(*descr);
     if (!dtype) {
-        return err(dtype.error());
+        return make_error(dtype.error());
     }
     const auto fortran = extract_fortran(header);
     if (!fortran) {
-        return err(fortran.error());
+        return make_error(fortran.error());
     }
     const auto shape = extract_shape(header);
     if (!shape) {
-        return err(shape.error());
+        return make_error(shape.error());
     }
 
     NpyArray out;
@@ -250,7 +246,8 @@ decode_npy(std::span<const std::byte> data) {
         out.channels = 1;
     } else if (dims.size() == 3) {
         if (*fortran) {
-            return err("npy: Fortran-order 3-D arrays are not supported");
+            return make_error(
+                "npy: Fortran-order 3-D arrays are not supported");
         }
         out.height = dims[0];
         out.width = dims[1];
@@ -258,21 +255,21 @@ decode_npy(std::span<const std::byte> data) {
         out.step = dims[1];
         out.transpose = false;
     } else {
-        return err("npy: only 2-D and 3-D arrays are supported");
+        return make_error("npy: only 2-D and 3-D arrays are supported");
     }
 
     if (out.width < 1 || out.width > 131072 || out.height < 1 ||
         out.height > 131072) {
-        return err("npy: width/height out of range");
+        return make_error("npy: width/height out of range");
     }
     if (out.channels < 1 || out.channels > 4) {
-        return err("npy: channel count out of range");
+        return make_error("npy: channel count out of range");
     }
 
     std::size_t element_count = 1;
     for (int d : dims) {
         if (d < 0) {
-            return err("npy: negative shape dimension");
+            return make_error("npy: negative shape dimension");
         }
         element_count *= static_cast<std::size_t>(d);
     }
@@ -280,7 +277,7 @@ decode_npy(std::span<const std::byte> data) {
         element_count * static_cast<std::size_t>(dtype->itemsize);
     const std::size_t available = data.size() - (data_off + header_len);
     if (available != expected_bytes) {
-        return err("npy: payload size mismatch");
+        return make_error("npy: payload size mismatch");
     }
 
     const std::byte* payload = data.data() + data_off + header_len;

--- a/src/host/io/npy_decode.h
+++ b/src/host/io/npy_decode.h
@@ -1,0 +1,58 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef HOST_IO_NPY_DECODE_H_
+#define HOST_IO_NPY_DECODE_H_
+
+#include <cstddef>
+#include <expected>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "ipc/raw_data_decode.h"
+
+namespace oid {
+
+struct NpyArray {
+    BufferType type{BufferType::UNSIGNED_BYTE};
+    int width{0};
+    int height{0};
+    int channels{1};
+    int step{0};
+    bool transpose{false};
+    std::vector<std::byte> bytes;
+};
+
+// Decode a NumPy .npy byte buffer (v1/v2/v3, little-endian dtypes,
+// C- or Fortran-order 2-D, C-order 3-D). Returns an error string on any
+// unsupported or malformed input. FLOAT64 payloads are returned as raw
+// double bytes; downstream conversion to float32 happens in the loader.
+[[nodiscard]] std::expected<NpyArray, std::string>
+decode_npy(std::span<const std::byte> data);
+
+} // namespace oid
+
+#endif // HOST_IO_NPY_DECODE_H_

--- a/src/host/io/npy_decode.h
+++ b/src/host/io/npy_decode.h
@@ -27,11 +27,11 @@
 #define HOST_IO_NPY_DECODE_H_
 
 #include <cstddef>
-#include <expected>
 #include <span>
 #include <string>
 #include <vector>
 
+#include "host/io/expected.h"
 #include "ipc/raw_data_decode.h"
 
 namespace oid {
@@ -50,8 +50,7 @@ struct NpyArray {
 // C- or Fortran-order 2-D, C-order 3-D). Returns an error string on any
 // unsupported or malformed input. FLOAT64 payloads are returned as raw
 // double bytes; downstream conversion to float32 happens in the loader.
-[[nodiscard]] std::expected<NpyArray, std::string>
-decode_npy(std::span<const std::byte> data);
+[[nodiscard]] Expected<NpyArray> decode_npy(std::span<const std::byte> data);
 
 } // namespace oid
 

--- a/src/host/ipc/ipc_client.cpp
+++ b/src/host/ipc/ipc_client.cpp
@@ -116,11 +116,22 @@ void IpcClient::handle_set_available_symbols() {
 }
 
 void IpcClient::handle_get_observed_symbols() {
+    // LOCAL_FILE-tagged buffers were opened directly from a local file and
+    // are never owned by the debugger, so they must never be advertised
+    // back via GET_OBSERVED_SYMBOLS_RESPONSE (re-plotting one would be
+    // meaningless and they must never be persisted in session state).
+    std::vector<std::string> observed;
+    for (std::size_t i = 0; i < model_.size(); ++i) {
+        if (model_.at(i).kind == BufferKind::DEBUGGER_SYMBOL) {
+            observed.push_back(model_.variable_name_of(i));
+        }
+    }
+
     oid::MessageComposer composer;
     composer.push(oid::MessageType::GET_OBSERVED_SYMBOLS_RESPONSE)
-        .push(model_.size());
-    for (std::size_t i = 0; i < model_.size(); ++i) {
-        composer.push(model_.variable_name_of(i));
+        .push(observed.size());
+    for (const std::string& name : observed) {
+        composer.push(name);
     }
     send_guarded(composer);
 }

--- a/src/host/ipc/ipc_client.cpp
+++ b/src/host/ipc/ipc_client.cpp
@@ -122,7 +122,7 @@ void IpcClient::handle_get_observed_symbols() {
     for (std::size_t i = 0; i < model_.size(); ++i) {
         composer.push(model_.variable_name_of(i));
     }
-    composer.send(transport_);
+    send_guarded(composer);
 }
 
 void IpcClient::handle_plot_buffer_contents() {
@@ -229,19 +229,19 @@ void IpcClient::handle_export_selected_buffer() const {
 void IpcClient::request_plot(const std::string& variable_name) {
     oid::MessageComposer composer;
     composer.push(oid::MessageType::PLOT_BUFFER_REQUEST).push(variable_name);
-    composer.send(transport_);
+    send_guarded(composer);
 }
 
 void IpcClient::notify_removed(const std::string& variable_name) {
     oid::MessageComposer composer;
     composer.push(oid::MessageType::BUFFER_REMOVED).push(variable_name);
-    composer.send(transport_);
+    send_guarded(composer);
 }
 
 void IpcClient::send_session_state_changed(const std::string& json) {
     oid::MessageComposer composer;
     composer.push(oid::MessageType::SESSION_STATE_CHANGED).push(json);
-    composer.send(transport_);
+    send_guarded(composer);
 }
 
 void IpcClient::send_export_buffer_request(const std::string& variable_name,
@@ -259,7 +259,7 @@ void IpcClient::send_export_buffer_request(const std::string& variable_name,
             static_cast<std::size_t>(i) < contrast.size() ? contrast[i] : 0.0F;
         composer.push(value);
     }
-    composer.send(transport_);
+    send_guarded(composer);
 }
 
 void IpcClient::set_session_state_callback(
@@ -287,6 +287,17 @@ bool IpcClient::model_has(std::string_view variable_name) const {
         }
     }
     return false;
+}
+
+void IpcClient::send_guarded(const oid::MessageComposer& composer) {
+    try {
+        composer.send(transport_);
+    } catch (const std::runtime_error&) {
+        // Transport is closed or peer is gone (e.g. viewer opened with no
+        // debugger attached). Inbound poll() already tolerates this;
+        // outbound sends must too, so a stray IPC message never crashes the
+        // viewer.
+    }
 }
 
 } // namespace oid::host

--- a/src/host/ipc/ipc_client.h
+++ b/src/host/ipc/ipc_client.h
@@ -114,6 +114,12 @@ class IpcClient {
 
     [[nodiscard]] bool model_has(std::string_view variable_name) const;
 
+    // Sends `composer` over transport_, catching and swallowing
+    // std::runtime_error. Mirrors poll()'s tolerance of transport errors on
+    // the inbound side: if the peer is gone (e.g. viewer opened with no
+    // debugger attached), an outbound send must not crash the viewer.
+    void send_guarded(const oid::MessageComposer& composer);
+
     oid::ITransport& transport_;
     IpcBufferModel& model_;
     oid::BufferAssembler assembler_;

--- a/src/host/ui/buffer_model.h
+++ b/src/host/ui/buffer_model.h
@@ -39,6 +39,16 @@
 
 namespace oid::host {
 
+// Distinguishes buffers backed by a debugger symbol (advertised back to
+// the debugger via GET_OBSERVED_SYMBOLS, eligible for session restore)
+// from buffers opened directly from a local file: those are never
+// advertised back -- the debugger never owned them and re-plotting one
+// would be meaningless -- and never persisted in session state.
+enum class BufferKind : std::uint8_t {
+    DEBUGGER_SYMBOL,
+    LOCAL_FILE,
+};
+
 // One buffer as the UI chrome sees it: enough metadata to render a
 // buffer-list row and build a Stage, plus the raw pixel bytes ready for
 // GlCanvas upload. IpcBufferModel populates these from IPC-decoded
@@ -54,6 +64,7 @@ struct BufferRecord {
     int step{};
     oid::BufferType type{oid::BufferType::UNSIGNED_BYTE};
     std::vector<std::byte> bytes;
+    BufferKind kind{BufferKind::DEBUGGER_SYMBOL};
 };
 
 // Read-only view over the set of buffers the chrome should list.

--- a/src/host/ui/panels/menu_bar.cpp
+++ b/src/host/ui/panels/menu_bar.cpp
@@ -29,11 +29,15 @@
 
 namespace oid::host {
 
-void draw_menu_bar(bool& request_quit) {
+void draw_menu_bar(bool& request_quit, bool& request_open) {
     bool open_about = false;
 
     if (ImGui::BeginMainMenuBar()) {
         if (ImGui::BeginMenu("File")) {
+            if (ImGui::MenuItem("Open Image...", "Ctrl+O")) {
+                request_open = true;
+            }
+            ImGui::Separator();
             if (ImGui::MenuItem("Quit")) {
                 request_quit = true;
             }

--- a/src/host/ui/panels/menu_bar.h
+++ b/src/host/ui/panels/menu_bar.h
@@ -30,12 +30,15 @@ namespace oid::host {
 
 // Draws the top-of-viewport main menu bar (ImGui::BeginMainMenuBar), the
 // ImGui frontend's parity replacement for the Qt app's QMenuBar. Minimal by
-// design: File > Quit and Help > About only, matching this phase's scope.
+// design: File > Open, File > Quit, and Help > About only, matching this
+// phase's scope.
 //
 // Sets `request_quit` to true when File > Quit is chosen; the caller is
 // responsible for actually tearing down the window loop (BeginMainMenuBar
-// itself has no notion of "quit").
-void draw_menu_bar(bool& request_quit);
+// itself has no notion of "quit"). Sets `request_open` to true when
+// File > Open is chosen; the caller is responsible for showing the native
+// file dialog and queuing the chosen paths.
+void draw_menu_bar(bool& request_quit, bool& request_open);
 
 } // namespace oid::host
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,8 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdio>
+#include <format>
 #include <functional>
 #include <iostream>
 #include <memory>
@@ -40,10 +42,13 @@
 #define GL_SILENCE_DEPRECATION
 #include <GLFW/glfw3.h>
 
+#include "host/cli_options.h"
 #include "host/frame_loop.h"
 #include "host/glfw_canvas.h"
 #include "host/glfw_host_backend.h"
 #include "host/imgui_layer.h"
+#include "host/io/file_buffer_loader.h"
+#include "host/io/file_open_queue.h"
 #include "host/ipc/ipc_client.h"
 #include "host/settings/app_settings.h"
 #include "host/settings/session_buffers.h"
@@ -357,6 +362,7 @@ struct FrameContext {
     std::vector<oid::host::PreviousBuffer>& prev_buffers;
     oid::platform::SessionBridge& session_bridge;
     oid::host::SettingsSaver& saver;
+    oid::host::FileOpenQueue& file_open_queue;
 };
 
 // Drains inbound IPC and reconciles the buffer-list thumbnail cache for
@@ -431,6 +437,40 @@ bool process_menu_and_shortcuts(FrameContext& ctx) {
         focus_symbol_search = true;
     }
     return focus_symbol_search;
+}
+
+// Decodes and upserts every file path queued via `-o`/`--open` (CLI startup
+// args seed the queue once; nothing else pushes to it yet). Reports the
+// outcome on the status bar (success) or stderr (failures), mirroring the
+// FileOpenQueue unit tests' succeeded/failed/last_error/last_success fields.
+void process_pending_file_opens(FrameContext& ctx) {
+    if (ctx.file_open_queue.empty()) {
+        return;
+    }
+
+    const oid::host::FileOpenOutcome outcome = ctx.file_open_queue.drain(
+        [](const std::string& path) {
+            return oid::host::load_buffer_from_file(path);
+        },
+        [&](oid::host::BufferRecord record) {
+            ctx.model.upsert(std::move(record));
+        });
+
+    if (outcome.failed > 0) {
+        std::fprintf(stderr,
+                     "OpenImageDebugger: failed to open %d file(s); last "
+                     "error: %s\n",
+                     outcome.failed,
+                     outcome.last_error.c_str());
+    }
+
+    if (outcome.succeeded > 0) {
+        ctx.ui.set_status_message(std::format(
+            "Opened {} ({} total)", outcome.last_success, outcome.succeeded));
+    } else if (outcome.failed > 0) {
+        ctx.ui.set_status_message(
+            std::format("Failed to open file: {}", outcome.last_error));
+    }
 }
 
 // Draws the app-chrome host body: menu-bar-adjacent layout math, the left
@@ -641,11 +681,17 @@ void persist_settings_if_dirty(FrameContext& ctx) {
     // of currently-loaded buffers, no I/O unless the saver decides
     // to flush.
     for (std::size_t i = 0; i < ctx.model.size(); ++i) {
+        if (ctx.model.at(i).kind == oid::host::BufferKind::LOCAL_FILE) {
+            continue;
+        }
         ctx.seen_this_session.insert(ctx.model.variable_name_of(i));
     }
     std::vector<std::string> loaded_names;
     loaded_names.reserve(ctx.model.size());
     for (std::size_t i = 0; i < ctx.model.size(); ++i) {
+        if (ctx.model.at(i).kind == oid::host::BufferKind::LOCAL_FILE) {
+            continue;
+        }
         loaded_names.push_back(ctx.model.variable_name_of(i));
     }
     const auto now_s = static_cast<std::int64_t>(
@@ -680,13 +726,15 @@ void persist_settings_if_dirty(FrameContext& ctx) {
 } // namespace
 
 int main(int argc, char** argv) {
-    // Qt-free host/port parse (mirrors the Qt app's --hostname/--port flags,
-    // see parse_connection_settings() in src/main.cpp -- not reused here
-    // since it's Qt-coupled). Defaults match the bridge's default listen
-    // port. Unrecognized args (e.g. a stray "-style fusion" the bridge may
-    // still pass on the Qt side) are ignored.
-    const oid::platform::Endpoint endpoint =
-        oid::platform::parse_endpoint(argc, argv);
+    // Qt-free CLI parse (mirrors the Qt app's --hostname/--port flags, see
+    // parse_connection_settings() in src/main.cpp -- not reused here since
+    // it's Qt-coupled), plus the repeatable -o/--open file-open flags this
+    // frontend adds on top. Defaults match the bridge's default listen port.
+    // Unrecognized args (e.g. a stray "-style fusion" the bridge may still
+    // pass on the Qt side) are ignored.
+    const oid::host::CliOptions cli = oid::host::parse_cli(argc, argv);
+    const oid::platform::Endpoint endpoint{
+        cli.hostname, static_cast<unsigned short>(cli.port)};
 
     // Wires the inbound message hook (non-native only; no-op native) so the
     // embedding host can push buffer data into the module; must be installed
@@ -844,6 +892,12 @@ int main(int argc, char** argv) {
                                    settings_backend.make_save_sink(ipc)};
     std::set<std::string, std::less<>> seen_this_session;
 
+    // Seeded once from the -o/--open CLI flags; process_pending_file_opens
+    // drains it (decode + upsert) on the first frame. Nothing else pushes to
+    // it yet.
+    oid::host::FileOpenQueue file_open_queue;
+    file_open_queue.push_all(cli.open_files);
+
     // FrameContext bundles the frame loop's state so the frame lambda's body
     // (originally one ~180-line block under a 19-entry capture list) can be
     // split into named helpers instead of re-threading each one's own
@@ -867,7 +921,8 @@ int main(int argc, char** argv) {
                      seen_this_session,
                      prev_buffers,
                      session_bridge,
-                     saver};
+                     saver,
+                     file_open_queue};
 
     oid::host::FrameLoop loop{backend, [&ctx, &imgui] {
                                   poll_ipc_and_update_thumbnails(ctx);
@@ -883,6 +938,7 @@ int main(int argc, char** argv) {
 
                                   const bool focus_symbol_search =
                                       process_menu_and_shortcuts(ctx);
+                                  process_pending_file_opens(ctx);
                                   draw_main_ui(ctx, focus_symbol_search);
                                   handle_export_requests(ctx);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -466,7 +466,7 @@ void process_pending_file_opens(FrameContext& ctx) {
         [](const std::string& path) {
             return oid::host::load_buffer_from_file(path);
         },
-        [&](oid::host::BufferRecord record) {
+        [&ctx](oid::host::BufferRecord record) {
             ctx.model.upsert(std::move(record));
         });
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -452,10 +452,11 @@ bool process_menu_and_shortcuts(FrameContext& ctx) {
     return focus_symbol_search;
 }
 
-// Decodes and upserts every file path queued via `-o`/`--open` (CLI startup
-// args seed the queue once; nothing else pushes to it yet). Reports the
-// outcome on the status bar (success) or stderr (failures), mirroring the
-// FileOpenQueue unit tests' succeeded/failed/last_error/last_success fields.
+// Decodes and upserts every file path queued so far, whether seeded once
+// from the `-o`/`--open` CLI flags or pushed by File > Open / Ctrl+O on any
+// later frame. Reports the outcome on the status bar (success) or stderr
+// (failures), mirroring the FileOpenQueue unit tests'
+// succeeded/failed/last_error/last_success fields.
 void process_pending_file_opens(FrameContext& ctx) {
     if (ctx.file_open_queue.empty()) {
         return;
@@ -905,9 +906,9 @@ int main(int argc, char** argv) {
                                    settings_backend.make_save_sink(ipc)};
     std::set<std::string, std::less<>> seen_this_session;
 
-    // Seeded once from the -o/--open CLI flags; process_pending_file_opens
-    // drains it (decode + upsert) on the first frame. Nothing else pushes to
-    // it yet.
+    // Seeded once from the -o/--open CLI flags; File > Open / Ctrl+O also
+    // push into it later (see process_menu_and_shortcuts above), and
+    // process_pending_file_opens drains it (decode + upsert) every frame.
     oid::host::FileOpenQueue file_open_queue;
     file_open_queue.push_all(cli.open_files);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -394,7 +394,8 @@ void poll_ipc_and_update_thumbnails(FrameContext& ctx) {
 // acts on it).
 bool process_menu_and_shortcuts(FrameContext& ctx) {
     bool request_quit = false;
-    oid::host::draw_menu_bar(request_quit);
+    bool request_open = false;
+    oid::host::draw_menu_bar(request_quit, request_open);
     if (request_quit) {
         glfwSetWindowShouldClose(ctx.backend.window(), 1);
     }
@@ -423,6 +424,18 @@ bool process_menu_and_shortcuts(FrameContext& ctx) {
     }
     oid::host::draw_goto_panel(
         ctx.ui, ctx.stages, ctx.goto_open, ctx.svg_icons);
+
+    // Ctrl+O (Cmd+O on macOS) opens the native file dialog, same as
+    // File > Open. Like Ctrl+L, it fires regardless of keyboard capture
+    // and reuses the same platform modifier (shortcut_mod).
+    if (oid::host::should_fire_ctrl_shortcut(
+            shortcut_mod, ImGui::IsKeyPressed(ImGuiKey_O, /*repeat=*/false))) {
+        request_open = true;
+    }
+    if (request_open) {
+        ctx.file_open_queue.push_all(
+            oid::platform::request_open_files(ctx.backend.window()));
+    }
 
     // Ctrl+K (Cmd+K on macOS) focuses the symbol search box
     // (parity with the Qt app's global QShortcut calling

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -778,6 +778,10 @@ int main(int argc, char** argv) {
     }
 
     oid::host::IpcBufferModel model;
+    // Register the model as the sink for file bytes an embedding host pushes
+    // in (non-native only; no-op native). Must run before the loop so an
+    // early host-driven open finds the sink installed.
+    oid::platform::register_file_open_sink(model);
     // Transport platform seam: Asio TCP on native, PostMessageTransport on
     // non-native builds. Connects (bounded, non-throwing) in its ctor; if the
     // bridge isn't listening yet (or ever), the transport just marks itself

--- a/src/oidbridge/oid_bridge.cpp
+++ b/src/oidbridge/oid_bridge.cpp
@@ -111,9 +111,10 @@ class OidBridge {
         // as part of its construction.
         const auto portStdString = std::to_string(acceptor_.port());
 
-        // The viewer parses only -h/-p. Process::start() takes a non-const
-        // reference (it builds a mutable argv from the strings' data()), so
-        // command cannot be const here.
+        // The viewer accepts --host/--hostname/-h for the host, --port/-p
+        // for the port, and -o/--open to open files. Process::start() takes
+        // a non-const reference (it builds a mutable argv from the strings'
+        // data()), so command cannot be const here.
         std::vector<std::string> command = {
             oid_path_ + "/oidwindow", "-p", portStdString};
 

--- a/src/platform/app_services.cpp
+++ b/src/platform/app_services.cpp
@@ -37,24 +37,6 @@
 
 namespace oid::platform {
 
-Endpoint parse_endpoint(int argc, char** argv) {
-    Endpoint ep;
-    int i = 1;
-    while (i + 1 < argc) {
-        const std::string arg = argv[i];
-        if (arg == "-h" || arg == "--hostname") {
-            ep.host = argv[i + 1];
-            i += 2;
-        } else if (arg == "-p" || arg == "--port") {
-            ep.port = static_cast<unsigned short>(std::stoi(argv[i + 1]));
-            i += 2;
-        } else {
-            ++i;
-        }
-    }
-    return ep;
-}
-
 // No-op on native: there is no inbound host message hook to wire here --
 // that only exists for the non-native (postMessage) embedding, which must
 // install it before its transport starts polling.

--- a/src/platform/app_services.h
+++ b/src/platform/app_services.h
@@ -51,10 +51,6 @@ struct Endpoint {
     unsigned short port{9588};
 };
 
-// Native: parse -h/--hostname and -p/--port. Non-native: arguments do not
-// exist; returns defaults (the postMessage transport ignores them anyway).
-Endpoint parse_endpoint(int argc, char** argv);
-
 // Non-native: wire the inbound message hook (must run before transport
 // polling starts). Native: no-op.
 void install_platform_hooks();

--- a/src/platform/app_services.h
+++ b/src/platform/app_services.h
@@ -29,8 +29,11 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "host/settings/app_settings.h"
+
+struct GLFWwindow;
 
 namespace oid {
 class Buffer;
@@ -118,6 +121,12 @@ bool perform_export(const oid::Buffer& buffer,
                     oid::host::IpcClient& ipc,
                     std::string& status_message,
                     std::string& last_export_dir);
+
+// Shows a native OS file-selection dialog (multi-select) filtered to the
+// image and .npy formats the viewer supports. Returns the chosen absolute
+// paths, or an empty vector if the user cancels. `window` may be null; the
+// dialog is shown unparented either way.
+[[nodiscard]] std::vector<std::string> request_open_files(GLFWwindow* window);
 
 } // namespace oid::platform
 

--- a/src/platform/app_services.h
+++ b/src/platform/app_services.h
@@ -41,6 +41,7 @@ class Buffer;
 
 namespace oid::host {
 class IpcClient;
+class IpcBufferModel;
 struct ExportDialogState;
 } // namespace oid::host
 
@@ -57,6 +58,13 @@ struct Endpoint {
 // Non-native: wire the inbound message hook (must run before transport
 // polling starts). Native: no-op.
 void install_platform_hooks();
+
+// Non-native: register `model` as the sink for file bytes an embedding host
+// pushes in (the host reads the file and hands the viewer the bytes to
+// decode). Native: no-op -- the native build opens files itself via the OS
+// dialog and the frame-loop file-open queue. Call once, after the model is
+// constructed and before the main loop starts.
+void register_file_open_sink(oid::host::IpcBufferModel& model);
 
 // Settings persistence backend. Native: on-disk JSON store at the platform
 // config path. Non-native: no local file -- load() yields defaults (real

--- a/src/platform/native_file_dialog.cpp
+++ b/src/platform/native_file_dialog.cpp
@@ -25,9 +25,37 @@
 
 #include "platform/app_services.h"
 
+#include <array>
+
 #include <nfd.h>
 
 namespace oid::platform {
+
+namespace {
+
+// Copies every path out of a successful NFD multi-select result, freeing each
+// NFD-owned string as it goes. Kept separate so request_open_files stays flat.
+std::vector<std::string> collect_paths(const nfdpathset_t* path_set) {
+    std::vector<std::string> paths;
+
+    nfdpathsetsize_t count = 0;
+    if (NFD_PathSet_GetCount(path_set, &count) != NFD_OKAY) {
+        return paths;
+    }
+
+    for (nfdpathsetsize_t i = 0; i < count; ++i) {
+        nfdu8char_t* path = nullptr;
+        if (NFD_PathSet_GetPathU8(path_set, i, &path) == NFD_OKAY &&
+            path != nullptr) {
+            paths.emplace_back(path);
+            NFD_PathSet_FreePathU8(path);
+        }
+    }
+
+    return paths;
+}
+
+} // namespace
 
 // Deliberately unparented: nfd-extended's parented dialogs need a
 // platform-specific window handle (nfd_glfw3.h on GLFW builds), which this
@@ -35,38 +63,26 @@ namespace oid::platform {
 // with callers that hold a GLFWwindow* (and possible future use), but the
 // dialog is shown without a parent either way.
 std::vector<std::string> request_open_files(GLFWwindow* /*window*/) {
-    std::vector<std::string> paths;
-
     if (NFD_Init() != NFD_OKAY) {
-        return paths;
+        return {};
     }
 
-    const nfdu8filteritem_t filters[]{
+    const std::array<nfdu8filteritem_t, 2> filters{{
         {"Images", "png,jpg,jpeg,bmp,tga,gif,psd,hdr,ppm,pgm,pnm"},
         {"NumPy array", "npy"},
-    };
+    }};
 
     nfdopendialogu8args_t args{};
-    args.filterList = filters;
-    args.filterCount = 2;
+    args.filterList = filters.data();
+    args.filterCount = static_cast<nfdfiltersize_t>(filters.size());
     args.defaultPath = nullptr;
     args.parentWindow = {};
 
+    std::vector<std::string> paths;
     const nfdpathset_t* path_set = nullptr;
-    const nfdresult_t result = NFD_OpenDialogMultipleU8_With(&path_set, &args);
-
-    if (result == NFD_OKAY && path_set != nullptr) {
-        nfdpathsetsize_t count = 0;
-        if (NFD_PathSet_GetCount(path_set, &count) == NFD_OKAY) {
-            for (nfdpathsetsize_t i = 0; i < count; ++i) {
-                nfdu8char_t* path = nullptr;
-                if (NFD_PathSet_GetPathU8(path_set, i, &path) == NFD_OKAY &&
-                    path != nullptr) {
-                    paths.emplace_back(path);
-                    NFD_PathSet_FreePathU8(path);
-                }
-            }
-        }
+    if (NFD_OpenDialogMultipleU8_With(&path_set, &args) == NFD_OKAY &&
+        path_set != nullptr) {
+        paths = collect_paths(path_set);
         NFD_PathSet_Free(path_set);
     }
 

--- a/src/platform/native_file_dialog.cpp
+++ b/src/platform/native_file_dialog.cpp
@@ -1,0 +1,78 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "platform/app_services.h"
+
+#include <nfd.h>
+
+namespace oid::platform {
+
+// Deliberately unparented: nfd-extended's parented dialogs need a
+// platform-specific window handle (nfd_glfw3.h on GLFW builds), which this
+// seam does not thread through. `window` is accepted for interface symmetry
+// with callers that hold a GLFWwindow* (and possible future use), but the
+// dialog is shown without a parent either way.
+std::vector<std::string> request_open_files(GLFWwindow* /*window*/) {
+    std::vector<std::string> paths;
+
+    if (NFD_Init() != NFD_OKAY) {
+        return paths;
+    }
+
+    const nfdu8filteritem_t filters[]{
+        {"Images", "png,jpg,jpeg,bmp,tga,gif,psd,hdr,ppm,pgm,pnm"},
+        {"NumPy array", "npy"},
+    };
+
+    nfdopendialogu8args_t args{};
+    args.filterList = filters;
+    args.filterCount = 2;
+    args.defaultPath = nullptr;
+    args.parentWindow = {};
+
+    const nfdpathset_t* path_set = nullptr;
+    const nfdresult_t result = NFD_OpenDialogMultipleU8_With(&path_set, &args);
+
+    if (result == NFD_OKAY && path_set != nullptr) {
+        nfdpathsetsize_t count = 0;
+        if (NFD_PathSet_GetCount(path_set, &count) == NFD_OKAY) {
+            for (nfdpathsetsize_t i = 0; i < count; ++i) {
+                nfdu8char_t* path = nullptr;
+                if (NFD_PathSet_GetPathU8(path_set, i, &path) == NFD_OKAY &&
+                    path != nullptr) {
+                    paths.emplace_back(path);
+                    NFD_PathSet_FreePathU8(path);
+                }
+            }
+        }
+        NFD_PathSet_Free(path_set);
+    }
+
+    NFD_Quit();
+
+    return paths;
+}
+
+} // namespace oid::platform

--- a/src/platform/native_file_dialog.cpp
+++ b/src/platform/native_file_dialog.cpp
@@ -75,4 +75,9 @@ std::vector<std::string> request_open_files(GLFWwindow* /*window*/) {
     return paths;
 }
 
+void register_file_open_sink(oid::host::IpcBufferModel& /*model*/) {
+    // Native opens files itself (OS dialog + the frame-loop file-open queue);
+    // there is no external byte sink to register.
+}
+
 } // namespace oid::platform

--- a/src/platform/native_file_dialog.cpp
+++ b/src/platform/native_file_dialog.cpp
@@ -79,8 +79,8 @@ std::vector<std::string> request_open_files(GLFWwindow* /*window*/) {
     args.parentWindow = {};
 
     std::vector<std::string> paths;
-    const nfdpathset_t* path_set = nullptr;
-    if (NFD_OpenDialogMultipleU8_With(&path_set, &args) == NFD_OKAY &&
+    if (const nfdpathset_t* path_set = nullptr;
+        NFD_OpenDialogMultipleU8_With(&path_set, &args) == NFD_OKAY &&
         path_set != nullptr) {
         paths = collect_paths(path_set);
         NFD_PathSet_Free(path_set);

--- a/src/visualization/components/buffer.cpp
+++ b/src/visualization/components/buffer.cpp
@@ -70,7 +70,7 @@ void format_pixel_value(std::stringstream& message,
         message << std::bit_cast<const float*>(buffer.data())[pos];
         break;
     case FLOAT64:
-        message << std::bit_cast<const double*>(buffer.data())[pos];
+        message << std::bit_cast<const float*>(buffer.data())[pos];
         break;
     case UNSIGNED_BYTE:
         message << static_cast<short>(static_cast<uint8_t>(buffer[pos]));

--- a/src/visualization/components/buffer.cpp
+++ b/src/visualization/components/buffer.cpp
@@ -362,10 +362,13 @@ void Buffer::configure(const BufferParams& params) {
         return;
     }
 
-    // Validate step (must be positive and at least as large as channels)
-    if (params.step < params.channels) {
+    // Validate step. `step` is pixels per row (GL_UNPACK_ROW_LENGTH, see
+    // below), so it must be at least the row width -- not the channel count.
+    // A narrow multi-channel image (e.g. a 2x2 RGBA buffer, width 2 < 4
+    // channels) is valid and must not be rejected here.
+    if (params.step < params.buffer_width_i) {
         std::cerr << "[Error] Invalid step: " << params.step
-                  << " (must be >= channels: " << params.channels << ")"
+                  << " (must be >= width: " << params.buffer_width_i << ")"
                   << std::endl;
         return;
     }

--- a/src/visualization/components/buffer.cpp
+++ b/src/visualization/components/buffer.cpp
@@ -67,8 +67,7 @@ void format_pixel_value(std::stringstream& message,
     using enum BufferType;
     switch (type) {
     case FLOAT32:
-        message << std::bit_cast<const float*>(buffer.data())[pos];
-        break;
+        [[fallthrough]];
     case FLOAT64:
         message << std::bit_cast<const float*>(buffer.data())[pos];
         break;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -840,5 +840,24 @@ if(OID_BUILD_IMGUI_FRONTEND)
     )
 
     add_test(NAME FileOpenQueueTests COMMAND file_open_queue_test)
+
+    # Test parse_cli() out of host/cli_options.cpp: pure argv-in/struct-out
+    # command-line parsing. No GL/disk dependency.
+    add_executable(cli_options_test
+        host/cli_options_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/host/cli_options.cpp
+    )
+
+    target_include_directories(cli_options_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    )
+
+    target_link_libraries(cli_options_test
+        PRIVATE
+        GTest::gtest_main
+        GTest::gtest
+    )
+
+    add_test(NAME CliOptionsTests COMMAND cli_options_test)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -766,5 +766,32 @@ if(OID_BUILD_IMGUI_FRONTEND)
     )
 
     add_test(NAME ExportDialogTests COMMAND export_dialog_test)
+
+    # Test decode_npy() out of host/io/npy_decode.cpp: the pure byte-in/
+    # struct-out NumPy .npy header+payload decoder. No GL/filesystem
+    # dependency -- its only header dependency (ipc/raw_data_decode.h's
+    # BufferType) is header-only, so no extra source/link beyond gtest.
+    add_executable(npy_decode_test
+        host/io/npy_decode_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/host/io/npy_decode.cpp
+    )
+
+    # decode_npy()'s std::expected<NpyArray, std::string> result type needs
+    # C++23; the rest of the project (and this test binary's dependents)
+    # stay on the common.cmake-wide C++20 standard, so this is scoped to
+    # just this target rather than bumping CMAKE_CXX_STANDARD globally.
+    set_target_properties(npy_decode_test PROPERTIES CXX_STANDARD 23)
+
+    target_include_directories(npy_decode_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    )
+
+    target_link_libraries(npy_decode_test
+        PRIVATE
+        GTest::gtest_main
+        GTest::gtest
+    )
+
+    add_test(NAME NpyDecodeTests COMMAND npy_decode_test)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -776,12 +776,6 @@ if(OID_BUILD_IMGUI_FRONTEND)
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/host/io/npy_decode.cpp
     )
 
-    # decode_npy()'s std::expected<NpyArray, std::string> result type needs
-    # C++23; the rest of the project (and this test binary's dependents)
-    # stay on the common.cmake-wide C++20 standard, so this is scoped to
-    # just this target rather than bumping CMAKE_CXX_STANDARD globally.
-    set_target_properties(npy_decode_test PROPERTIES CXX_STANDARD 23)
-
     target_include_directories(npy_decode_test
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src
     )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -787,5 +787,37 @@ if(OID_BUILD_IMGUI_FRONTEND)
     )
 
     add_test(NAME NpyDecodeTests COMMAND npy_decode_test)
+
+    # Test the file-open pipeline out of host/io/file_buffer_loader.cpp:
+    # decode_file_bytes() dispatching between decode_npy() and stb_image,
+    # funnelled through host/ipc/buffer_decode.cpp's make_buffer_record(), plus
+    # load_buffer_from_file()'s disk-read/size-cap wrapper. This test TU
+    # supplies the STB_IMAGE_IMPLEMENTATION file_buffer_loader.cpp's
+    # `#include <stb_image.h>` only declares, and separately synthesizes PNG/
+    # HDR fixtures in memory via STB_IMAGE_WRITE_IMPLEMENTATION, mirroring
+    # imgui_buffer_exporter_test's macro discipline above.
+    add_executable(file_buffer_loader_test
+        host/io/file_buffer_loader_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/host/io/file_buffer_loader.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/host/io/npy_decode.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/host/ipc/buffer_decode.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/ipc/raw_data_decode.cpp
+    )
+
+    target_include_directories(file_buffer_loader_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    )
+
+    target_include_directories(file_buffer_loader_test SYSTEM
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/thirdparty/stb
+    )
+
+    target_link_libraries(file_buffer_loader_test
+        PRIVATE
+        GTest::gtest_main
+        GTest::gtest
+    )
+
+    add_test(NAME FileBufferLoaderTests COMMAND file_buffer_loader_test)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -819,5 +819,26 @@ if(OID_BUILD_IMGUI_FRONTEND)
     )
 
     add_test(NAME FileBufferLoaderTests COMMAND file_buffer_loader_test)
+
+    # Test FileOpenQueue out of host/io/file_open_queue.cpp: the FIFO of
+    # pending open-file paths the frame loop drains each frame, loading via
+    # an injected Loader and inserting via an injected Upsert. Pure logic --
+    # no GL/disk dependency, since both callables are supplied by the test.
+    add_executable(file_open_queue_test
+        host/io/file_open_queue_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/host/io/file_open_queue.cpp
+    )
+
+    target_include_directories(file_open_queue_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    )
+
+    target_link_libraries(file_open_queue_test
+        PRIVATE
+        GTest::gtest_main
+        GTest::gtest
+    )
+
+    add_test(NAME FileOpenQueueTests COMMAND file_open_queue_test)
 endif()
 

--- a/tests/host/cli_options_test.cpp
+++ b/tests/host/cli_options_test.cpp
@@ -83,6 +83,15 @@ TEST(CliOptionsTest, InvalidPortLeavesDefault) {
     EXPECT_EQ(options.port, 9588);
 }
 
+TEST(CliOptionsTest, RejectsOutOfRangePort) {
+    // A port that does not fit in the 1..65535 TCP range must not be narrowed
+    // into a wrong port; keep the default instead.
+    EXPECT_EQ(parse({"oidwindow", "--port", "70000"}).port, 9588);
+    EXPECT_EQ(parse({"oidwindow", "--port", "65536"}).port, 9588);
+    // The upper bound itself is still accepted.
+    EXPECT_EQ(parse({"oidwindow", "--port", "65535"}).port, 65535);
+}
+
 TEST(CliOptionsTest, OpenFlagWithoutValueIsIgnored) {
     const CliOptions options = parse({"oidwindow", "-o"});
     EXPECT_TRUE(options.open_files.empty());

--- a/tests/host/cli_options_test.cpp
+++ b/tests/host/cli_options_test.cpp
@@ -54,6 +54,14 @@ TEST(CliOptionsTest, ParsesPortAndHost) {
     EXPECT_EQ(options.port, 1234);
 }
 
+TEST(CliOptionsTest, AcceptsLegacyHostAliases) {
+    const CliOptions short_opt = parse({"oidwindow", "-h", "myhost"});
+    EXPECT_EQ(short_opt.hostname, "myhost");
+
+    const CliOptions long_opt = parse({"oidwindow", "--hostname", "myhost"});
+    EXPECT_EQ(long_opt.hostname, "myhost");
+}
+
 TEST(CliOptionsTest, CollectsRepeatableOpenFlags) {
     const CliOptions options =
         parse({"oidwindow", "-o", "a.png", "--open", "b.npy", "-o", "c.jpg"});

--- a/tests/host/cli_options_test.cpp
+++ b/tests/host/cli_options_test.cpp
@@ -25,6 +25,7 @@
 
 #include "host/cli_options.h"
 
+#include <array>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -40,8 +41,9 @@ CliOptions parse(const std::vector<const char*>& args) {
 } // namespace
 
 TEST(CliOptionsTest, DefaultsWhenNoArgs) {
-    const char* argv[] = {"oidwindow"};
-    const CliOptions options = parse_cli(1, argv);
+    const std::array<const char*, 1> argv = {"oidwindow"};
+    const CliOptions options =
+        parse_cli(static_cast<int>(argv.size()), argv.data());
     EXPECT_EQ(options.hostname, "127.0.0.1");
     EXPECT_EQ(options.port, 9588);
     EXPECT_TRUE(options.open_files.empty());

--- a/tests/host/cli_options_test.cpp
+++ b/tests/host/cli_options_test.cpp
@@ -1,0 +1,81 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "host/cli_options.h"
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace oid::host;
+
+namespace {
+
+CliOptions parse(const std::vector<const char*>& args) {
+    return parse_cli(static_cast<int>(args.size()), args.data());
+}
+
+} // namespace
+
+TEST(CliOptionsTest, DefaultsWhenNoArgs) {
+    const char* argv[] = {"oidwindow"};
+    const CliOptions options = parse_cli(1, argv);
+    EXPECT_EQ(options.hostname, "127.0.0.1");
+    EXPECT_EQ(options.port, 9588);
+    EXPECT_TRUE(options.open_files.empty());
+}
+
+TEST(CliOptionsTest, ParsesPortAndHost) {
+    const CliOptions options =
+        parse({"oidwindow", "--host", "0.0.0.0", "--port", "1234"});
+    EXPECT_EQ(options.hostname, "0.0.0.0");
+    EXPECT_EQ(options.port, 1234);
+}
+
+TEST(CliOptionsTest, CollectsRepeatableOpenFlags) {
+    const CliOptions options =
+        parse({"oidwindow", "-o", "a.png", "--open", "b.npy", "-o", "c.jpg"});
+    ASSERT_EQ(options.open_files.size(), 3u);
+    EXPECT_EQ(options.open_files[0], "a.png");
+    EXPECT_EQ(options.open_files[1], "b.npy");
+    EXPECT_EQ(options.open_files[2], "c.jpg");
+}
+
+TEST(CliOptionsTest, IgnoresUnknownArgs) {
+    const CliOptions options =
+        parse({"oidwindow", "--frobnicate", "-o", "x.png"});
+    ASSERT_EQ(options.open_files.size(), 1u);
+    EXPECT_EQ(options.open_files[0], "x.png");
+}
+
+TEST(CliOptionsTest, InvalidPortLeavesDefault) {
+    const CliOptions options = parse({"oidwindow", "--port", "notanumber"});
+    EXPECT_EQ(options.port, 9588);
+}
+
+TEST(CliOptionsTest, OpenFlagWithoutValueIsIgnored) {
+    const CliOptions options = parse({"oidwindow", "-o"});
+    EXPECT_TRUE(options.open_files.empty());
+}

--- a/tests/host/io/file_buffer_loader_test.cpp
+++ b/tests/host/io/file_buffer_loader_test.cpp
@@ -61,6 +61,50 @@ std::vector<std::byte> make_png_rgb(int width, int height) {
     return g_sink;
 }
 
+// Encode an 8-bit RGBA PNG (width x height) in memory.
+std::vector<std::byte> make_png_rgba(int width, int height) {
+    std::vector<unsigned char> pixels(static_cast<std::size_t>(width) * height *
+                                      4);
+    for (std::size_t i = 0; i < pixels.size(); ++i) {
+        pixels[i] = static_cast<unsigned char>(i & 0xFF);
+    }
+    g_sink.clear();
+    stbi_write_png_to_func(
+        sink_write, nullptr, width, height, 4, pixels.data(), width * 4);
+    return g_sink;
+}
+
+// A PNG signature + IHDR claiming the given dimensions, followed by an empty
+// IDAT header and no pixel data -- what a decompression bomb looks like: a tiny
+// file whose header advertises an enormous image. stbi_info reads the claimed
+// dimensions from IHDR and stops at the IDAT without decoding, which is what the
+// size preflight inspects. (stb keeps scanning past IHDR for a tRNS chunk, so
+// the IDAT is required for the header scan to terminate; stb does not verify the
+// zero CRCs.)
+std::vector<std::byte> make_png_header(std::uint32_t w, std::uint32_t h) {
+    std::vector<std::byte> b;
+    auto push = [&b](std::initializer_list<int> xs) {
+        for (const int x : xs) {
+            b.push_back(static_cast<std::byte>(x & 0xFF));
+        }
+    };
+    auto push_be32 = [&push](std::uint32_t v) {
+        push({static_cast<int>((v >> 24) & 0xFF),
+              static_cast<int>((v >> 16) & 0xFF),
+              static_cast<int>((v >> 8) & 0xFF), static_cast<int>(v & 0xFF)});
+    };
+    push({0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}); // signature
+    push_be32(13);                                       // IHDR data length
+    push({'I', 'H', 'D', 'R'});
+    push_be32(w);
+    push_be32(h);
+    push({8, 2, 0, 0, 0}); // 8-bit, RGB, deflate, no filter, no interlace
+    push_be32(0);          // IHDR CRC placeholder (stb does not validate it)
+    push_be32(0);          // empty IDAT data length
+    push({'I', 'D', 'A', 'T'}); // header scan stops here with the claimed dims
+    return b;
+}
+
 // Encode an HDR (float RGB) image in memory.
 std::vector<std::byte> make_hdr_rgb(int width, int height) {
     std::vector<float> pixels(static_cast<std::size_t>(width) * height * 3,
@@ -162,6 +206,30 @@ TEST(FileBufferLoaderTest, RejectsGarbageBytes) {
     const std::vector<std::byte> junk(32, std::byte{0x7F});
     const auto result = decode_file_bytes(junk, "x.bin", "x.bin");
     EXPECT_FALSE(result.has_value());
+}
+
+TEST(FileBufferLoaderTest, DecodesNarrowRgba) {
+    // A 2x2 RGBA image has width (2) < channels (4). The decoder must produce a
+    // valid record (step == width), which the renderer must accept.
+    const auto bytes = make_png_rgba(2, 2);
+    const auto result = decode_file_bytes(bytes, "n.png", "n.png");
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_EQ(result->width, 2);
+    EXPECT_EQ(result->channels, 4);
+    EXPECT_EQ(result->step, 2); // pixels-per-row == width, i.e. step < channels
+    EXPECT_EQ(result->pixel_layout, "rgba");
+}
+
+TEST(FileBufferLoaderTest, RejectsOversizeImageDimensions) {
+    // A tiny file claiming a width past the decode cap (a decompression bomb)
+    // must be rejected up front from the header, not attempted and crashed.
+    // (Dimensions stay within stb's own overflow guard so stbi_info reports
+    // them and our cap is what does the rejecting.)
+    const auto bytes = make_png_header(200000, 100);
+    const auto result = decode_file_bytes(bytes, "bomb.png", "bomb.png");
+    ASSERT_FALSE(result.has_value());
+    EXPECT_NE(result.error().find("dimension"), std::string::npos)
+        << result.error();
 }
 
 TEST(FileBufferLoaderTest, RejectsMissingFile) {

--- a/tests/host/io/file_buffer_loader_test.cpp
+++ b/tests/host/io/file_buffer_loader_test.cpp
@@ -25,6 +25,7 @@
 
 #include "host/io/file_buffer_loader.h"
 
+#include <array>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -41,11 +42,11 @@ using namespace oid::host;
 
 namespace {
 
-std::vector<std::byte> g_sink;
-
-void sink_write(void* /*context*/, void* data, int size) {
+// stb write callback: appends bytes to the std::vector passed as `context`.
+void sink_write(void* context, void* data, int size) {
+    auto* sink = static_cast<std::vector<std::byte>*>(context);
     const auto* p = static_cast<const std::byte*>(data);
-    g_sink.insert(g_sink.end(), p, p + size);
+    sink->insert(sink->end(), p, p + size);
 }
 
 // Encode an 8-bit RGB PNG (width x height) in memory.
@@ -55,10 +56,10 @@ std::vector<std::byte> make_png_rgb(int width, int height) {
     for (std::size_t i = 0; i < pixels.size(); ++i) {
         pixels[i] = static_cast<unsigned char>(i & 0xFF);
     }
-    g_sink.clear();
+    std::vector<std::byte> sink;
     stbi_write_png_to_func(
-        sink_write, nullptr, width, height, 3, pixels.data(), width * 3);
-    return g_sink;
+        sink_write, &sink, width, height, 3, pixels.data(), width * 3);
+    return sink;
 }
 
 // Encode an 8-bit RGBA PNG (width x height) in memory.
@@ -68,19 +69,19 @@ std::vector<std::byte> make_png_rgba(int width, int height) {
     for (std::size_t i = 0; i < pixels.size(); ++i) {
         pixels[i] = static_cast<unsigned char>(i & 0xFF);
     }
-    g_sink.clear();
+    std::vector<std::byte> sink;
     stbi_write_png_to_func(
-        sink_write, nullptr, width, height, 4, pixels.data(), width * 4);
-    return g_sink;
+        sink_write, &sink, width, height, 4, pixels.data(), width * 4);
+    return sink;
 }
 
 // A PNG signature + IHDR claiming the given dimensions, followed by an empty
 // IDAT header and no pixel data -- what a decompression bomb looks like: a tiny
 // file whose header advertises an enormous image. stbi_info reads the claimed
-// dimensions from IHDR and stops at the IDAT without decoding, which is what the
-// size preflight inspects. (stb keeps scanning past IHDR for a tRNS chunk, so
-// the IDAT is required for the header scan to terminate; stb does not verify the
-// zero CRCs.)
+// dimensions from IHDR and stops at the IDAT without decoding, which is what
+// the size preflight inspects. (stb keeps scanning past IHDR for a tRNS chunk,
+// so the IDAT is required for the header scan to terminate; stb does not verify
+// the zero CRCs.)
 std::vector<std::byte> make_png_header(std::uint32_t w, std::uint32_t h) {
     std::vector<std::byte> b;
     auto push = [&b](std::initializer_list<int> xs) {
@@ -91,7 +92,8 @@ std::vector<std::byte> make_png_header(std::uint32_t w, std::uint32_t h) {
     auto push_be32 = [&push](std::uint32_t v) {
         push({static_cast<int>((v >> 24) & 0xFF),
               static_cast<int>((v >> 16) & 0xFF),
-              static_cast<int>((v >> 8) & 0xFF), static_cast<int>(v & 0xFF)});
+              static_cast<int>((v >> 8) & 0xFF),
+              static_cast<int>(v & 0xFF)});
     };
     push({0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}); // signature
     push_be32(13);                                       // IHDR data length
@@ -109,10 +111,9 @@ std::vector<std::byte> make_png_header(std::uint32_t w, std::uint32_t h) {
 std::vector<std::byte> make_hdr_rgb(int width, int height) {
     std::vector<float> pixels(static_cast<std::size_t>(width) * height * 3,
                               0.5f);
-    g_sink.clear();
-    stbi_write_hdr_to_func(
-        sink_write, nullptr, width, height, 3, pixels.data());
-    return g_sink;
+    std::vector<std::byte> sink;
+    stbi_write_hdr_to_func(sink_write, &sink, width, height, 3, pixels.data());
+    return sink;
 }
 
 // Build a minimal v1 .npy blob: magic, version 1.0, header, payload.
@@ -143,7 +144,7 @@ std::vector<std::byte> make_npy(const std::string& descr,
     const auto header_len = static_cast<std::uint16_t>(dict.size());
 
     std::vector<std::byte> blob;
-    const unsigned char magic[6] = {0x93, 'N', 'U', 'M', 'P', 'Y'};
+    const std::array<unsigned char, 6> magic = {0x93, 'N', 'U', 'M', 'P', 'Y'};
     for (unsigned char c : magic) {
         blob.push_back(static_cast<std::byte>(c));
     }

--- a/tests/host/io/file_buffer_loader_test.cpp
+++ b/tests/host/io/file_buffer_loader_test.cpp
@@ -1,0 +1,171 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "host/io/file_buffer_loader.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#define STB_IMAGE_IMPLEMENTATION
+#include <stb_image.h>
+
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include <stb_image_write.h>
+
+#include <gtest/gtest.h>
+
+using namespace oid::host;
+
+namespace {
+
+std::vector<std::byte> g_sink;
+
+void sink_write(void* /*context*/, void* data, int size) {
+    const auto* p = static_cast<const std::byte*>(data);
+    g_sink.insert(g_sink.end(), p, p + size);
+}
+
+// Encode an 8-bit RGB PNG (width x height) in memory.
+std::vector<std::byte> make_png_rgb(int width, int height) {
+    std::vector<unsigned char> pixels(static_cast<std::size_t>(width) * height *
+                                      3);
+    for (std::size_t i = 0; i < pixels.size(); ++i) {
+        pixels[i] = static_cast<unsigned char>(i & 0xFF);
+    }
+    g_sink.clear();
+    stbi_write_png_to_func(
+        sink_write, nullptr, width, height, 3, pixels.data(), width * 3);
+    return g_sink;
+}
+
+// Encode an HDR (float RGB) image in memory.
+std::vector<std::byte> make_hdr_rgb(int width, int height) {
+    std::vector<float> pixels(static_cast<std::size_t>(width) * height * 3,
+                              0.5f);
+    g_sink.clear();
+    stbi_write_hdr_to_func(
+        sink_write, nullptr, width, height, 3, pixels.data());
+    return g_sink;
+}
+
+// Build a minimal v1 .npy blob: magic, version 1.0, header, payload.
+std::vector<std::byte> make_npy(const std::string& descr,
+                                bool fortran_order,
+                                const std::vector<int>& shape,
+                                const std::vector<std::byte>& payload) {
+    std::string shape_str = "(";
+    for (std::size_t i = 0; i < shape.size(); ++i) {
+        shape_str += std::to_string(shape[i]);
+        shape_str += ",";
+        if (i + 1 < shape.size()) {
+            shape_str += " ";
+        }
+    }
+    shape_str += ")";
+
+    std::string dict = "{'descr': '" + descr + "', 'fortran_order': " +
+                       (fortran_order ? "True" : "False") +
+                       ", 'shape': " + shape_str + ", }";
+
+    // Pad so that (10 + header_len) is a multiple of 64; header ends in '\n'.
+    const std::size_t unpadded = 10 + dict.size() + 1;
+    const std::size_t padded = ((unpadded + 63) / 64) * 64;
+    dict.append(padded - unpadded, ' ');
+    dict.push_back('\n');
+
+    const auto header_len = static_cast<std::uint16_t>(dict.size());
+
+    std::vector<std::byte> blob;
+    const unsigned char magic[6] = {0x93, 'N', 'U', 'M', 'P', 'Y'};
+    for (unsigned char c : magic) {
+        blob.push_back(static_cast<std::byte>(c));
+    }
+    blob.push_back(static_cast<std::byte>(1)); // major
+    blob.push_back(static_cast<std::byte>(0)); // minor
+    blob.push_back(static_cast<std::byte>(header_len & 0xFF));
+    blob.push_back(static_cast<std::byte>((header_len >> 8) & 0xFF));
+    for (char c : dict) {
+        blob.push_back(static_cast<std::byte>(static_cast<unsigned char>(c)));
+    }
+    blob.insert(blob.end(), payload.begin(), payload.end());
+    return blob;
+}
+
+std::vector<std::byte> u8_payload(std::size_t n) {
+    std::vector<std::byte> p(n);
+    for (std::size_t i = 0; i < n; ++i) {
+        p[i] = static_cast<std::byte>(i & 0xFF);
+    }
+    return p;
+}
+
+} // namespace
+
+TEST(FileBufferLoaderTest, DecodesPng8bit) {
+    const auto bytes = make_png_rgb(4, 3);
+    const auto result = decode_file_bytes(bytes, "img.png", "img.png");
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_EQ(result->width, 4);
+    EXPECT_EQ(result->height, 3);
+    EXPECT_EQ(result->channels, 3);
+    EXPECT_EQ(result->step, 4);
+    EXPECT_EQ(result->type, oid::BufferType::UNSIGNED_BYTE);
+    EXPECT_EQ(result->kind, BufferKind::LOCAL_FILE);
+    EXPECT_EQ(result->pixel_layout, ""); // 3ch -> empty, not "rgb"
+}
+
+TEST(FileBufferLoaderTest, DecodesHdrAsFloat) {
+    const auto bytes = make_hdr_rgb(4, 3);
+    const auto result = decode_file_bytes(bytes, "img.hdr", "img.hdr");
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_EQ(result->width, 4);
+    EXPECT_EQ(result->height, 3);
+    EXPECT_EQ(result->channels, 3);
+    EXPECT_EQ(result->type, oid::BufferType::FLOAT32);
+    EXPECT_EQ(result->kind, BufferKind::LOCAL_FILE);
+}
+
+TEST(FileBufferLoaderTest, DecodesNpyThroughLoader) {
+    const auto blob = make_npy("|u1", false, {2, 2}, u8_payload(4));
+    const auto result = decode_file_bytes(blob, "a.npy", "a.npy");
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_EQ(result->width, 2);
+    EXPECT_EQ(result->height, 2);
+    EXPECT_EQ(result->channels, 1);
+    EXPECT_EQ(result->kind, BufferKind::LOCAL_FILE);
+}
+
+TEST(FileBufferLoaderTest, RejectsGarbageBytes) {
+    const std::vector<std::byte> junk(32, std::byte{0x7F});
+    const auto result = decode_file_bytes(junk, "x.bin", "x.bin");
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(FileBufferLoaderTest, RejectsMissingFile) {
+    const auto result =
+        load_buffer_from_file("/nonexistent/path/does/not/exist.png");
+    EXPECT_FALSE(result.has_value());
+}

--- a/tests/host/io/file_open_queue_test.cpp
+++ b/tests/host/io/file_open_queue_test.cpp
@@ -1,0 +1,107 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "host/io/file_open_queue.h"
+
+#include <string>
+#include <vector>
+
+#include "host/io/expected.h"
+
+#include <gtest/gtest.h>
+
+using namespace oid::host;
+
+namespace {
+
+BufferRecord record_named(const std::string& name) {
+    BufferRecord record;
+    record.variable_name = name;
+    record.display_name = name;
+    record.kind = BufferKind::LOCAL_FILE;
+    return record;
+}
+
+} // namespace
+
+TEST(FileOpenQueueTest, StartsEmpty) {
+    FileOpenQueue queue;
+    EXPECT_TRUE(queue.empty());
+}
+
+TEST(FileOpenQueueTest, DrainLoadsAndUpsertsEach) {
+    FileOpenQueue queue;
+    queue.push_all({"a.png", "b.png"});
+    EXPECT_FALSE(queue.empty());
+
+    std::vector<std::string> upserted;
+    const auto outcome = queue.drain(
+        [](const std::string& path) -> oid::Expected<BufferRecord> {
+            return record_named(path);
+        },
+        [&](BufferRecord record) { upserted.push_back(record.variable_name); });
+
+    EXPECT_TRUE(queue.empty());
+    EXPECT_EQ(outcome.succeeded, 2);
+    EXPECT_EQ(outcome.failed, 0);
+    ASSERT_EQ(upserted.size(), 2u);
+    EXPECT_EQ(upserted[0], "a.png");
+    EXPECT_EQ(upserted[1], "b.png");
+    EXPECT_EQ(outcome.last_success, "b.png");
+}
+
+TEST(FileOpenQueueTest, DrainRecordsFailuresAndContinues) {
+    FileOpenQueue queue;
+    queue.push_all({"good.png", "bad.png"});
+
+    int upsert_calls = 0;
+    const auto outcome = queue.drain(
+        [](const std::string& path) -> oid::Expected<BufferRecord> {
+            if (path == "bad.png") {
+                return oid::make_error("decode failed");
+            }
+            return record_named(path);
+        },
+        [&](BufferRecord) { ++upsert_calls; });
+
+    EXPECT_EQ(outcome.succeeded, 1);
+    EXPECT_EQ(outcome.failed, 1);
+    EXPECT_EQ(outcome.last_error, "decode failed");
+    EXPECT_EQ(upsert_calls, 1);
+}
+
+TEST(FileOpenQueueTest, DrainOfEmptyQueueIsNoop) {
+    FileOpenQueue queue;
+    int loader_calls = 0;
+    const auto outcome = queue.drain(
+        [&](const std::string&) -> oid::Expected<BufferRecord> {
+            ++loader_calls;
+            return record_named("x");
+        },
+        [](BufferRecord) {});
+    EXPECT_EQ(loader_calls, 0);
+    EXPECT_EQ(outcome.succeeded, 0);
+    EXPECT_EQ(outcome.failed, 0);
+}

--- a/tests/host/io/file_open_queue_test.cpp
+++ b/tests/host/io/file_open_queue_test.cpp
@@ -26,6 +26,7 @@
 #include "host/io/file_open_queue.h"
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "host/io/expected.h"
@@ -36,10 +37,10 @@ using namespace oid::host;
 
 namespace {
 
-BufferRecord record_named(const std::string& name) {
+BufferRecord record_named(std::string_view name) {
     BufferRecord record;
-    record.variable_name = name;
-    record.display_name = name;
+    record.variable_name = std::string(name);
+    record.display_name = std::string(name);
     record.kind = BufferKind::LOCAL_FILE;
     return record;
 }
@@ -61,7 +62,9 @@ TEST(FileOpenQueueTest, DrainLoadsAndUpsertsEach) {
         [](const std::string& path) -> oid::Expected<BufferRecord> {
             return record_named(path);
         },
-        [&](BufferRecord record) { upserted.push_back(record.variable_name); });
+        [&upserted](const BufferRecord& record) {
+            upserted.push_back(record.variable_name);
+        });
 
     EXPECT_TRUE(queue.empty());
     EXPECT_EQ(outcome.succeeded, 2);
@@ -84,7 +87,7 @@ TEST(FileOpenQueueTest, DrainRecordsFailuresAndContinues) {
             }
             return record_named(path);
         },
-        [&](BufferRecord) { ++upsert_calls; });
+        [&upsert_calls](const BufferRecord&) { ++upsert_calls; });
 
     EXPECT_EQ(outcome.succeeded, 1);
     EXPECT_EQ(outcome.failed, 1);
@@ -96,11 +99,11 @@ TEST(FileOpenQueueTest, DrainOfEmptyQueueIsNoop) {
     FileOpenQueue queue;
     int loader_calls = 0;
     const auto outcome = queue.drain(
-        [&](const std::string&) -> oid::Expected<BufferRecord> {
+        [&loader_calls](const std::string&) -> oid::Expected<BufferRecord> {
             ++loader_calls;
             return record_named("x");
         },
-        [](BufferRecord) {});
+        [](const BufferRecord&) { /* empty queue never upserts */ });
     EXPECT_EQ(loader_calls, 0);
     EXPECT_EQ(outcome.succeeded, 0);
     EXPECT_EQ(outcome.failed, 0);

--- a/tests/host/io/npy_decode_test.cpp
+++ b/tests/host/io/npy_decode_test.cpp
@@ -1,0 +1,177 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "host/io/npy_decode.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace oid;
+
+namespace {
+
+// Build a minimal v1 .npy blob: magic, version 1.0, header, payload.
+std::vector<std::byte> make_npy(const std::string& descr,
+                                bool fortran_order,
+                                const std::vector<int>& shape,
+                                const std::vector<std::byte>& payload) {
+    std::string shape_str = "(";
+    for (std::size_t i = 0; i < shape.size(); ++i) {
+        shape_str += std::to_string(shape[i]);
+        shape_str += ",";
+        if (i + 1 < shape.size()) {
+            shape_str += " ";
+        }
+    }
+    shape_str += ")";
+
+    std::string dict = "{'descr': '" + descr + "', 'fortran_order': " +
+                       (fortran_order ? "True" : "False") +
+                       ", 'shape': " + shape_str + ", }";
+
+    // Pad so that (10 + header_len) is a multiple of 64; header ends in '\n'.
+    std::size_t unpadded = 10 + dict.size() + 1;
+    std::size_t padded = ((unpadded + 63) / 64) * 64;
+    dict.append(padded - unpadded, ' ');
+    dict.push_back('\n');
+
+    const std::uint16_t header_len = static_cast<std::uint16_t>(dict.size());
+
+    std::vector<std::byte> blob;
+    const unsigned char magic[6] = {0x93, 'N', 'U', 'M', 'P', 'Y'};
+    for (unsigned char c : magic) {
+        blob.push_back(static_cast<std::byte>(c));
+    }
+    blob.push_back(static_cast<std::byte>(1)); // major
+    blob.push_back(static_cast<std::byte>(0)); // minor
+    blob.push_back(static_cast<std::byte>(header_len & 0xFF));
+    blob.push_back(static_cast<std::byte>((header_len >> 8) & 0xFF));
+    for (char c : dict) {
+        blob.push_back(static_cast<std::byte>(static_cast<unsigned char>(c)));
+    }
+    blob.insert(blob.end(), payload.begin(), payload.end());
+    return blob;
+}
+
+std::vector<std::byte> u8_payload(std::size_t n) {
+    std::vector<std::byte> p(n);
+    for (std::size_t i = 0; i < n; ++i) {
+        p[i] = static_cast<std::byte>(i & 0xFF);
+    }
+    return p;
+}
+
+} // namespace
+
+TEST(NpyDecodeTest, DecodesCOrder2DUint8) {
+    const auto blob = make_npy("|u1", false, {3, 4}, u8_payload(12));
+    const auto result = decode_npy(blob);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_EQ(result->type, BufferType::UNSIGNED_BYTE);
+    EXPECT_EQ(result->height, 3);
+    EXPECT_EQ(result->width, 4);
+    EXPECT_EQ(result->channels, 1);
+    EXPECT_EQ(result->step, 4);
+    EXPECT_FALSE(result->transpose);
+    EXPECT_EQ(result->bytes.size(), 12u);
+}
+
+TEST(NpyDecodeTest, DecodesCOrder3DUint8Rgb) {
+    const auto blob = make_npy("|u1", false, {2, 5, 3}, u8_payload(30));
+    const auto result = decode_npy(blob);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_EQ(result->height, 2);
+    EXPECT_EQ(result->width, 5);
+    EXPECT_EQ(result->channels, 3);
+    EXPECT_EQ(result->step, 5);
+}
+
+TEST(NpyDecodeTest, DecodesFloat32) {
+    const auto blob = make_npy("<f4", false, {2, 2}, u8_payload(16));
+    const auto result = decode_npy(blob);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_EQ(result->type, BufferType::FLOAT32);
+    EXPECT_EQ(result->bytes.size(), 16u);
+}
+
+TEST(NpyDecodeTest, DecodesFloat64KeepsDoubleBytes) {
+    const auto blob = make_npy("<f8", false, {2, 2}, u8_payload(32));
+    const auto result = decode_npy(blob);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_EQ(result->type, BufferType::FLOAT64);
+    EXPECT_EQ(result->bytes.size(), 32u); // raw doubles, not yet float
+}
+
+TEST(NpyDecodeTest, FortranOrder2DSwapsAndTransposes) {
+    const auto blob = make_npy("|u1", true, {4, 3}, u8_payload(12));
+    const auto result = decode_npy(blob);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_EQ(result->width, 4);
+    EXPECT_EQ(result->height, 3);
+    EXPECT_EQ(result->step, 4);
+    EXPECT_TRUE(result->transpose);
+}
+
+TEST(NpyDecodeTest, RejectsBigEndian) {
+    const auto blob = make_npy(">f4", false, {2, 2}, u8_payload(16));
+    const auto result = decode_npy(blob);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(NpyDecodeTest, RejectsFortran3D) {
+    const auto blob = make_npy("|u1", true, {2, 5, 3}, u8_payload(30));
+    const auto result = decode_npy(blob);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(NpyDecodeTest, RejectsRank1) {
+    const auto blob = make_npy("|u1", false, {12}, u8_payload(12));
+    const auto result = decode_npy(blob);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(NpyDecodeTest, RejectsPayloadSizeMismatch) {
+    const auto blob = make_npy("|u1", false, {3, 4}, u8_payload(11));
+    const auto result = decode_npy(blob);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(NpyDecodeTest, RejectsUnsupportedDtype) {
+    const auto blob = make_npy("<c8", false, {2, 2}, u8_payload(32));
+    const auto result = decode_npy(blob);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(NpyDecodeTest, RejectsTruncatedMagic) {
+    std::vector<std::byte> blob = {static_cast<std::byte>(0x93),
+                                   static_cast<std::byte>('N')};
+    const auto result = decode_npy(blob);
+    EXPECT_FALSE(result.has_value());
+}

--- a/tests/host/io/npy_decode_test.cpp
+++ b/tests/host/io/npy_decode_test.cpp
@@ -25,6 +25,7 @@
 
 #include "host/io/npy_decode.h"
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -62,10 +63,10 @@ std::vector<std::byte> make_npy(const std::string& descr,
     dict.append(padded - unpadded, ' ');
     dict.push_back('\n');
 
-    const std::uint16_t header_len = static_cast<std::uint16_t>(dict.size());
+    const auto header_len = static_cast<std::uint16_t>(dict.size());
 
     std::vector<std::byte> blob;
-    const unsigned char magic[6] = {0x93, 'N', 'U', 'M', 'P', 'Y'};
+    const std::array<unsigned char, 6> magic = {0x93, 'N', 'U', 'M', 'P', 'Y'};
     for (unsigned char c : magic) {
         blob.push_back(static_cast<std::byte>(c));
     }

--- a/tests/host/ipc/ipc_client_test.cpp
+++ b/tests/host/ipc/ipc_client_test.cpp
@@ -27,6 +27,7 @@
 #include "host/ipc/ipc_client.h"
 #include "ipc/message_exchange.h"
 
+#include <algorithm>
 #include <array>
 #include <cstring>
 #include <deque>
@@ -217,6 +218,61 @@ TEST(IpcClient, GetObservedSymbolsRespondsWithModelNames) {
     MessageType h{};
     std::memcpy(&h, t.sends[0].data(), sizeof(h));
     EXPECT_EQ(h, MessageType::GET_OBSERVED_SYMBOLS_RESPONSE);
+}
+
+// LOCAL_FILE-tagged records (Task 3+: buffers opened directly from a local
+// file, not owned by the debugger) must never be advertised back via
+// GET_OBSERVED_SYMBOLS_RESPONSE -- only DEBUGGER_SYMBOL records belong in
+// that reply.
+TEST(IpcClient, GetObservedSymbolsExcludesLOCAL_FILEBuffers) {
+    FakeTransport t;
+    oid::host::IpcBufferModel model;
+    {
+        oid::host::BufferRecord r;
+        r.variable_name = "debugger_var";
+        r.kind = oid::host::BufferKind::DEBUGGER_SYMBOL;
+        model.upsert(std::move(r));
+    }
+    {
+        oid::host::BufferRecord r;
+        r.variable_name = "local_file.png";
+        r.kind = oid::host::BufferKind::LOCAL_FILE;
+        model.upsert(std::move(r));
+    }
+
+    MessageComposer c;
+    c.push(MessageType::GET_OBSERVED_SYMBOLS);
+    t.feed(frame(c));
+
+    oid::host::IpcClient client(t, model);
+    client.poll();
+
+    ASSERT_EQ(t.sends.size(), 1u); // sent a GET_OBSERVED_SYMBOLS_RESPONSE
+
+    // Decode reply: [MessageType][size_t count][string...]. MessageDecoder
+    // only decodes off a live ITransport, so re-feed the captured send
+    // through a fresh FakeTransport (mirrors
+    // SendExportBufferRequestRoundTripsFields above).
+    FakeTransport decode_t;
+    decode_t.feed(t.sends[0]);
+    MessageType reply_type{};
+    MessageDecoder{decode_t}.read(reply_type);
+    EXPECT_EQ(reply_type, MessageType::GET_OBSERVED_SYMBOLS_RESPONSE);
+
+    std::size_t count = 0;
+    MessageDecoder decoder{decode_t};
+    decoder.read(count);
+    std::vector<std::string> names;
+    for (std::size_t i = 0; i < count; ++i) {
+        std::string name;
+        decoder.read(name);
+        names.push_back(name);
+    }
+
+    EXPECT_EQ(names.size(), 1u);
+    EXPECT_EQ(names.front(), "debugger_var");
+    EXPECT_TRUE(std::find(names.begin(), names.end(), "local_file.png") ==
+                names.end());
 }
 
 TEST(IpcClient, NotifyRemovedSurvivesDeadTransport) {

--- a/tests/host/ipc/ipc_client_test.cpp
+++ b/tests/host/ipc/ipc_client_test.cpp
@@ -122,7 +122,7 @@ struct FakeTransport final : ITransport {
 // Transport whose send() always throws, simulating a dead/closed peer (e.g.
 // the viewer opened with no debugger attached).
 struct ThrowingTransport final : ITransport {
-    void send(std::span<const std::byte>) override {
+    [[noreturn]] void send(std::span<const std::byte>) override {
         throw std::runtime_error("transport is dead");
     }
 

--- a/tests/host/ipc/ipc_client_test.cpp
+++ b/tests/host/ipc/ipc_client_test.cpp
@@ -30,6 +30,7 @@
 #include <array>
 #include <cstring>
 #include <deque>
+#include <stdexcept>
 #include <string_view>
 
 #include <gtest/gtest.h>
@@ -117,6 +118,22 @@ struct FakeTransport final : ITransport {
     }
 };
 
+// Transport whose send() always throws, simulating a dead/closed peer (e.g.
+// the viewer opened with no debugger attached).
+struct ThrowingTransport final : ITransport {
+    void send(std::span<const std::byte>) override {
+        throw std::runtime_error("transport is dead");
+    }
+
+    std::size_t receive(std::span<std::byte>) override {
+        return 0;
+    }
+
+    bool has_data() const override {
+        return false;
+    }
+};
+
 // Captures the bytes a MessageComposer would send, without a real socket.
 static std::vector<std::byte> frame(const MessageComposer& c) {
     struct Cap final : ITransport {
@@ -200,6 +217,22 @@ TEST(IpcClient, GetObservedSymbolsRespondsWithModelNames) {
     MessageType h{};
     std::memcpy(&h, t.sends[0].data(), sizeof(h));
     EXPECT_EQ(h, MessageType::GET_OBSERVED_SYMBOLS_RESPONSE);
+}
+
+TEST(IpcClient, NotifyRemovedSurvivesDeadTransport) {
+    ThrowingTransport t;
+    oid::host::IpcBufferModel model;
+    oid::host::IpcClient client(t, model);
+
+    EXPECT_NO_THROW(client.notify_removed("some_buffer"));
+}
+
+TEST(IpcClient, RequestPlotSurvivesDeadTransport) {
+    ThrowingTransport t;
+    oid::host::IpcBufferModel model;
+    oid::host::IpcClient client(t, model);
+
+    EXPECT_NO_THROW(client.request_plot("some_buffer"));
 }
 
 TEST(IpcClient, RequestPlotSends) {

--- a/tests/host/ipc/ipc_client_test.cpp
+++ b/tests/host/ipc/ipc_client_test.cpp
@@ -220,11 +220,11 @@ TEST(IpcClient, GetObservedSymbolsRespondsWithModelNames) {
     EXPECT_EQ(h, MessageType::GET_OBSERVED_SYMBOLS_RESPONSE);
 }
 
-// LOCAL_FILE-tagged records (Task 3+: buffers opened directly from a local
-// file, not owned by the debugger) must never be advertised back via
+// LOCAL_FILE-tagged records (buffers opened directly from a local file, not
+// owned by the debugger) must never be advertised back via
 // GET_OBSERVED_SYMBOLS_RESPONSE -- only DEBUGGER_SYMBOL records belong in
 // that reply.
-TEST(IpcClient, GetObservedSymbolsExcludesLOCAL_FILEBuffers) {
+TEST(IpcClient, GetObservedSymbolsExcludesLocalFileBuffers) {
     FakeTransport t;
     oid::host::IpcBufferModel model;
     {

--- a/tests/host/ui/buffer_model_test.cpp
+++ b/tests/host/ui/buffer_model_test.cpp
@@ -29,6 +29,7 @@
 
 #include "ipc/raw_data_decode.h"
 
+using oid::host::BufferKind;
 using oid::host::make_default_mock_model;
 using oid::host::MockBufferModel;
 using oid::host::type_label;
@@ -41,6 +42,15 @@ TEST(MockBufferModel, HoldsDeterministicBuffers) {
     EXPECT_EQ(r.width * r.height * r.channels,
               static_cast<int>(r.bytes.size()));
     EXPECT_FALSE(r.variable_name.empty());
+}
+
+// Locally-opened buffers (Task 3+) are tagged BufferKind::LOCAL_FILE so they
+// can be excluded from GET_OBSERVED_SYMBOLS; every other record -- including
+// these deterministic mock buffers -- defaults to DEBUGGER_SYMBOL.
+TEST(MockBufferModel, DefaultRecordKindIsDEBUGGER_SYMBOL) {
+    MockBufferModel m = make_default_mock_model();
+    ASSERT_GE(m.size(), 1u);
+    EXPECT_EQ(m.at(0).kind, BufferKind::DEBUGGER_SYMBOL);
 }
 
 // step is "pixels per row" (see Buffer::configure / GL_UNPACK_ROW_LENGTH),

--- a/tests/host/ui/buffer_model_test.cpp
+++ b/tests/host/ui/buffer_model_test.cpp
@@ -44,10 +44,10 @@ TEST(MockBufferModel, HoldsDeterministicBuffers) {
     EXPECT_FALSE(r.variable_name.empty());
 }
 
-// Locally-opened buffers (Task 3+) are tagged BufferKind::LOCAL_FILE so they
-// can be excluded from GET_OBSERVED_SYMBOLS; every other record -- including
-// these deterministic mock buffers -- defaults to DEBUGGER_SYMBOL.
-TEST(MockBufferModel, DefaultRecordKindIsDEBUGGER_SYMBOL) {
+// Locally-opened buffers are tagged BufferKind::LOCAL_FILE so they can be
+// excluded from GET_OBSERVED_SYMBOLS; every other record -- including these
+// deterministic mock buffers -- defaults to DEBUGGER_SYMBOL.
+TEST(MockBufferModel, DefaultRecordKindIsDebuggerSymbol) {
     MockBufferModel m = make_default_mock_model();
     ASSERT_GE(m.size(), 1u);
     EXPECT_EQ(m.at(0).kind, BufferKind::DEBUGGER_SYMBOL);


### PR DESCRIPTION
## Summary

Open an image or NumPy array directly in the viewer, with no debugger session, via two entry points:

- a repeatable `-o` / `--open <path>` CLI flag (seeded at startup), and
- a **File → Open** menu item + `Ctrl+O`, backed by a native OS file dialog.

Supported formats are the stb_image set (`png`, `jpg`/`jpeg`, `bmp`, `tga`, `gif`, `psd`, `hdr`, `ppm`/`pgm`/`pnm`) and NumPy `.npy` (little-endian `uint8`/`uint16`/`int16`/`int32`/`float32`/`float64`; 2‑D grayscale or 3‑D with 1–4 channels).

Fixes #644.

## Approach

The render path below `IpcBufferModel::upsert()` is source-agnostic, so a locally-inserted `BufferRecord` renders identically to an IPC-delivered one. A host-side loader decodes file bytes into `BufferRecordParams`, funnels them through the existing `make_buffer_record()`, tags the record `BufferKind::LOCAL_FILE`, and calls `upsert()`. Both entry points feed a per-frame `FileOpenQueue`. Local-file records are excluded from `GET_OBSERVED_SYMBOLS` replies and from settings persistence, so they never leak into debugger-session state.

New host modules (all C++20, unit-tested where not GL-coupled):
- `host/io/npy_decode` — `.npy` byte-buffer decoder (11 tests)
- `host/io/file_buffer_loader` — stb + npy dispatch → `BufferRecord` with a 512 MB cap (5 tests)
- `host/io/file_open_queue` — FIFO drain with outcome reporting (4 tests)
- `host/io/expected` — minimal `oid::Expected<T>` value-or-error result (the project targets C++20; `std::expected` is unavailable)
- `host/cli_options` — argument parser (7 tests, incl. legacy `-h`/`--hostname` compatibility)
- `platform/native_file_dialog` — native dialog via nativefiledialog-extended v1.3.0 (new submodule, native-only)

## Companion fixes

- **IpcClient tolerates a dead transport on outbound sends** — previously, pressing Delete on a buffer with no debugger attached could throw and crash the viewer.
- **FLOAT64 pixel tooltip** in `buffer.cpp` now reads the float32-backed payload correctly (matching the other readers).

## Testing

- Clean `rm -rf build` → configure → build → `ctest`: **31/31 targets pass** on macOS.
- Full build links `oidwindow` with nfd on macOS.

## Notes for reviewers

- The non-native / embedding platform (`OID_PLATFORM_DIR`) must supply its own `oid::platform::request_open_files` implementation; the native impl lives in `platform/native_file_dialog.cpp` and nfd is compiled/linked only in the native build.
- No drag-and-drop and no OS file-association registration in this change (documented as out of scope in the README).
- Interactive smoke of the native window + OS dialog is a manual acceptance step.
