### PR TITLE
feat(perf): decouple agent servicing from the vsync present

### DIFF
--- a/resources/oidmcp/oidmcp/protocol.py
+++ b/resources/oidmcp/oidmcp/protocol.py
@@ -67,10 +67,12 @@ class ControlClient:
 
         The debugger endpoint's reply always carries 'stop_generation';
         the viewer endpoint's does not (a viewer has no stop notion, and
-        replies '{"ok": true}' instead). `SessionManager`'s viewer
-        connection pool still calls this to detect a dead connection, so
-        a missing key defaults to 0 rather than raising -- only the
-        debugger side relies on the returned value being meaningful.
+        replies '{"ok": true}' instead), so a missing key defaults to 0
+        rather than raising -- only the debugger side relies on the
+        returned value being meaningful. `SessionManager` no longer pings
+        for liveness (a stale pooled socket surfaces as OSError on the
+        call itself and is rebuilt once); its debugger fetch path still
+        calls this for the stop generation that keys the per-stop cache.
         """
         response, _ = self._call({'method': 'ping'})
         return response.get('stop_generation', 0)

--- a/resources/oidmcp/oidmcp/server.py
+++ b/resources/oidmcp/oidmcp/server.py
@@ -83,35 +83,57 @@ class SessionManager:
         self._cache = BufferCache(capacity=4)
         self._max_bytes = _parse_max_bytes()
 
-    def _client(self, info) -> ControlClient:
-        client = self._clients.get(info.pid)
-        if client is not None:
-            try:
-                client.ping()
-                return client
-            except OSError:
-                client.close()
-                del self._clients[info.pid]
-        client = ControlClient('127.0.0.1', info.port, info.token)
-        self._clients[info.pid] = client
-        return client
+    def _call_with_retry(self, pool, resolve, fn):
+        """
+        Run ``fn(client)`` against the pooled connection for the endpoint
+        ``resolve()`` names.
 
-    def _viewer_client(self, info) -> ControlClient:
-        # Pooled separately from debugger clients (own dict, keyed by the
-        # viewer's own pid): a debugger session and its paired viewer are
-        # different live endpoints and must never share a pool slot, even
-        # though nothing stops the two pid spaces from colliding.
-        client = self._viewer_clients.get(info.pid)
-        if client is not None:
+        The warm path is a single round-trip: no liveness ping. A
+        transport error (``OSError``; ``ConnectionError`` and timeouts
+        are subclasses) means the pooled socket went stale -- e.g. the
+        endpoint restarted -- so discovery is re-resolved and the client
+        rebuilt once against the fresh record (which may name a new
+        port, token, or even pid), then ``fn`` retried. Safe because
+        every verb is repeat-safe: ``set_view`` is absolute, ``plot``
+        re-displays the same buffer rather than duplicating it, the rest
+        are pure reads, and a repeated hello is harmless. A
+        ``ControlError`` is a real reply from the endpoint and is never
+        retried. Debugger and viewer clients live in separate pools: two
+        live endpoints whose pid spaces could collide must never share a
+        slot.
+        """
+        info = resolve()
+        client = pool.get(info.pid)
+        if client is None:
+            client = ControlClient('127.0.0.1', info.port, info.token)
+            pool[info.pid] = client
+        try:
+            return fn(client)
+        except OSError:
+            client.close()
+            del pool[info.pid]
+            info = resolve()
+            fresh = ControlClient('127.0.0.1', info.port, info.token)
+            pool[info.pid] = fresh
             try:
-                client.ping()
-                return client
+                return fn(fresh)
             except OSError:
-                client.close()
-                del self._viewer_clients[info.pid]
-        client = ControlClient('127.0.0.1', info.port, info.token)
-        self._viewer_clients[info.pid] = client
-        return client
+                # A second transport failure -- e.g. a timeout on a live
+                # but stalled endpoint -- can leave a half-completed
+                # exchange on the socket; if that client stayed pooled, a
+                # late reply would desync request/reply pairing on the
+                # next call. Never keep it.
+                fresh.close()
+                del pool[info.pid]
+                raise
+
+    def _call_debugger(self, session, fn):
+        return self._call_with_retry(
+            self._clients, lambda: self._resolve(session), fn)
+
+    def _call_viewer(self, session, fn):
+        return self._call_with_retry(
+            self._viewer_clients, lambda: self._resolve_viewer(session), fn)
 
     def _resolve(self, session):
         return pick_session(live_sessions(), session)
@@ -180,12 +202,14 @@ class SessionManager:
             return 'viewer', self._resolve_viewer(session)
 
     def list_buffers(self, session) -> dict:
-        kind, info = self._resolve_pixel_source(session)
+        kind, _ = self._resolve_pixel_source(session)
         if kind == 'viewer':
-            buffers = self._viewer_client(info).list_viewer_buffers()
+            buffers = self._call_viewer(
+                session, lambda c: c.list_viewer_buffers())
             return {'symbols': [b['name'] for b in buffers],
                     'stop_generation': 0}
-        symbols, generation = self._client(info).list_symbols()
+        symbols, generation = self._call_debugger(
+            session, lambda c: c.list_symbols())
         return {'symbols': symbols, 'stop_generation': generation}
 
     def fetch(self, session, symbol):
@@ -199,21 +223,44 @@ class SessionManager:
         state, so caching it under a constant key would serve stale
         pixels forever.
         """
-        kind, info = self._resolve_pixel_source(session)
+        kind, _ = self._resolve_pixel_source(session)
         if kind == 'viewer':
