### PR TITLE
feat(export): add NumPy .npy as a buffer export format

### DIFF
--- a/src/host/io/imgui_buffer_exporter_glue.cpp
+++ b/src/host/io/imgui_buffer_exporter_glue.cpp
@@ -53,6 +53,8 @@ bool export_buffer_imgui(const oid::Buffer& buffer,
         }
         case OCTAVE_MATRIX:
             return oid::BufferExporter::export_octave(buffer, path);
+        case NUMPY_ARRAY:
+            return oid::BufferExporter::export_npy(buffer, path);
         }
         return false;
     } catch (const std::exception& e) {

--- a/src/host/io/imgui_buffer_exporter_glue.cpp
+++ b/src/host/io/imgui_buffer_exporter_glue.cpp
@@ -41,20 +41,20 @@
 
 namespace oid::host {
 
-bool export_buffer_imgui(const oid::Buffer& buffer,
+bool export_buffer_imgui(const Buffer& buffer,
                          const std::string& path,
-                         oid::BufferExporter::OutputType type) {
+                         BufferExporter::OutputType type) {
     try {
-        using enum oid::BufferExporter::OutputType;
+        using enum BufferExporter::OutputType;
         switch (type) {
         case BITMAP: {
-            const auto image = oid::BufferExporter::normalize_to_rgba8(buffer);
+            const auto image = BufferExporter::normalize_to_rgba8(buffer);
             return export_rgba_png(image, path);
         }
         case OCTAVE_MATRIX:
-            return oid::BufferExporter::export_octave(buffer, path);
+            return BufferExporter::export_octave(buffer, path);
         case NUMPY_ARRAY:
-            return oid::BufferExporter::export_npy(buffer, path);
+            return BufferExporter::export_npy(buffer, path);
         }
         return false;
     } catch (const std::exception& e) {

--- a/src/host/ui/export_dialog.cpp
+++ b/src/host/ui/export_dialog.cpp
@@ -40,9 +40,10 @@ namespace {
 
 // Anonymous-namespace export-format registry; see export_formats() below for
 // the public accessor. Adding a format (e.g. NumPy .npy) is one row here.
-constexpr std::array<ExportFormat, 2> EXPORT_FORMATS{{
+constexpr std::array<ExportFormat, 3> EXPORT_FORMATS{{
     {oid::BufferExporter::OutputType::BITMAP, ".png", "PNG image"},
     {oid::BufferExporter::OutputType::OCTAVE_MATRIX, ".oct", "Octave matrix"},
+    {oid::BufferExporter::OutputType::NUMPY_ARRAY, ".npy", "NumPy array"},
 }};
 
 // Case-insensitive ASCII suffix test. Export extensions are ASCII, so a

--- a/src/host/ui/export_dialog.cpp
+++ b/src/host/ui/export_dialog.cpp
@@ -55,11 +55,13 @@ bool ends_with_ci(std::string_view s, std::string_view suffix) {
         return false;
     }
     const std::string_view tail = s.substr(s.size() - suffix.size());
-    return std::equal(
-        tail.begin(), tail.end(), suffix.begin(), [](char a, char b) {
-            return std::tolower(static_cast<unsigned char>(a)) ==
-                   std::tolower(static_cast<unsigned char>(b));
-        });
+    return std::equal(tail.begin(),
+                      tail.end(),
+                      suffix.begin(),
+                      [](const char a, const char b) {
+                          return std::tolower(static_cast<unsigned char>(a)) ==
+                                 std::tolower(static_cast<unsigned char>(b));
+                      });
 }
 
 // Copies `s` into `buf` as a null-terminated C string, truncating to fit

--- a/src/host/ui/export_dialog.h
+++ b/src/host/ui/export_dialog.h
@@ -87,8 +87,9 @@ std::span<const ExportFormat> export_formats();
 std::string_view extension_for(oid::BufferExporter::OutputType format);
 
 // Returns the type of the first export_formats() row whose extension `path`
-// ends with (case-sensitive); falls back to the default first row (currently
-// BITMAP/PNG) when none matches. Used to derive the export format from the
+// ends with (case-insensitively); falls back to the default first row
+// (currently BITMAP/PNG) when none matches. Used to derive the export
+// format from the
 // path chosen in the native save dialog (nfd appends the selected filter's
 // extension).
 oid::BufferExporter::OutputType classify_export_format(std::string_view path);

--- a/src/host/ui/export_dialog.h
+++ b/src/host/ui/export_dialog.h
@@ -45,8 +45,7 @@ struct ExportDialogState {
     bool open{false};
     std::string buffer_name;           // target buffer's variable_name
     std::array<char, 1024> path_buf{}; // fixed-size destination path buffer
-    oid::BufferExporter::OutputType format{
-        oid::BufferExporter::OutputType::BITMAP};
+    BufferExporter::OutputType format{BufferExporter::OutputType::BITMAP};
 };
 
 // Composes a default export path with no filesystem checks -- pure string
@@ -57,7 +56,7 @@ struct ExportDialogState {
 std::string default_export_path(std::string_view last_export_dir,
                                 const char* home_env,
                                 const std::string& buffer_name,
-                                oid::BufferExporter::OutputType format);
+                                BufferExporter::OutputType format);
 
 // Opens the dialog for `buffer_name`: resets `st` (format back to the
 // BITMAP default) and seeds `path_buf` via default_export_path(
@@ -73,7 +72,7 @@ void open_export_dialog(ExportDialogState& st,
 // Adding a format is one row in the registry, plus its OutputType enumerator
 // and encoder branch in export_buffer_imgui().
 struct ExportFormat {
-    oid::BufferExporter::OutputType type;
+    BufferExporter::OutputType type;
     const char* extension; // ".png"
     const char* label;     // "PNG image"
 };
@@ -84,7 +83,7 @@ std::span<const ExportFormat> export_formats();
 
 // Returns the extension (with leading dot) for `format`, per the registry;
 // returns the default format's extension if `format` is somehow not listed.
-std::string_view extension_for(oid::BufferExporter::OutputType format);
+std::string_view extension_for(BufferExporter::OutputType format);
 
 // Returns the type of the first export_formats() row whose extension `path`
 // ends with (case-insensitively); falls back to the default first row
@@ -92,13 +91,13 @@ std::string_view extension_for(oid::BufferExporter::OutputType format);
 // format from the
 // path chosen in the native save dialog (nfd appends the selected filter's
 // extension).
-oid::BufferExporter::OutputType classify_export_format(std::string_view path);
+BufferExporter::OutputType classify_export_format(std::string_view path);
 
 // Appends the registry extension for `format` to `path` if it is not
 // already there; returns `path` unchanged otherwise. Safety net for when the
 // chosen path lacks a recognized extension.
 std::string ensure_export_extension(std::string path,
-                                    oid::BufferExporter::OutputType format);
+                                    BufferExporter::OutputType format);
 
 // Copies `path` into `st.path_buf` as a null-terminated C string, truncating
 // to fit the 1024-byte buffer. Used once a destination path has been

--- a/src/io/buffer_export_adapters.cpp
+++ b/src/io/buffer_export_adapters.cpp
@@ -37,7 +37,7 @@ namespace oid::BufferExporter {
 RgbaImage normalize_to_rgba8(const Buffer& buffer) {
     const auto* bc = buffer.auto_buffer_contrast_brightness();
     auto bc_comp = std::array<float, 8>{};
-    std::copy(bc, bc + 8, bc_comp.begin());
+    std::copy_n(bc, 8, bc_comp.begin());
 
     return normalize_to_rgba8_raw(
         std::bit_cast<const std::uint8_t*>(buffer.buffer().data()),

--- a/src/io/buffer_export_adapters.cpp
+++ b/src/io/buffer_export_adapters.cpp
@@ -61,4 +61,15 @@ bool export_octave(const Buffer& buffer, const std::string& path) {
         path);
 }
 
+bool export_npy(const Buffer& buffer, const std::string& path) {
+    return export_npy_raw(
+        std::bit_cast<const std::uint8_t*>(buffer.buffer().data()),
+        buffer.type(),
+        static_cast<int>(buffer.buffer_width_f()),
+        static_cast<int>(buffer.buffer_height_f()),
+        buffer.channels(),
+        buffer.step(),
+        path);
+}
+
 } // namespace oid::BufferExporter

--- a/src/io/buffer_export_core.cpp
+++ b/src/io/buffer_export_core.cpp
@@ -211,6 +211,80 @@ bool export_octave_impl(const std::uint8_t* data,
     return ofs.good();
 }
 
+std::string npy_descr(BufferType type) {
+    using enum BufferType;
+    switch (type) {
+    case UNSIGNED_BYTE:
+        return "|u1";
+    case UNSIGNED_SHORT:
+        return "<u2";
+    case SHORT:
+        return "<i2";
+    case INT32:
+        return "<i4";
+    case FLOAT32:
+    case FLOAT64: // OID stores doubles as float32
+        return "<f4";
+    }
+    return "|u1";
+}
+
+// Writes the .npy v1.0 header: magic, version, uint16-LE length, then a
+// space-padded, '\n'-terminated dict so that (10 + header_len) % 64 == 0.
+void write_npy_header(std::ofstream& ofs,
+                      const std::string& descr,
+                      int height,
+                      int width,
+                      int channels) {
+    const std::string shape =
+        channels == 1
+            ? "(" + std::to_string(height) + ", " + std::to_string(width) + ")"
+            : "(" + std::to_string(height) + ", " + std::to_string(width) +
+                  ", " + std::to_string(channels) + ")";
+    std::string dict = "{'descr': '" + descr +
+                       "', 'fortran_order': False, 'shape': " + shape + ", }";
+
+    // 10 bytes precede the dict (6 magic + 2 version + 2 length); the dict
+    // carries a trailing '\n'. Pad with spaces up to the next 64-byte boundary.
+    const std::size_t unpadded = 10 + dict.size() + 1;
+    const std::size_t padded = ((unpadded + 63) / 64) * 64;
+    dict.append(padded - unpadded, ' ');
+    dict.push_back('\n');
+
+    const auto header_len = static_cast<std::uint16_t>(dict.size());
+    ofs.write("\x93NUMPY", 6);
+    const char version[2] = {1, 0};
+    ofs.write(version, sizeof(version));
+    ofs.write(reinterpret_cast<const char*>(&header_len), sizeof(header_len));
+    ofs.write(dict.data(), static_cast<std::streamsize>(dict.size()));
+}
+
+template <typename T>
+bool export_npy_impl(const std::uint8_t* data,
+                     BufferType type,
+                     int width,
+                     int height,
+                     int channels_i,
+                     int step,
+                     const std::string& path) {
+    const auto width_i = static_cast<std::size_t>(width);
+    const auto height_i = static_cast<std::size_t>(height);
+    const auto in_ptr = std::bit_cast<const T*>(data);
+
+    auto ofs = std::ofstream{std::filesystem::path{path}, std::ios::binary};
+    write_npy_header(ofs, npy_descr(type), height, width, channels_i);
+
+    const auto row_bytes =
+        sizeof(T) * static_cast<std::size_t>(channels_i) * width_i;
+    for (std::size_t y = 0; y < height_i; ++y) {
+        ofs.write(reinterpret_cast<const char*>(
+                      in_ptr + y * static_cast<std::size_t>(step) *
+                                   static_cast<std::size_t>(channels_i)),
+                  static_cast<std::streamsize>(row_bytes));
+    }
+    return ofs.good();
+}
+
 } // namespace
 
 RgbaImage normalize_to_rgba8_raw(const std::uint8_t* data,
@@ -290,6 +364,36 @@ bool export_octave_raw(const std::uint8_t* data,
     case FLOAT64:
         return export_octave_impl<float>(
             data, width, height, channels, step, path);
+    }
+    return false;
+}
+
+bool export_npy_raw(const std::uint8_t* data,
+                    const BufferType type,
+                    const int width,
+                    const int height,
+                    const int channels,
+                    const int step,
+                    const std::string& path) {
+    using enum BufferType;
+    switch (type) {
+    case UNSIGNED_BYTE:
+        return export_npy_impl<std::uint8_t>(
+            data, type, width, height, channels, step, path);
+    case UNSIGNED_SHORT:
+        return export_npy_impl<std::uint16_t>(
+            data, type, width, height, channels, step, path);
+    case SHORT:
+        return export_npy_impl<std::int16_t>(
+            data, type, width, height, channels, step, path);
+    case INT32:
+        return export_npy_impl<std::int32_t>(
+            data, type, width, height, channels, step, path);
+    case FLOAT32:
+        [[fallthrough]];
+    case FLOAT64:
+        return export_npy_impl<float>(
+            data, type, width, height, channels, step, path);
     }
     return false;
 }

--- a/src/io/buffer_export_core.cpp
+++ b/src/io/buffer_export_core.cpp
@@ -31,6 +31,7 @@
 #include <cassert>
 #include <cstdint>
 #include <filesystem>
+#include <format>
 #include <fstream>
 #include <limits>
 
@@ -211,7 +212,7 @@ bool export_octave_impl(const std::uint8_t* data,
     return ofs.good();
 }
 
-std::string npy_descr(BufferType type) {
+std::string npy_descr(const BufferType type) {
     using enum BufferType;
     switch (type) {
     case UNSIGNED_BYTE:
@@ -233,16 +234,16 @@ std::string npy_descr(BufferType type) {
 // space-padded, '\n'-terminated dict so that (10 + header_len) % 64 == 0.
 void write_npy_header(std::ofstream& ofs,
                       const std::string& descr,
-                      int height,
-                      int width,
-                      int channels) {
+                      const int height,
+                      const int width,
+                      const int channels) {
     const std::string shape =
-        channels == 1
-            ? "(" + std::to_string(height) + ", " + std::to_string(width) + ")"
-            : "(" + std::to_string(height) + ", " + std::to_string(width) +
-                  ", " + std::to_string(channels) + ")";
-    std::string dict = "{'descr': '" + descr +
-                       "', 'fortran_order': False, 'shape': " + shape + ", }";
+        channels == 1 ? std::format("({}, {})", height, width)
+                      : std::format("({}, {}, {})", height, width, channels);
+    std::string dict =
+        std::format("{{'descr': '{}', 'fortran_order': False, 'shape': {}, }}",
+                    descr,
+                    shape);
 
     // 10 bytes precede the dict (6 magic + 2 version + 2 length); the dict
     // carries a trailing '\n'. Pad with spaces up to the next 64-byte boundary.
@@ -251,35 +252,41 @@ void write_npy_header(std::ofstream& ofs,
     dict.append(padded - unpadded, ' ');
     dict.push_back('\n');
 
+    // The .npy spec fixes the header length as two little-endian bytes,
+    // independent of host byte order, so emit them explicitly.
     const auto header_len = static_cast<std::uint16_t>(dict.size());
+    const std::array len_le = {static_cast<char>(header_len & 0xFF),
+                               static_cast<char>((header_len >> 8) & 0xFF)};
+    constexpr std::array<char, 2> version = {1, 0};
     ofs.write("\x93NUMPY", 6);
-    const char version[2] = {1, 0};
-    ofs.write(version, sizeof(version));
-    ofs.write(reinterpret_cast<const char*>(&header_len), sizeof(header_len));
+    ofs.write(version.data(), version.size());
+    ofs.write(len_le.data(), len_le.size());
     ofs.write(dict.data(), static_cast<std::streamsize>(dict.size()));
 }
 
 template <typename T>
 bool export_npy_impl(const std::uint8_t* data,
-                     BufferType type,
-                     int width,
-                     int height,
-                     int channels_i,
-                     int step,
+                     const BufferType type,
+                     const int width,
+                     const int height,
+                     const int channels_i,
+                     const int step,
                      const std::string& path) {
     const auto width_i = static_cast<std::size_t>(width);
     const auto height_i = static_cast<std::size_t>(height);
-    const auto in_ptr = std::bit_cast<const T*>(data);
+    const auto channels = static_cast<std::size_t>(channels_i);
+    const auto step_i = static_cast<std::size_t>(step);
 
     auto ofs = std::ofstream{std::filesystem::path{path}, std::ios::binary};
     write_npy_header(ofs, npy_descr(type), height, width, channels_i);
 
-    const auto row_bytes =
-        sizeof(T) * static_cast<std::size_t>(channels_i) * width_i;
+    // step is measured in pixels; each pixel spans channels * sizeof(T) bytes.
+    // Offsetting the byte pointer directly avoids assuming the input is an
+    // aligned, live T[] sequence.
+    const auto row_bytes = sizeof(T) * channels * width_i;
+    const auto row_stride = sizeof(T) * channels * step_i;
     for (std::size_t y = 0; y < height_i; ++y) {
-        ofs.write(reinterpret_cast<const char*>(
-                      in_ptr + y * static_cast<std::size_t>(step) *
-                                   static_cast<std::size_t>(channels_i)),
+        ofs.write(reinterpret_cast<const char*>(data + y * row_stride),
                   static_cast<std::streamsize>(row_bytes));
     }
     return ofs.good();

--- a/src/io/buffer_export_core.h
+++ b/src/io/buffer_export_core.h
@@ -54,6 +54,9 @@ struct RgbaImage {
 // Octave raw-matrix writer. Returns false on stream failure.
 bool export_octave(const Buffer& buffer, const std::string& path);
 
+// NumPy .npy writer. Returns false on stream failure.
+bool export_npy(const Buffer& buffer, const std::string& path);
+
 // Buffer geometry/typing, grouped so normalize_to_rgba8_raw() stays under
 // Sonar's parameter-count limit. `data` and `bc_comp` stay separate
 // parameters: they're the payload being normalized, not buffer shape.
@@ -80,9 +83,6 @@ bool export_octave_raw(const std::uint8_t* data,
                        int channels,
                        int step,
                        const std::string& path);
-
-// NumPy .npy writer. Returns false on stream failure.
-bool export_npy(const Buffer& buffer, const std::string& path);
 
 bool export_npy_raw(const std::uint8_t* data,
                     BufferType type,

--- a/src/io/buffer_export_core.h
+++ b/src/io/buffer_export_core.h
@@ -39,7 +39,7 @@ class Buffer;
 
 namespace oid::BufferExporter {
 
-enum class OutputType { BITMAP, OCTAVE_MATRIX };
+enum class OutputType { BITMAP, OCTAVE_MATRIX, NUMPY_ARRAY };
 
 struct RgbaImage {
     int width{0};
@@ -80,6 +80,17 @@ bool export_octave_raw(const std::uint8_t* data,
                        int channels,
                        int step,
                        const std::string& path);
+
+// NumPy .npy writer. Returns false on stream failure.
+bool export_npy(const Buffer& buffer, const std::string& path);
+
+bool export_npy_raw(const std::uint8_t* data,
+                    BufferType type,
+                    int width,
+                    int height,
+                    int channels,
+                    int step,
+                    const std::string& path);
 
 } // namespace oid::BufferExporter
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -582,6 +582,7 @@ if(OID_BUILD_IMGUI_FRONTEND)
     add_executable(buffer_export_core_test
         io/buffer_export_core_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/io/buffer_export_core.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/host/io/npy_decode.cpp
     )
 
     target_compile_definitions(buffer_export_core_test PRIVATE OID_IMGUI_FRONTEND)

--- a/tests/host/ui/export_dialog_test.cpp
+++ b/tests/host/ui/export_dialog_test.cpp
@@ -101,6 +101,9 @@ TEST(ExportDialog, ClassifyFormatFromExtension) {
     // extension still classifies to the right format.
     EXPECT_EQ(classify_export_format("buf.OCT"), OutputType::OCTAVE_MATRIX);
     EXPECT_EQ(classify_export_format("/a/buf.PNG"), OutputType::BITMAP);
+    EXPECT_EQ(classify_export_format("/a/buf.npy"), OutputType::NUMPY_ARRAY);
+    EXPECT_EQ(classify_export_format("/a/buf.NPY"),
+              OutputType::NUMPY_ARRAY); // case-insensitive
 }
 
 TEST(ExportDialog, EnsureExtensionAppendsWhenMissing) {

--- a/tests/host/ui/export_dialog_test.cpp
+++ b/tests/host/ui/export_dialog_test.cpp
@@ -111,6 +111,8 @@ TEST(ExportDialog, EnsureExtensionAppendsWhenMissing) {
               "/a/buf.png");
     EXPECT_EQ(ensure_export_extension("/a/buf", OutputType::OCTAVE_MATRIX),
               "/a/buf.oct");
+    EXPECT_EQ(ensure_export_extension("/a/buf", OutputType::NUMPY_ARRAY),
+              "/a/buf.npy");
 }
 
 TEST(ExportDialog, EnsureExtensionNoOpWhenPresent) {

--- a/tests/io/buffer_export_core_test.cpp
+++ b/tests/io/buffer_export_core_test.cpp
@@ -134,8 +134,42 @@ TEST(ExportCore, NpyPayloadEqualsOctavePayload) {
     const std::vector<char> o = read(oct);
     const std::vector<char> n = read(npy);
     const char* payload = reinterpret_cast<const char*>(px);
+    ASSERT_GE(o.size(), 12u);
+    ASSERT_GE(n.size(), 12u);
     EXPECT_TRUE(std::equal(o.end() - 12, o.end(), payload));
     EXPECT_TRUE(std::equal(n.end() - 12, n.end(), payload));
+}
+
+TEST(ExportCore, NpyDescrForAllDtypes) {
+    const auto check = [](oid::BufferType type,
+                          const std::vector<std::uint8_t>& px,
+                          int width,
+                          int height,
+                          const std::string& expected_descr) {
+        const auto p = oid::test::scratch_dir() / "oid_descr.npy";
+        std::filesystem::remove(p);
+        ASSERT_TRUE(oid::BufferExporter::export_npy_raw(
+            px.data(), type, width, height, 1, width, p.string()));
+        std::ifstream is{p, std::ios::binary};
+        const std::string data{std::istreambuf_iterator<char>(is), {}};
+        EXPECT_NE(data.find(expected_descr), std::string::npos)
+            << "missing " << expected_descr;
+    };
+
+    // SHORT, 1x1, itemsize=2.
+    check(oid::BufferType::SHORT, {0x34, 0x12}, 1, 1, "'descr': '<i2'");
+    // INT32, 2x1, itemsize=4, 2 elements => 8 bytes.
+    check(oid::BufferType::INT32,
+          {0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00},
+          2,
+          1,
+          "'descr': '<i4'");
+    // FLOAT64, 1x1, itemsize=8.
+    check(oid::BufferType::FLOAT64,
+          {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x3f},
+          1,
+          1,
+          "'descr': '<f4'");
 }
 
 TEST(ExportCore, NpyRoundTripsThroughReader) {
@@ -176,4 +210,27 @@ TEST(ExportCore, NpyMultiChannelShapeIs3D) {
     std::ifstream is{p, std::ios::binary};
     const std::string data{std::istreambuf_iterator<char>(is), {}};
     EXPECT_NE(data.find("'shape': (2, 2, 2)"), std::string::npos);
+}
+
+TEST(ExportCore, NpyMultiChannelRoundTripsThroughReader) {
+    const std::uint8_t px[] = {1, 2, 3, 4, 5, 6, 7, 8}; // 2x2, 2ch, step=2
+    const auto p = oid::test::scratch_dir() / "oid_rt_3d.npy";
+    std::filesystem::remove(p);
+    ASSERT_TRUE(oid::BufferExporter::export_npy_raw(
+        px, oid::BufferType::UNSIGNED_BYTE, 2, 2, 2, 2, p.string()));
+    std::ifstream is{p, std::ios::binary};
+    std::vector<std::byte> raw;
+    for (std::istreambuf_iterator<char> it{is}, end; it != end; ++it) {
+        raw.push_back(static_cast<std::byte>(*it));
+    }
+    const auto arr = oid::decode_npy(raw);
+    ASSERT_TRUE(arr.has_value());
+    EXPECT_EQ(arr->type, oid::BufferType::UNSIGNED_BYTE);
+    EXPECT_EQ(arr->width, 2);
+    EXPECT_EQ(arr->height, 2);
+    EXPECT_EQ(arr->channels, 2);
+    EXPECT_EQ(arr->bytes.size(), sizeof(px));
+    EXPECT_TRUE(std::equal(arr->bytes.begin(),
+                           arr->bytes.end(),
+                           reinterpret_cast<const std::byte*>(px)));
 }

--- a/tests/io/buffer_export_core_test.cpp
+++ b/tests/io/buffer_export_core_test.cpp
@@ -40,28 +40,28 @@
 TEST(ExportCore, NormalizeUint8GrayIdentityContrast) {
     // 2x2 single-channel uint8, bc = {1,1,1,1, 0,0,0,0} (gain 1, bias 0),
     // layout "rgba"
-    const std::uint8_t px[] = {0, 64, 128, 255};
-    const auto img = oid::BufferExporter::normalize_to_rgba8_raw(
-        px,
-        {.type = oid::BufferType::UNSIGNED_BYTE,
-         .width = 2,
-         .height = 2,
-         .channels = 1,
-         .step = 2,
-         .pixel_layout = "rgba"},
-        {1, 1, 1, 1, 0, 0, 0, 0});
-    ASSERT_EQ(img.width, 2);
-    ASSERT_EQ(img.height, 2);
-    ASSERT_EQ(img.pixels.size(), 16u);
+    constexpr std::uint8_t px[] = {0, 64, 128, 255};
+    const auto [width, height, pixels] =
+        oid::BufferExporter::normalize_to_rgba8_raw(
+            px,
+            {.type = oid::BufferType::UNSIGNED_BYTE,
+             .width = 2,
+             .height = 2,
+             .channels = 1,
+             .step = 2,
+             .pixel_layout = "rgba"},
+            {1, 1, 1, 1, 0, 0, 0, 0});
+    ASSERT_EQ(width, 2);
+    ASSERT_EQ(height, 2);
+    ASSERT_EQ(pixels.size(), 16u);
     // Grayscale repeats ch0 into G,B; A=255.
     const std::uint8_t expected[] = {
         0, 0, 0, 255, 64, 64, 64, 255, 128, 128, 128, 255, 255, 255, 255, 255};
-    EXPECT_TRUE(std::equal(img.pixels.begin(), img.pixels.end(), expected));
+    EXPECT_TRUE(std::equal(pixels.begin(), pixels.end(), expected));
 }
 
 TEST(ExportCore, NormalizeFloatScalesTo255) {
-    const std::array<float, 2> px = {0.0f,
-                                     1.0f}; // width=2, height=1, 1ch, step=2
+    constexpr std::array px = {0.0f, 1.0f}; // width=2, height=1, 1ch, step=2
     const auto img = oid::BufferExporter::normalize_to_rgba8_raw(
         reinterpret_cast<const std::uint8_t*>(px.data()),
         {.type = oid::BufferType::FLOAT32,
@@ -84,8 +84,9 @@ TEST(ExportCore, OctaveGoldenBytes) {
     std::ifstream is{p, std::ios::binary};
     std::vector<char> got{std::istreambuf_iterator<char>(is), {}};
     // "uint8\n" + int32 LE height=2, width=3, channels=1 + 6 payload bytes
-    const char expected[] = {'u', 'i', 'n', 't', '8', '\n', 2, 0, 0, 0, 3, 0,
-                             0,   0,   1,   0,   0,   0,    1, 2, 3, 4, 5, 6};
+    constexpr char expected[] = {'u', 'i', 'n', 't', '8', '\n', 2, 0,
+                                 0,   0,   3,   0,   0,   0,    1, 0,
+                                 0,   0,   1,   2,   3,   4,    5, 6};
     ASSERT_EQ(got.size(), sizeof(expected));
     EXPECT_TRUE(std::equal(got.begin(), got.end(), expected));
 }
@@ -117,23 +118,28 @@ TEST(ExportCore, NpyGoldenBytes) {
 
 TEST(ExportCore, NpyPayloadEqualsOctavePayload) {
     // .npy and .oct share the same tightly-packed raw data region.
-    const std::uint16_t px[] = {10, 20, 30, 40, 50, 60}; // 3x2, 1ch, step=3
+    const std::array<std::uint16_t, 6> px = {
+        10, 20, 30, 40, 50, 60}; // 3x2, 1ch
     const auto oct = oid::test::scratch_dir() / "oid_cmp.oct";
     const auto npy = oid::test::scratch_dir() / "oid_cmp.npy";
     std::filesystem::remove(oct);
     std::filesystem::remove(npy);
-    const auto* bytes = reinterpret_cast<const std::uint8_t*>(px);
+    const auto* bytes = reinterpret_cast<const std::uint8_t*>(px.data());
     ASSERT_TRUE(oid::BufferExporter::export_octave_raw(
         bytes, oid::BufferType::UNSIGNED_SHORT, 3, 2, 1, 3, oct.string()));
     ASSERT_TRUE(oid::BufferExporter::export_npy_raw(
         bytes, oid::BufferType::UNSIGNED_SHORT, 3, 2, 1, 3, npy.string()));
     const auto read = [](const std::filesystem::path& p) {
         std::ifstream is{p, std::ios::binary};
-        return std::vector<char>{std::istreambuf_iterator<char>(is), {}};
+        std::vector<std::byte> vector;
+        for (std::istreambuf_iterator<char> it{is}, end; it != end; ++it) {
+            vector.push_back(static_cast<std::byte>(*it));
+        }
+        return vector;
     };
-    const std::vector<char> o = read(oct);
-    const std::vector<char> n = read(npy);
-    const char* payload = reinterpret_cast<const char*>(px);
+    const std::vector<std::byte> o = read(oct);
+    const std::vector<std::byte> n = read(npy);
+    const auto* payload = reinterpret_cast<const std::byte*>(px.data());
     ASSERT_GE(o.size(), 12u);
     ASSERT_GE(n.size(), 12u);
     EXPECT_TRUE(std::equal(o.end() - 12, o.end(), payload));
@@ -151,7 +157,7 @@ TEST(ExportCore, NpyDescrForAllDtypes) {
         ASSERT_TRUE(oid::BufferExporter::export_npy_raw(
             px.data(), type, width, height, 1, width, p.string()));
         std::ifstream is{p, std::ios::binary};
-        const std::string data{std::istreambuf_iterator<char>(is), {}};
+        const std::string data{std::istreambuf_iterator(is), {}};
         EXPECT_NE(data.find(expected_descr), std::string::npos)
             << "missing " << expected_descr;
     };
@@ -173,11 +179,11 @@ TEST(ExportCore, NpyDescrForAllDtypes) {
 }
 
 TEST(ExportCore, NpyRoundTripsThroughReader) {
-    const float px[] = {1.5f, -2.0f, 3.25f, 4.0f}; // 2x2, 1ch, step=2
+    constexpr std::array px = {1.5f, -2.0f, 3.25f, 4.0f}; // 2x2, 1ch
     const auto p = oid::test::scratch_dir() / "oid_rt.npy";
     std::filesystem::remove(p);
     ASSERT_TRUE(oid::BufferExporter::export_npy_raw(
-        reinterpret_cast<const std::uint8_t*>(px),
+        reinterpret_cast<const std::uint8_t*>(px.data()),
         oid::BufferType::FLOAT32,
         2,
         2,
@@ -198,7 +204,7 @@ TEST(ExportCore, NpyRoundTripsThroughReader) {
     EXPECT_EQ(arr->bytes.size(), sizeof(px));
     EXPECT_TRUE(std::equal(arr->bytes.begin(),
                            arr->bytes.end(),
-                           reinterpret_cast<const std::byte*>(px)));
+                           reinterpret_cast<const std::byte*>(px.data())));
 }
 
 TEST(ExportCore, NpyMultiChannelShapeIs3D) {
@@ -208,7 +214,7 @@ TEST(ExportCore, NpyMultiChannelShapeIs3D) {
     ASSERT_TRUE(oid::BufferExporter::export_npy_raw(
         px, oid::BufferType::UNSIGNED_BYTE, 2, 2, 2, 2, p.string()));
     std::ifstream is{p, std::ios::binary};
-    const std::string data{std::istreambuf_iterator<char>(is), {}};
+    const std::string data{std::istreambuf_iterator(is), {}};
     EXPECT_NE(data.find("'shape': (2, 2, 2)"), std::string::npos);
 }
 

--- a/tests/io/buffer_export_core_test.cpp
+++ b/tests/io/buffer_export_core_test.cpp
@@ -33,6 +33,7 @@
 
 #include <gtest/gtest.h>
 
+#include "host/io/npy_decode.h"
 #include "io/buffer_export_core.h"
 #include "support/scratch_dir.h"
 
@@ -87,4 +88,92 @@ TEST(ExportCore, OctaveGoldenBytes) {
                              0,   0,   1,   0,   0,   0,    1, 2, 3, 4, 5, 6};
     ASSERT_EQ(got.size(), sizeof(expected));
     EXPECT_TRUE(std::equal(got.begin(), got.end(), expected));
+}
+
+TEST(ExportCore, NpyGoldenBytes) {
+    const std::uint8_t px[] = {1, 2, 3, 4, 5, 6}; // 3 wide, 2 high, 1ch, step=3
+    const auto p = oid::test::scratch_dir() / "oid_npy_golden.npy";
+    std::filesystem::remove(p);
+    ASSERT_TRUE(oid::BufferExporter::export_npy_raw(
+        px, oid::BufferType::UNSIGNED_BYTE, 3, 2, 1, 3, p.string()));
+    std::ifstream is{p, std::ios::binary};
+    std::vector<char> got{std::istreambuf_iterator<char>(is), {}};
+
+    std::string expected;
+    expected.append("\x93NUMPY", 6);
+    expected.push_back('\x01');
+    expected.push_back('\x00');
+    expected.push_back('\x76'); // header_len = 118, little-endian
+    expected.push_back('\x00');
+    expected += "{'descr': '|u1', 'fortran_order': False, 'shape': (2, 3), }";
+    expected.append(58, ' ');
+    expected.push_back('\n');
+    const char payload[] = {1, 2, 3, 4, 5, 6};
+    expected.append(payload, sizeof(payload));
+
+    ASSERT_EQ(got.size(), expected.size()); // 134
+    EXPECT_TRUE(std::equal(got.begin(), got.end(), expected.begin()));
+}
+
+TEST(ExportCore, NpyPayloadEqualsOctavePayload) {
+    // .npy and .oct share the same tightly-packed raw data region.
+    const std::uint16_t px[] = {10, 20, 30, 40, 50, 60}; // 3x2, 1ch, step=3
+    const auto oct = oid::test::scratch_dir() / "oid_cmp.oct";
+    const auto npy = oid::test::scratch_dir() / "oid_cmp.npy";
+    std::filesystem::remove(oct);
+    std::filesystem::remove(npy);
+    const auto* bytes = reinterpret_cast<const std::uint8_t*>(px);
+    ASSERT_TRUE(oid::BufferExporter::export_octave_raw(
+        bytes, oid::BufferType::UNSIGNED_SHORT, 3, 2, 1, 3, oct.string()));
+    ASSERT_TRUE(oid::BufferExporter::export_npy_raw(
+        bytes, oid::BufferType::UNSIGNED_SHORT, 3, 2, 1, 3, npy.string()));
+    const auto read = [](const std::filesystem::path& p) {
+        std::ifstream is{p, std::ios::binary};
+        return std::vector<char>{std::istreambuf_iterator<char>(is), {}};
+    };
+    const std::vector<char> o = read(oct);
+    const std::vector<char> n = read(npy);
+    const char* payload = reinterpret_cast<const char*>(px);
+    EXPECT_TRUE(std::equal(o.end() - 12, o.end(), payload));
+    EXPECT_TRUE(std::equal(n.end() - 12, n.end(), payload));
+}
+
+TEST(ExportCore, NpyRoundTripsThroughReader) {
+    const float px[] = {1.5f, -2.0f, 3.25f, 4.0f}; // 2x2, 1ch, step=2
+    const auto p = oid::test::scratch_dir() / "oid_rt.npy";
+    std::filesystem::remove(p);
+    ASSERT_TRUE(oid::BufferExporter::export_npy_raw(
+        reinterpret_cast<const std::uint8_t*>(px),
+        oid::BufferType::FLOAT32,
+        2,
+        2,
+        1,
+        2,
+        p.string()));
+    std::ifstream is{p, std::ios::binary};
+    std::vector<std::byte> raw;
+    for (std::istreambuf_iterator<char> it{is}, end; it != end; ++it) {
+        raw.push_back(static_cast<std::byte>(*it));
+    }
+    const auto arr = oid::decode_npy(raw);
+    ASSERT_TRUE(arr.has_value());
+    EXPECT_EQ(arr->type, oid::BufferType::FLOAT32);
+    EXPECT_EQ(arr->width, 2);
+    EXPECT_EQ(arr->height, 2);
+    EXPECT_EQ(arr->channels, 1);
+    EXPECT_EQ(arr->bytes.size(), sizeof(px));
+    EXPECT_TRUE(std::equal(arr->bytes.begin(),
+                           arr->bytes.end(),
+                           reinterpret_cast<const std::byte*>(px)));
+}
+
+TEST(ExportCore, NpyMultiChannelShapeIs3D) {
+    const std::uint8_t px[] = {1, 2, 3, 4, 5, 6, 7, 8}; // 2x2, 2ch, step=2
+    const auto p = oid::test::scratch_dir() / "oid_3d.npy";
+    std::filesystem::remove(p);
+    ASSERT_TRUE(oid::BufferExporter::export_npy_raw(
+        px, oid::BufferType::UNSIGNED_BYTE, 2, 2, 2, 2, p.string()));
+    std::ifstream is{p, std::ios::binary};
+    const std::string data{std::istreambuf_iterator<char>(is), {}};
+    EXPECT_NE(data.find("'shape': (2, 2, 2)"), std::string::npos);
 }


### PR DESCRIPTION
## Summary

Adds NumPy `.npy` as a third buffer-export format alongside PNG and the Octave matrix. Like the Octave format (and unlike the contrast-normalized PNG), it writes the **raw native-type buffer values**, so the file is loadable with `numpy.load()` and round-trips through OID's existing `.npy` reader.

## What changed

- New `OutputType::NUMPY_ARRAY` and an `export_npy` / `export_npy_raw` encoder in `buffer_export_core`, written as a *parallel* encoder to the Octave one — the PNG and Octave paths are untouched.
- `.npy` v1.0 byte format:
  - `descr` per `BufferType`: `|u1`, `<u2`, `<i2`, `<i4`, `<f4`. `FLOAT64` is stored as float32 in OID, so it maps to `<f4` (matching the Octave exporter and the actual in-memory data).
  - 64-byte-aligned header dict, `fortran_order: False`, shape `(H, W)` for single-channel buffers else `(H, W, C)`, tightly-packed rows (row-stride padding removed).
- Wired through the `Buffer` adapter + the `export_buffer_imgui` glue dispatch, and registered with a single `EXPORT_FORMATS` row — which lights up every save dialog plus the `classify` / `ensure` / `extension_for` helpers.
- Corrects a stale `classify_export_format` doc comment ("case-sensitive" → case-insensitive, matching the current implementation).

## Testing

- New unit tests: golden header + payload bytes, all six dtypes, payload **byte-identical to the Octave data region** for the same buffer, and a full round-trip through `decode_npy`.
- Full native suite passes (`ctest`, 31/31).