-            client = self._viewer_client(info)
-            viewer_meta, raw = client.get_buffer(symbol,
-                                                 max_bytes=self._max_bytes)
+            viewer_meta, raw = self._call_viewer(
+                session, lambda c: c.get_buffer(symbol,
+                                                max_bytes=self._max_bytes))
             meta = to_bridge_meta(viewer_meta)
             return meta, decode_buffer(meta, raw)
 
-        client = self._client(info)
-        generation = client.ping()
-        key = (info.pid, symbol, generation)
-        cached = self._cache.get(key)
+        # The ping is functional, not a liveness probe: it returns the
+        # current stop generation, which keys the per-stop cache. Ping,
+        # cache lookup, and (only on a miss) get_buffer all run on the SAME
+        # client inside ONE retry scope, and the key takes its pid from the
+        # record that scope actually resolved -- a mid-call re-resolution
+        # (endpoint restart, possibly under a new pid) can therefore never
+        # split the key across two endpoints, and a retry re-pings so the
+        # generation always matches the client that served the bytes.
+        used_info = None
+
+        def resolve():
+            nonlocal used_info
+            used_info = self._resolve(session)
+            return used_info
+
+        def ping_then_fetch(client):
+            generation = client.ping()
+            key = (used_info.pid, symbol, generation)
+            cached = self._cache.get(key)
+            if cached is not None:
+                return key, cached, None
+            meta, raw = client.get_buffer(symbol,
+                                          max_bytes=self._max_bytes)
+            return key, None, (meta, raw)
+
+        key, cached, fetched = self._call_with_retry(
+            self._clients, resolve, ping_then_fetch)
         if cached is not None:
             return cached
-        meta, raw = client.get_buffer(symbol, max_bytes=self._max_bytes)
+        meta, raw = fetched
         arr = decode_buffer(meta, raw)
         # Store under the same key we looked up (the ping generation), not
         # meta['stop_generation']: if the stop advanced between ping and
@@ -223,18 +270,17 @@ class SessionManager:
         return meta, arr
 
     def plot(self, session, symbol) -> None:
-        kind, info = self._resolve_pixel_source(session)
+        kind, _ = self._resolve_pixel_source(session)
         if kind == 'viewer':
             raise RuntimeError(
                 'the buffer is already displayed in that viewer')
-        self._client(info).plot(symbol)
+        self._call_debugger(session, lambda c: c.plot(symbol))
 
     def set_view(self, session, **fields) -> dict:
-        return self._viewer_client(self._resolve_viewer(session)) \
-            .set_view(**fields)
+        return self._call_viewer(session, lambda c: c.set_view(**fields))
 
     def get_view(self, session) -> dict:
-        return self._viewer_client(self._resolve_viewer(session)).get_view()
+        return self._call_viewer(session, lambda c: c.get_view())
 
 
 _INSTRUCTIONS = (

--- a/resources/oidmcp/tests/conftest.py
+++ b/resources/oidmcp/tests/conftest.py
@@ -160,6 +160,9 @@ class _FakeViewerEndpoint:
             'buffer': None, 'center': None, 'zoom': None,
             'rotation_deg': None, 'channel': None, 'auto_contrast': False,
         }
+        # Post-hello wire requests served, across all connections; lets
+        # tests assert the warm path is ping-free (one request per call).
+        self.requests_served = 0
         self.token = secrets.token_hex(32)
         self._listener = socket.socket()
         self._listener.bind(('127.0.0.1', 0))
@@ -173,7 +176,8 @@ class _FakeViewerEndpoint:
         # `_FakeViewerEndpoint` on a new port, but possibly the same
         # declared pid if the global `_manager` singleton is reused
         # across tests) silently keep talking to this dead one instead of
-        # failing the pool's ping() health check and reconnecting.
+        # failing the pooled client's next call with an ``OSError``,
+        # which `_call_with_retry` answers by rebuilding the client once.
         self._conns_lock = threading.Lock()
         self._conns = []
         self._thread = threading.Thread(target=self._accept_loop,
@@ -212,6 +216,7 @@ class _FakeViewerEndpoint:
             self._handle(conn, request)
 
     def _handle(self, conn, request):
+        self.requests_served += 1
         method = request.get('method')
         handler = {
             'ping': self._handle_ping,
@@ -282,6 +287,15 @@ class _FakeViewerEndpoint:
                 pass  # peer already gone; nothing to shut down
             conn.close()
         self._thread.join(timeout=2)
+
+    def drop_connections(self):
+        """Sever every accepted connection (the listener stays up),
+        simulating a pooled client whose socket died while the viewer
+        lives on."""
+        with self._conns_lock:
+            conns = list(self._conns)
+        for conn in conns:
+            conn.close()
 
 
 class FakeViewer:

--- a/resources/oidmcp/tests/test_server_tools.py
+++ b/resources/oidmcp/tests/test_server_tools.py
@@ -4,6 +4,7 @@ import pytest
 
 from oidmcp import server
 from oidmcp.analysis import compute_stats
+from oidmcp.protocol import ControlError
 
 
 @pytest.fixture
@@ -283,3 +284,57 @@ def test_list_sessions_pairs_debugger_and_viewer(live_endpoint, live_viewer):
     assert any(d['pid'] == session.pid for d in result['debuggers'])
     assert any(v['pid'] == viewer.pid and v['debugger_pid'] == session.pid
               for v in result['viewers'])
+
+
+# --- pooled-client retry (no per-call liveness ping) --------------------
+
+def test_warm_control_calls_are_single_round_trips(live_viewer):
+    viewer = live_viewer()
+    mgr = server.SessionManager()
+    mgr.set_view(None, zoom=1.5)
+    mgr.get_view(None)
+    # Two calls, two wire requests: no ping precedes a warm call.
+    assert viewer.endpoint.requests_served == 2
+
+
+def test_stale_pooled_client_is_rebuilt_once(live_viewer):
+    viewer = live_viewer()
+    mgr = server.SessionManager()
+    mgr.set_view(None, zoom=1.5)
+    viewer.endpoint.drop_connections()
+    view = mgr.get_view(None)  # transparent reconnect + single retry
+    assert view['zoom'] == pytest.approx(1.5)
+    assert viewer.endpoint.requests_served == 2
+
+
+def test_control_error_reply_is_not_retried(live_viewer):
+    viewer = live_viewer()
+    mgr = server.SessionManager()
+    with pytest.raises(ControlError):
+        mgr.fetch(None, 'missing')
+    # A real error reply must not be blindly re-sent.
+    assert viewer.endpoint.requests_served == 1
+
+
+def test_dead_viewer_propagates_after_one_rebuild(live_viewer):
+    viewer = live_viewer()
+    mgr = server.SessionManager()
+    mgr.set_view(None, zoom=1.0)
+    viewer.endpoint.close()
+    with pytest.raises(OSError):
+        mgr.get_view(None)
+
+
+def test_retry_re_resolves_a_restarted_viewer(live_viewer):
+    # The rebuild must target freshly re-resolved discovery, not the record
+    # captured before the failure: a restarted viewer publishes a new port
+    # and token (same pool key here: both fixtures default to os.getpid()).
+    old = live_viewer(start_time=100.0)
+    mgr = server.SessionManager()
+    mgr.set_view(None, zoom=1.5)         # pools a client to `old`
+    old.endpoint.close()                 # viewer "restarts"...
+    new = live_viewer(start_time=200.0)  # ...republishing discovery
+    view = mgr.set_view(None, zoom=2.0)  # stale socket -> re-resolve -> new
+    assert view['zoom'] == pytest.approx(2.0)
+    assert new.endpoint.requests_served == 1
+    assert old.endpoint.requests_served == 1

--- a/resources/oidmcp/uv.lock
+++ b/resources/oidmcp/uv.lock
@@ -578,7 +578,7 @@ wheels = [
 
 [[package]]
 name = "oidmcp"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -192,6 +192,7 @@ if(OID_BUILD_IMGUI_FRONTEND)
       platform/native_file_dialog.cpp
       host/agent/native_view_model.cpp
       host/agent/agent_server.cpp
+      host/frame_pacer.cpp
       host/agent/discovery_file.cpp
     )
   endif()
@@ -209,9 +210,11 @@ if(OID_BUILD_IMGUI_FRONTEND)
   # They need AppKit/Foundation, plus UniformTypeIdentifiers for UTType.
   if(APPLE)
     target_sources(oidwindow PRIVATE host/app_icon_mac.mm
-                                     platform/native_file_dialog_mac.mm)
+                                     platform/native_file_dialog_mac.mm
+                                     platform/app_nap_mac.mm)
     set_source_files_properties(host/app_icon_mac.mm
                                 platform/native_file_dialog_mac.mm
+                                platform/app_nap_mac.mm
       PROPERTIES COMPILE_OPTIONS "-fobjc-arc")
     target_link_libraries(oidwindow PRIVATE "-framework AppKit"
                                             "-framework Foundation"

--- a/src/host/agent/agent_server.cpp
+++ b/src/host/agent/agent_server.cpp
@@ -28,9 +28,9 @@
 #include <array>
 #include <atomic>
 #include <chrono>
-#include <cstdint>
 #include <exception>
 #include <format>
+#include <iostream>
 #include <memory>
 #include <random>
 #include <span>
@@ -50,6 +50,16 @@
 namespace oid::host::agent {
 
 namespace {
+
+// Logged once per process: a throwing enqueue listener silently degrades
+// wake latency to per-frame draining only, which is otherwise invisible.
+void log_listener_failure_once(const char* what) {
+    static std::atomic_flag logged;
+    if (!logged.test_and_set()) {
+        std::cerr << "[oid-agent] enqueue listener threw (" << what
+                  << "); requests are still served by the per-frame drain\n";
+    }
+}
 
 // Mirrors agentendpoint.py's MAX_CLIENTS: ceiling on simultaneously served
 // connections; connections beyond this are closed immediately.
@@ -449,8 +459,9 @@ void AgentServer::serve_client(asio::io_context& conn_ctx,
 std::future<Reply> AgentServer::enqueue(nlohmann::json request, bool* authed) {
     std::promise<Reply> promise;
     std::future<Reply> future = promise.get_future();
+    std::function<void()> on_enqueue;
     {
-        std::scoped_lock lock(queue_mutex_);
+        const std::scoped_lock lock(queue_mutex_);
         if (stopped_.load()) {
             // Shutting down: a serve thread can reach here concurrently
             // with stop() (e.g. it finished decode_frame just as stop()
@@ -462,6 +473,24 @@ std::future<Reply> AgentServer::enqueue(nlohmann::json request, bool* authed) {
         } else {
             pending_.emplace_back(
                 std::move(request), std::move(promise), authed);
+            // Copied under lock, invoked outside it: slow listener
+            // must not stall other serve threads' enqueues or drain().
+            on_enqueue = enqueue_listener_;
+        }
+    }
+    if (on_enqueue) {
+        // Exception boundary: this runs on a serve thread, where an escaping
+        // exception would unwind the request loop and drop the client (or
+        // terminate). The listener contract says cheap and nonthrowing (it is
+        // FramePacer::wake), but a listener bug must not destabilize the
+        // transport, so failures are absorbed: the request is already queued
+        // and the per-frame drain still serves it.
+        try {
+            on_enqueue();
+        } catch (const std::exception& e) { // NOSONAR - deliberate boundary
+            log_listener_failure_once(e.what());
+        } catch (...) { // NOSONAR - deliberately absorb listener failures
+            log_listener_failure_once("unknown exception");
         }
     }
     return future;
@@ -484,6 +513,11 @@ void AgentServer::drain() {
             item.reply.set_exception(std::current_exception());
         }
     }
+}
+
+void AgentServer::set_enqueue_listener(std::function<void()> listener) {
+    const std::scoped_lock lock(queue_mutex_);
+    enqueue_listener_ = std::move(listener);
 }
 
 void AgentServer::stop() {

--- a/src/host/agent/agent_server.h
+++ b/src/host/agent/agent_server.h
@@ -29,6 +29,7 @@
 #include <atomic>
 #include <cstddef>
 #include <filesystem>
+#include <functional>
 #include <future>
 #include <memory>
 #include <mutex>
@@ -77,6 +78,15 @@ class AgentServer {
     // Dispatches every request queued since the last call, on the calling
     // thread. Intended to be invoked once per frame from the main loop.
     void drain();
+
+    // Registers a listener to be invoked (without arguments) when a request is
+    // queued. Thread-safe; the listener is copied under lock and invoked
+    // outside the lock to avoid stalling other serve threads. Passing a
+    // default-constructed std::function (which is nullptr-like) deregisters
+    // the listener (e.g., to restore a no-op). Intended for the FramePacer to
+    // use: wake itself and force the main loop to drain() sooner on each
+    // request, instead of waiting for the next scheduled frame.
+    void set_enqueue_listener(std::function<void()> listener);
 
     // Stops accepting connections, joins the accept thread, and removes
     // the discovery file. Idempotent; also invoked by the destructor.
@@ -166,6 +176,11 @@ class AgentServer {
     // handle_accept() caps concurrent connections at MAX_CLIENTS. drain()
     // therefore processes at most MAX_CLIENTS requests per frame.
     std::vector<PendingRequest> pending_;
+
+    // Listener to invoke when a request is queued. Guarded by queue_mutex_.
+    // Thread-safe: copied under lock, invoked outside it to avoid stalling
+    // other serve threads' enqueues or drain().
+    std::function<void()> enqueue_listener_;
 
     std::filesystem::path discovery_path_;
     bool discovery_written_ = false;

--- a/src/host/frame_pacer.cpp
+++ b/src/host/frame_pacer.cpp
@@ -1,0 +1,84 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "host/frame_pacer.h"
+
+namespace oid::host {
+
+FramePacer::FramePacer(std::chrono::nanoseconds period)
+    : period_{period}, deadline_{Clock::now() + period} {}
+
+void FramePacer::wake() {
+    {
+        const std::scoped_lock lock(mutex_);
+        ++wakes_;
+    }
+    cv_.notify_one();
+}
+
+void FramePacer::set_period(std::chrono::nanoseconds period) {
+    {
+        const std::scoped_lock lock(mutex_);
+        period_ = period;
+        // Re-anchor so the new cadence applies now, not after the old
+        // deadline expires.
+        deadline_ = Clock::now() + period;
+    }
+    // A pace() parked on the old (possibly much later) deadline must
+    // re-evaluate against the new one.
+    cv_.notify_one();
+}
+
+void FramePacer::pace(const std::function<void()>& on_wake) {
+    std::unique_lock lock(mutex_);
+    for (;;) {
+        while (consumed_ < wakes_ && Clock::now() < deadline_) {
+            // Coalesce: one on_wake serves the whole pending burst (drain()
+            // empties the queue), so N rapid wakes cost one dispatch. The
+            // deadline bound keeps a hot client that re-wakes during
+            // on_wake() from starving the frame: once the deadline passes,
+            // surplus wakes stay pending and the next pace() serves them on
+            // entry.
+            consumed_ = wakes_;
+            lock.unlock();
+            if (on_wake) {
+                on_wake();
+            }
+            lock.lock();
+        }
+        if (Clock::now() >= deadline_) {
+            break;
+        }
+        // Spurious wakeups are harmless: loop re-checks wake
+        // counter and deadline.
+        cv_.wait_until(lock, deadline_);
+    }
+    deadline_ += period_;
+    if (const auto now = Clock::now(); deadline_ < now) {
+        deadline_ = now + period_;
+    }
+}
+
+} // namespace oid::host

--- a/src/host/frame_pacer.h
+++ b/src/host/frame_pacer.h
@@ -1,0 +1,76 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef HOST_FRAME_PACER_H_
+#define HOST_FRAME_PACER_H_
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+
+namespace oid::host {
+
+// Paces agent-enabled render loop in place of vsync. With agent
+// endpoint up, swap no longer blocks (vsync off), so the loop calls
+// pace() each frame: sleeps on condition variable until the next
+// frame deadline, so OS cannot stretch it the way it stretches a
+// background window's present. An agent request wake()s the wait,
+// drained immediately instead of waiting for the next presented frame.
+class FramePacer {
+  public:
+    explicit FramePacer(std::chrono::nanoseconds period);
+
+    // Thread-safe; called from any thread (an AgentServer serve thread,
+    // right after it queues a request). Interrupts pace() in progress; if
+    // none in progress, it is served on the next pace() entry.
+    void wake();
+
+    // Thread-safe; the new cadence takes effect immediately (the current
+    // deadline is re-anchored to now + period). Used when the window moves
+    // to a monitor with a different refresh rate.
+    void set_period(std::chrono::nanoseconds period);
+
+    // GL-thread only. Serves all pending burst wake() calls, one per
+    // on_wake() invocation, until the frame deadline passes, advances the
+    // deadline by one period -- clamped to now + period on overrun so a
+    // slow frame never schedules a catch-up burst -- then returns.
+    void pace(const std::function<void()>& on_wake);
+
+  private:
+    using Clock = std::chrono::steady_clock;
+
+    std::chrono::nanoseconds period_;
+    Clock::time_point deadline_;
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    std::uint64_t wakes_ = 0;    // total wake() calls
+    std::uint64_t consumed_ = 0; // wakes pace() has already served
+};
+
+} // namespace oid::host
+
+#endif // HOST_FRAME_PACER_H_

--- a/src/host/glfw_host_backend.cpp
+++ b/src/host/glfw_host_backend.cpp
@@ -109,21 +109,8 @@ void GlfwHostBackend::end_frame() {
     glfwSwapBuffers(window_);
 }
 
-void GlfwHostBackend::shutdown() {
-    if (window_ != nullptr) {
-        glfwDestroyWindow(window_);
-        window_ = nullptr;
-        glfwTerminate();
-    }
-}
-
-std::pair<int, int> GlfwHostBackend::window_size() const {
-    int w = 0;
-    int h = 0;
-    if (window_ != nullptr) {
-        glfwGetWindowSize(window_, &w, &h);
-    }
-    return {w, h};
+void GlfwHostBackend::set_vsync(bool enabled) {
+    glfwSwapInterval(enabled ? 1 : 0);
 }
 
 namespace {
@@ -146,6 +133,73 @@ bool platform_supports_window_position() {
 }
 
 } // namespace
+
+int GlfwHostBackend::refresh_rate_hz() const {
+    // Pace from the monitor actually showing the window -- the one whose
+    // area overlaps it most -- not the primary: on mixed-refresh
+    // multi-monitor setups the primary's rate would pace an agent run too
+    // slow (or needlessly fast) on the other monitor.
+    // (glfwGetWindowMonitor only answers for fullscreen windows.) Falls
+    // back to the primary when undetermined, and to 60 Hz when GLFW
+    // cannot say.
+    GLFWmonitor* best = glfwGetPrimaryMonitor();
+    // Overlap needs the window's global position, which Wayland (and the
+    // Emscripten shim) never provide -- there the primary is the best
+    // answer available, without error-callback spam.
+    if (window_ != nullptr && platform_supports_window_position()) {
+        int wx = 0;
+        int wy = 0;
+        int ww = 0;
+        int wh = 0;
+        glfwGetWindowPos(window_, &wx, &wy);
+        glfwGetWindowSize(window_, &ww, &wh);
+        int monitor_count = 0;
+        GLFWmonitor** monitors = glfwGetMonitors(&monitor_count);
+        int best_overlap = 0;
+        for (int i = 0; i < monitor_count; ++i) {
+            const GLFWvidmode* m = glfwGetVideoMode(monitors[i]);
+            if (m == nullptr) {
+                continue;
+            }
+            int mx = 0;
+            int my = 0;
+            glfwGetMonitorPos(monitors[i], &mx, &my);
+            const int ox = (std::max)(0,
+                                      (std::min)(wx + ww, mx + m->width) -
+                                          (std::max)(wx, mx));
+            const int oy = (std::max)(0,
+                                      (std::min)(wy + wh, my + m->height) -
+                                          (std::max)(wy, my));
+            const int overlap = ox * oy;
+            if (overlap > best_overlap) {
+                best_overlap = overlap;
+                best = monitors[i];
+            }
+        }
+    }
+    if (best == nullptr) {
+        return 60; // headless: no monitor to ask
+    }
+    const GLFWvidmode* mode = glfwGetVideoMode(best);
+    return (mode != nullptr && mode->refreshRate > 0) ? mode->refreshRate : 60;
+}
+
+void GlfwHostBackend::shutdown() {
+    if (window_ != nullptr) {
+        glfwDestroyWindow(window_);
+        window_ = nullptr;
+        glfwTerminate();
+    }
+}
+
+std::pair<int, int> GlfwHostBackend::window_size() const {
+    int w = 0;
+    int h = 0;
+    if (window_ != nullptr) {
+        glfwGetWindowSize(window_, &w, &h);
+    }
+    return {w, h};
+}
 
 std::pair<int, int> GlfwHostBackend::window_position() const {
     int x = 0;

--- a/src/host/glfw_host_backend.h
+++ b/src/host/glfw_host_backend.h
@@ -56,6 +56,17 @@ class GlfwHostBackend final : public HostBackend {
     void end_frame() override;
     void shutdown() override;
 
+    // Toggle vsync on the current GL context (initialize() leaves it
+    // current and defaults to on). Agent runs turn it off: FramePacer
+    // paces the loop instead, so the swap must not block on a present the
+    // OS may throttle for a background window.
+    void set_vsync(bool enabled);
+
+    // Refresh rate, in Hz, of the monitor showing the window (greatest
+    // overlap); the primary's when undetermined (no window yet, or the
+    // platform hides window positions), 60 when GLFW cannot say.
+    [[nodiscard]] int refresh_rate_hz() const;
+
     [[nodiscard]] GLFWwindow* window() const {
         return window_;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,6 +48,8 @@
 #if !defined(__EMSCRIPTEN__)
 #include "host/agent/agent_server.h"
 #include "host/agent/native_view_model.h"
+#include "host/frame_pacer.h"
+#include "platform/app_nap.h"
 #endif
 #include "host/cli_options.h"
 #include "host/frame_loop.h"
@@ -386,6 +388,20 @@ struct FrameContext {
 void drain_agent(FrameContext& ctx) {
     if (ctx.agent != nullptr) {
         ctx.agent->drain();
+    }
+}
+
+// Re-derives the agent-run pacing period from the monitor currently under
+// the window (the display can change when the window is dragged to a
+// different-Hz monitor). Render cadence only -- agent latency is
+// wake-driven regardless of the period.
+void repace_if_monitor_changed(const oid::host::GlfwHostBackend& backend,
+                               oid::host::FramePacer& pacer,
+                               int& paced_hz) {
+    if (const int hz = backend.refresh_rate_hz(); hz != paced_hz) {
+        paced_hz = hz;
+        pacer.set_period(std::chrono::nanoseconds{std::chrono::seconds{1}} /
+                         hz);
     }
 }
 #else
@@ -892,6 +908,14 @@ int main(int argc, char** argv) {
     // requests for the per-frame drain() call below to dispatch on this
     // (the GL) thread. Native-only: the Emscripten build supplies its own
     // agent glue via the out-of-tree platform port and has no asio.
+    // Paces the agent-run render loop (vsync is off then). Declared BEFORE
+    // agent_server so it is destroyed after it on every exit path: even an
+    // exception unwind that never reaches the explicit stop() below runs
+    // ~AgentServer -- whose stop() joins every serve thread -- before the
+    // pacer goes away, so a serve thread can never wake() a destroyed
+    // pacer. (Initialization order is independent: the optionals are
+    // emplaced in dependency order inside the try block below.)
+    std::optional<oid::host::FramePacer> pacer;
     std::optional<oid::host::agent::NativeViewModel> agent_model;
     std::optional<oid::host::agent::AgentServer> agent_server;
     if (const char* v = std::getenv("OID_AGENT");
@@ -907,9 +931,22 @@ int main(int argc, char** argv) {
             agent_server.emplace(*agent_model,
                                  oid::host::agent::AgentServerConfig{
                                      /*enabled=*/true, cli.agent_debugger_pid});
+            pacer.emplace(std::chrono::nanoseconds{std::chrono::seconds{1}} /
+                          backend.refresh_rate_hz());
+            agent_server->set_enqueue_listener([&p = *pacer] { p.wake(); });
+            oid::platform::begin_agent_activity();
+            // Only after the endpoint is actually up, and as the very last
+            // step of agent startup: any earlier throw falls back to the
+            // default vsync loop, so vsync is never left off on a path
+            // that ends in plain loop.run().
+            backend.set_vsync(false);
         } catch (const std::exception& e) {
             agent_server.reset();
             agent_model.reset();
+            pacer.reset();
+            // Idempotent (and a no-op if begin never ran): the fallback
+            // non-agent run must not keep the App Nap opt-out active.
+            oid::platform::end_agent_activity();
             std::cerr << "[oid] agent endpoint disabled: " << e.what() << "\n";
         }
     }
@@ -1048,13 +1085,50 @@ int main(int argc, char** argv) {
                                   persist_settings_if_dirty(ctx);
                               }};
 
+#if !defined(__EMSCRIPTEN__)
+    if (pacer) {
+        // Agent run: the swap returns immediately (vsync off above), and
+        // pace() owns the frame cadence. A request wakes the pacing wait
+        // and is drained within ~1 ms regardless of focus/occlusion,
+        // instead of once per (possibly OS-throttled) present.
+        // The display can change under us (window dragged to a monitor
+        // with a different refresh rate); re-derive the pacing period about
+        // once a second. Render cadence only -- agent latency is
+        // wake-driven regardless of the period.
+        constexpr int REFRESH_RECHECK_FRAMES = 60;
+        int paced_hz = backend.refresh_rate_hz();
+        while (loop.tick()) {
+            if (loop.frame_count() % REFRESH_RECHECK_FRAMES == 0) {
+                repace_if_monitor_changed(backend, *pacer, paced_hz);
+            }
+            pacer->pace([&ctx] {
+                // Same poll-before-read contract as the frame lambda: the
+                // agent is a model consumer, so inbound IPC is reconciled
+                // into the model before draining -- a gap-drained readback
+                // must not answer with the previous frame's state, and a
+                // gap-applied set_view must land on the current model.
+                // Only the minimal reconcile runs here: the thumbnail
+                // bookkeeping in poll_ipc_and_update_thumbnails is
+                // render-side, budgeted once per frame, and never read by
+                // the agent.
+                ctx.ipc.poll();
+                drain_agent(ctx);
+            });
+        }
+    } else {
+        loop.run();
+    }
+#else
     loop.run();
+#endif
+
 #if !defined(__EMSCRIPTEN__)
     // Stop accepting/serving agent connections before the GL context and
     // Stage/Buffer state below are torn down, so no in-flight drain() call
     // can touch them.
     if (agent_server) {
         agent_server->stop();
+        oid::platform::end_agent_activity();
     }
 #endif
     // Force a final save if a debounced write was still pending when the

--- a/src/platform/app_nap.h
+++ b/src/platform/app_nap.h
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef PLATFORM_APP_NAP_H_
+#define PLATFORM_APP_NAP_H_
+
+namespace oid::platform {
+
+#if defined(__APPLE__)
+// Registers an NSProcessInfo activity while the agent endpoint is up, so
+// App Nap cannot stretch the FramePacer's timers when the viewer is
+// backgrounded. Idempotent; end without begin is a no-op. Not thread-safe:
+// both functions are for main()'s startup/shutdown path on the GL thread --
+// add external synchronization before calling them from anywhere else.
+void begin_agent_activity();
+void end_agent_activity();
+#else
+inline void begin_agent_activity() {
+    // No-op: App Nap is a macOS-only mechanism; no other platform throttles
+    // the process in a way this assertion could lift.
+}
+inline void end_agent_activity() {
+    // No-op: nothing is ever registered on non-macOS platforms.
+}
+#endif
+
+} // namespace oid::platform
+
+#endif // PLATFORM_APP_NAP_H_

--- a/src/platform/app_nap_mac.mm
+++ b/src/platform/app_nap_mac.mm
@@ -1,0 +1,57 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+
+#include "platform/app_nap.h"
+
+namespace oid::platform {
+
+namespace {
+// Token for the registered activity. Retained automatically under ARC.
+id activity_token = nil;
+} // namespace
+
+void begin_agent_activity() {
+    if (activity_token != nil) {
+        return;
+    }
+    const NSActivityOptions options =
+        NSActivityUserInitiatedAllowingIdleSystemSleep |
+        NSActivityLatencyCritical;
+    activity_token = [[NSProcessInfo processInfo]
+        beginActivityWithOptions:options
+                          reason:@"OID agent endpoint active"];
+}
+
+void end_agent_activity() {
+    if (activity_token == nil) {
+        return;
+    }
+    [[NSProcessInfo processInfo] endActivity:activity_token];
+    activity_token = nil;
+}
+
+} // namespace oid::platform

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -886,6 +886,15 @@ if(OID_BUILD_IMGUI_FRONTEND)
     target_link_libraries(wire_buffer_type_test PRIVATE GTest::gtest_main GTest::gtest)
     add_test(NAME WireBufferTypeTests COMMAND wire_buffer_type_test)
 
+    # FramePacer: deterministic ordering/count tests for agent-run frame
+    # pacing (pending-wake service, burst coalescing, deadline return).
+    add_executable(frame_pacer_test host/frame_pacer_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/host/frame_pacer.cpp)
+    target_include_directories(frame_pacer_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+    target_link_libraries(frame_pacer_test PRIVATE Threads::Threads GTest::gtest_main GTest::gtest)
+    add_test(NAME FramePacerTests COMMAND frame_pacer_test)
+
     # Test AgentCore's request dispatch out of host/agent/agent_core.cpp
     # against FakeViewModel: hello/ping/list_buffers/get_buffer/get_view/
     # set_view semantics and error codes. Pure logic -- vendored

--- a/tests/host/agent/agent_server_test.cpp
+++ b/tests/host/agent/agent_server_test.cpp
@@ -445,3 +445,25 @@ TEST_F(AgentServerTest, DrainRunsOnCallingThread) {
 
     server.stop();
 }
+
+TEST_F(AgentServerTest, EnqueueListenerFiresWhenARequestIsQueued) {
+    // The native main loop registers a listener that wakes its FramePacer;
+    // this pins the seam: queuing a decoded request must invoke it.
+    FakeViewModel model;
+    AgentServerConfig cfg;
+    cfg.enabled = true;
+    AgentServer server(model, cfg);
+
+    std::atomic notifications{0};
+    server.set_enqueue_listener([&notifications] { ++notifications; });
+
+    asio::ip::tcp::socket sock = connect_to(server);
+    send_frame(sock, {{"method", "hello"}, {"token", server.token()}});
+    drain_until_reply(server, sock);
+    (void)read_frame(sock); // hello reply
+
+    // Exactly one frame was sent, so exactly one notification: an accidental
+    // double-notify per enqueue would be a real (if benign-looking) bug.
+    EXPECT_EQ(notifications.load(), 1);
+    server.stop();
+}

--- a/tests/host/frame_pacer_test.cpp
+++ b/tests/host/frame_pacer_test.cpp
@@ -1,0 +1,128 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "host/frame_pacer.h"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using oid::host::FramePacer;
+
+// All assertions are on ordering/counts, never durations: periods are
+// milliseconds-scale so the suite stays fast, and no test asserts how long
+// anything took (CI machines stall arbitrarily).
+
+TEST(FramePacer, ReturnsAtDeadlineWithoutWakes) {
+    FramePacer pacer{std::chrono::milliseconds(5)};
+    int calls = 0;
+    pacer.pace([&calls] { ++calls; });
+    EXPECT_EQ(calls, 0);
+}
+
+TEST(FramePacer, PendingWakeIsServedOnEntry) {
+    // 100 ms period: the pending wake must be served before the deadline
+    // check, so the period is the tolerance against a CI scheduling stall
+    // between wake() and pace() -- 5 ms was too tight for loaded VMs.
+    FramePacer pacer{std::chrono::milliseconds(100)};
+    pacer.wake();
+    int calls = 0;
+    pacer.pace([&calls] { ++calls; });
+    EXPECT_EQ(calls, 1);
+}
+
+TEST(FramePacer, BurstOfWakesCoalescesIntoOneDrain) {
+    FramePacer pacer{std::chrono::milliseconds(100)};
+    pacer.wake();
+    pacer.wake();
+    pacer.wake();
+    int calls = 0;
+    pacer.pace([&calls] { ++calls; });
+    EXPECT_EQ(calls, 1);
+}
+
+TEST(FramePacer, WakeDuringPaceRunsCallback) {
+    // No single fragile timing window: the waker retries until a wake is
+    // served, and pace() is re-entered until one lands -- a wake falling
+    // between two pace() calls is served on the next entry, so both loops
+    // terminate under any scheduling.
+    FramePacer pacer{std::chrono::milliseconds(5)};
+    std::atomic calls{0};
+    std::atomic done{false};
+    std::jthread waker([&pacer, &done] {
+        while (!done.load()) {
+            pacer.wake();
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    });
+    while (calls.load() == 0) {
+        pacer.pace([&calls] { ++calls; });
+    }
+    done.store(true);
+    EXPECT_GE(calls.load(), 1);
+}
+
+TEST(FramePacer, WakeStormCannotStarveTheDeadline) {
+    // A hot client can wake() again from inside on_wake (its reply lets it
+    // send the next request immediately). pace() must still return once the
+    // deadline passes -- with an unbounded drain loop this test never
+    // returns instead of failing an assertion.
+    FramePacer pacer{std::chrono::milliseconds(5)};
+    int calls = 0;
+    pacer.wake();
+    pacer.pace([&pacer, &calls] {
+        ++calls;
+        pacer.wake(); // reentrant: keeps the backlog permanently non-empty
+    });
+    EXPECT_GE(calls, 1);
+}
+
+TEST(FramePacer, WakeAfterPaceReturnsIsSafeAndCarriesOver) {
+    FramePacer pacer{std::chrono::milliseconds(100)};
+    int calls = 0;
+    pacer.pace([&calls] { ++calls; });
+    pacer.wake(); // nobody waiting: must neither crash nor block
+    pacer.pace([&calls] { ++calls; });
+    EXPECT_EQ(calls, 1);
+}
+
+TEST(FramePacer, SetPeriodKeepsServingWakes) {
+    // A cadence change (window moved to a different-Hz monitor) must not
+    // disrupt wake service: a pending wake is still served on the next
+    // pace() entry, and pace() still returns.
+    FramePacer pacer{std::chrono::milliseconds(100)};
+    int calls = 0;
+    pacer.pace([&calls] { ++calls; });
+    pacer.set_period(std::chrono::milliseconds(50));
+    pacer.wake();
+    pacer.pace([&calls] { ++calls; });
+    EXPECT_EQ(calls, 1);
+}
+
+} // namespace


### PR DESCRIPTION
## Agent responsiveness

Follow-up to #984. Payload-free control calls (`set_view`/`get_view`) felt slow from an MCP client because two structural gates compound: the agent drain ran once per presented frame — and macOS deprioritizes a background window's present, collapsing the drain cadence with it — and the pooled oid-mcp client pinged before every reused request (≥2 round-trips per call).

### Mechanism

- **`FramePacer`** — with `OID_AGENT=1`, vsync goes off (only after the endpoint actually starts; every failure path keeps the default vsync loop) and the loop paces itself with an interruptible CV wait at the refresh rate of the monitor showing the window (best-overlap selection, Wayland-safe, re-derived about once a second if the window moves). An enqueued agent request wakes the wait and is drained in ~1 ms regardless of focus or occlusion. Wake bursts coalesce and are deadline-bounded, so a hot client cannot starve rendering; gap drains run `ipc.poll()` first, honoring the same poll-before-read contract as the frame lambda.
- **`AgentServer::set_enqueue_listener`** — serve threads wake the pacer the moment a request is queued; a throwing listener is absorbed at the boundary (logged once) so it can never drop a connection.
- **App Nap opt-out (macOS)** — an `NSProcessInfo` activity while the endpoint is up, released on shutdown and on the startup failure path.
- **oid-mcp ping drop** — a warm control call is now one round-trip. A stale pooled socket surfaces as `OSError`, discovery is re-resolved (new port/token/pid reachable), the client is rebuilt once, and the repeat-safe call retried; a second failure evicts the client so a half-completed exchange can never desync a later reply. The debugger-path fetch keeps its functional generation ping, with ping + cache lookup + `get_buffer` in one retry scope so the cache key always matches the endpoint that served the bytes.
- **Default (non-agent) runs are byte-for-byte unchanged**, and wasm is structurally untouched (its glue calls `AgentCore::handle` synchronously).

### Verification

- 36 native tests (7 FramePacer tests assert ordering/counts only — no wall-clock CI assertions), 194 oidmcp tests.
- Downstream non-native port against this branch: wasm `build:viewer`, `tsc`, 250 node tests — all pass.
- Whole-branch review: Ready, no critical/important findings; 12 CI/SonarCloud/Qodo rounds with every finding fixed or answered on its thread.
- Live acceptance: with the viewer backgrounded under an MCP client, `set_view`/`get_view` respond instantly.

All review follow-ups landed on-branch; a post-merge simplification idea (GLFW-built-in pacing, connect-per-call MCP) is recorded in the sibling docs repo, where the spec and implementation plan also live.
