### PR TITLE
feat(perf): primary-rate agent pacing + connect-per-call MCP (post-#988)

### DIFF
--- a/resources/oidmcp/acceptance/README.md
+++ b/resources/oidmcp/acceptance/README.md
@@ -1,0 +1,72 @@
+# Agent-endpoint acceptance scripts
+
+Live-acceptance harness for the OID viewer's agent endpoint. These verify the
+property that unit tests cannot: that a **backgrounded** viewer window still
+services agent requests promptly. That behaviour depends on runtime OS event
+scheduling (macOS throttles a non-active window's event loop), so it must be
+measured against a real, backgrounded window.
+
+They talk to a live viewer through the same `oidmcp` client the MCP server
+uses, so they must run in the package's environment (`uv run`).
+
+## Why "backgrounded" matters
+
+The viewer paces its render loop with a condition variable (`FramePacer`) and
+wakes it from the serve thread the moment a request is queued, so latency is
+independent of window focus. A design that instead waited on the GLFW event
+loop (`glfwWaitEventsTimeout` + `glfwPostEmptyEvent`) measured ~90x slower
+here while backgrounded, because macOS delivers a non-active window's posted
+events only at the timeout — which is exactly why this harness exists. Always
+click another app so the OID window is **not** frontmost before measuring.
+
+## Usage
+
+Build the viewer, then launch it with the agent endpoint enabled and a buffer
+to look at (any image or `.npy`; `gen_image.py` writes a colourful one):
+
+```bash
+# from the repo root
+python resources/oidmcp/acceptance/gen_image.py /tmp/oid_vis.npy
+OID_AGENT=1 build/src/oidwindow --open /tmp/oid_vis.npy &
+# now click another app so the OID window is backgrounded
+```
+
+Then, from this directory's package environment:
+
+```bash
+cd resources/oidmcp
+
+# Quantitative: per-request round-trip latency against the backgrounded window.
+# A working wake lands ~1 ms; a dead/throttled wake sits near half a refresh
+# period (~8 ms at 60 Hz), which "feels instant" would mask.
+uv run python acceptance/latency.py
+
+# Visual: animate the view (rotation + zoom + pan) via set_view; watch the
+# backgrounded window render at the monitor rate. Smooth == the paced loop
+# renders while inactive.
+uv run python acceptance/spin.py --seconds 12
+```
+
+Both discover the viewer automatically via the agent discovery directory
+(`OID_AGENT_DIR`, or the per-user default), so no pid/port is needed.
+
+## IPC-push path (buffers pushed from the debugger side)
+
+The two scripts above exercise the *agent* path (control calls waking the
+render loop). The other half is the *IPC* path: buffers pushed over the
+debugger->viewer socket, picked up by the viewer's periodic `ipc.poll()` each
+frame rather than by a wake. The repo already ships a check for it -- the
+plugin's test mode pushes two sample buffers to a freshly spawned viewer over
+the real IPC transport:
+
+```bash
+# from an install tree (out/OpenImageDebugger), using the Homebrew python3 on macOS
+OID_AGENT=1 python3 out/OpenImageDebugger/oid.py --test
+```
+
+A viewer opens showing `sample_buffer_1` (colour pattern) and `sample_buffer_2`
+(Mandelbrot). Background it, then drive `spin.py` against it to confirm the
+paced loop keeps rendering the IPC-pushed buffer while inactive. Because the
+FramePacer keeps the loop iterating at the monitor period regardless of focus,
+a debugger-pushed buffer repaints within ~one period (~17 ms at 60 Hz) even
+backgrounded -- the same liveness the agent-latency numbers above prove.

--- a/resources/oidmcp/acceptance/gen_image.py
+++ b/resources/oidmcp/acceptance/gen_image.py
@@ -1,0 +1,32 @@
+"""Write a colourful test .npy (size x size x 3 uint8) for the acceptance viewer.
+
+The pattern -- red/green ramps, a blue checkerboard, and a white diagonal
+stripe -- makes rotation and zoom unmistakable when driving spin.py.
+"""
+import argparse
+
+import numpy as np
+
+
+def make_image(size: int = 256) -> np.ndarray:
+    y, x = np.mgrid[0:size, 0:size]
+    img = np.zeros((size, size, 3), np.uint8)
+    img[..., 0] = x.astype(np.uint8)                                 # red ramp L->R
+    img[..., 1] = y.astype(np.uint8)                                 # green ramp T->B
+    img[..., 2] = (((x // 32 + y // 32) % 2) * 255).astype(np.uint8)  # blue checker
+    img[np.abs(x - y) < 4] = 255                                     # white diagonal
+    return img
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('path', help='output .npy path, e.g. /tmp/oid_vis.npy')
+    parser.add_argument('--size', type=int, default=256)
+    args = parser.parse_args()
+    img = make_image(args.size)
+    np.save(args.path, img)
+    print(f'wrote {args.path} {img.shape} {img.dtype}')
+
+
+if __name__ == '__main__':
+    main()

--- a/resources/oidmcp/acceptance/latency.py
+++ b/resources/oidmcp/acceptance/latency.py
@@ -1,0 +1,49 @@
+"""Measure agent round-trip latency against a live (ideally backgrounded) viewer.
+
+Uses one persistent connection so the number isolates the viewer's GL-thread
+wake latency (not per-call connect cost). Launch a viewer with OID_AGENT=1,
+click another app so it is backgrounded, then run this.
+
+A working condition-variable wake lands ~1 ms regardless of focus. A wake that
+depends on the OS event loop (throttled for a non-active window) instead sits
+near half a refresh period (~8 ms at 60 Hz) -- imperceptible to "feels
+instant", which is why this measures rather than eyeballs.
+"""
+import argparse
+import statistics
+import time
+
+from oidmcp import discovery
+from oidmcp.protocol import ControlClient
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--calls', type=int, default=100)
+    args = parser.parse_args()
+
+    viewers = discovery.live_viewers()
+    if not viewers:
+        raise SystemExit('no live OID viewer found; launch one with OID_AGENT=1')
+    viewer = viewers[0]
+
+    client = ControlClient('127.0.0.1', viewer.port, viewer.token)
+    latencies = []
+    try:
+        for _ in range(args.calls):
+            start = time.perf_counter()
+            client.get_view()
+            latencies.append((time.perf_counter() - start) * 1000)
+    finally:
+        client.close()
+
+    latencies.sort()
+    n = len(latencies)
+    print(f'{n} get_view round-trips (persistent connection)')
+    print(f'  median={statistics.median(latencies):.3f} ms  '
+          f'p90={latencies[int(n * 0.9)]:.3f} ms  '
+          f'max={latencies[-1]:.3f} ms')
+
+
+if __name__ == '__main__':
+    main()

--- a/resources/oidmcp/acceptance/spin.py
+++ b/resources/oidmcp/acceptance/spin.py
@@ -1,0 +1,72 @@
+"""Animate the view (rotation + zoom + pan) to confirm a backgrounded viewer renders.
+
+Launch a viewer with OID_AGENT=1 and a buffer (see gen_image.py), background it,
+then run this and watch: smooth rotation, zoom pulsing, and the center orbiting
+means the paced render loop keeps running at the monitor rate while the window
+is inactive. The printed latency is the per-update round-trip.
+
+All three motions are driven through set_view, so they work on any loaded buffer
+-- including one pushed over the debugger IPC path.
+"""
+import argparse
+import math
+import statistics
+import time
+
+from oidmcp import discovery
+from oidmcp.protocol import ControlClient
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--seconds', type=float, default=12.0)
+    parser.add_argument('--fps', type=float, default=60.0)
+    parser.add_argument('--pan-radius', type=float, default=50.0,
+                        help='center orbit radius in buffer pixels')
+    args = parser.parse_args()
+
+    viewers = discovery.live_viewers()
+    if not viewers:
+        raise SystemExit(
+            'no live OID viewer found; launch one with OID_AGENT=1 and a buffer')
+    viewer = viewers[0]
+
+    client = ControlClient('127.0.0.1', viewer.port, viewer.token)
+    origin = client.get_view().get('center', [0.0, 0.0])  # orbit around current center
+    print(f'Animating the (ideally backgrounded) window for ~{args.seconds:.0f}s '
+          '-- rotation + zoom + pan; watch it move smoothly...')
+
+    latencies = []
+    period = 1.0 / args.fps
+    start = time.perf_counter()
+    end = start + args.seconds
+    next_tick = start
+    try:
+        while time.perf_counter() < end:
+            t = time.perf_counter() - start
+            rotation = (t * 90.0) % 360.0                    # 90 deg/s
+            zoom = 2.0 + 1.2 * math.sin(t * 1.5)             # pulse ~0.8..3.2
+            orbit = t * 2.0                                  # rad/s
+            center = [origin[0] + args.pan_radius * math.cos(orbit),
+                      origin[1] + args.pan_radius * math.sin(orbit)]
+            call = time.perf_counter()
+            client.set_view(rotation_deg=rotation, zoom=zoom, center=center)
+            latencies.append((time.perf_counter() - call) * 1000)
+            next_tick += period
+            slack = next_tick - time.perf_counter()
+            if slack > 0:
+                time.sleep(slack)
+        client.set_view(rotation_deg=0.0, zoom=3.5, center=origin)  # clean view
+    finally:
+        client.close()
+
+    latencies.sort()
+    n = len(latencies)
+    print(f'sent {n} set_view updates (~{n / args.seconds:.0f}/s)')
+    print(f'  latency median={statistics.median(latencies):.2f} ms  '
+          f'p90={latencies[int(n * 0.9)]:.2f} ms  '
+          f'max={latencies[-1]:.2f} ms')
+
+
+if __name__ == '__main__':
+    main()

--- a/resources/oidmcp/oidmcp/buffers.py
+++ b/resources/oidmcp/oidmcp/buffers.py
@@ -68,13 +68,13 @@ def crop_region(arr: np.ndarray,
     return arr[y:y + h, x:x + w, :]
 
 
-# (session pid, symbol, stop generation) -> (metadata, decoded array)
-CacheKey = tuple[int, str, int]
+# (session pid, token, symbol, stop generation) -> (metadata, decoded array)
+CacheKey = tuple[int, str, str, int]
 CacheValue = tuple[dict, np.ndarray]
 
 
 class BufferCache:
-    """Small LRU keyed by (session pid, symbol, stop generation)."""
+    """Small LRU keyed by (session pid, token, symbol, stop generation)."""
 
     def __init__(self, capacity: int = 4):
         self._capacity = capacity

--- a/resources/oidmcp/oidmcp/protocol.py
+++ b/resources/oidmcp/oidmcp/protocol.py
@@ -69,10 +69,10 @@ class ControlClient:
         the viewer endpoint's does not (a viewer has no stop notion, and
         replies '{"ok": true}' instead), so a missing key defaults to 0
         rather than raising -- only the debugger side relies on the
-        returned value being meaningful. `SessionManager` no longer pings
-        for liveness (a stale pooled socket surfaces as OSError on the
-        call itself and is rebuilt once); its debugger fetch path still
-        calls this for the stop generation that keys the per-stop cache.
+        returned value being meaningful. `SessionManager` connects fresh
+        per call, so there is no liveness ping; its debugger fetch path
+        still calls this for the stop generation that keys the per-stop
+        cache.
         """
         response, _ = self._call({'method': 'ping'})
         return response.get('stop_generation', 0)

--- a/resources/oidmcp/oidmcp/server.py
+++ b/resources/oidmcp/oidmcp/server.py
@@ -75,65 +75,28 @@ def _parse_max_bytes() -> int:
 
 
 class SessionManager:
-    """Connection pool + per-stop buffer cache over live sessions."""
+    """Per-stop buffer cache over live sessions (a fresh connection per call)."""
 
     def __init__(self):
-        self._clients: dict[int, ControlClient] = {}
-        self._viewer_clients: dict[int, ControlClient] = {}
         self._cache = BufferCache(capacity=4)
         self._max_bytes = _parse_max_bytes()
 
-    def _call_with_retry(self, pool, resolve, fn):
-        """
-        Run ``fn(client)`` against the pooled connection for the endpoint
-        ``resolve()`` names.
-
-        The warm path is a single round-trip: no liveness ping. A
-        transport error (``OSError``; ``ConnectionError`` and timeouts
-        are subclasses) means the pooled socket went stale -- e.g. the
-        endpoint restarted -- so discovery is re-resolved and the client
-        rebuilt once against the fresh record (which may name a new
-        port, token, or even pid), then ``fn`` retried. Safe because
-        every verb is repeat-safe: ``set_view`` is absolute, ``plot``
-        re-displays the same buffer rather than duplicating it, the rest
-        are pure reads, and a repeated hello is harmless. A
-        ``ControlError`` is a real reply from the endpoint and is never
-        retried. Debugger and viewer clients live in separate pools: two
-        live endpoints whose pid spaces could collide must never share a
-        slot.
-        """
-        info = resolve()
-        client = pool.get(info.pid)
-        if client is None:
-            client = ControlClient('127.0.0.1', info.port, info.token)
-            pool[info.pid] = client
-        try:
-            return fn(client)
-        except OSError:
-            client.close()
-            del pool[info.pid]
-            info = resolve()
-            fresh = ControlClient('127.0.0.1', info.port, info.token)
-            pool[info.pid] = fresh
-            try:
-                return fn(fresh)
-            except OSError:
-                # A second transport failure -- e.g. a timeout on a live
-                # but stalled endpoint -- can leave a half-completed
-                # exchange on the socket; if that client stayed pooled, a
-                # late reply would desync request/reply pairing on the
-                # next call. Never keep it.
-                fresh.close()
-                del pool[info.pid]
-                raise
+    def _connect(self, info):
+        return ControlClient('127.0.0.1', info.port, info.token)
 
     def _call_debugger(self, session, fn):
-        return self._call_with_retry(
-            self._clients, lambda: self._resolve(session), fn)
+        client = self._connect(self._resolve(session))
+        try:
+            return fn(client)
+        finally:
+            client.close()
 
     def _call_viewer(self, session, fn):
-        return self._call_with_retry(
-            self._viewer_clients, lambda: self._resolve_viewer(session), fn)
+        client = self._connect(self._resolve_viewer(session))
+        try:
+            return fn(client)
+        finally:
+            client.close()
 
     def _resolve(self, session):
         return pick_session(live_sessions(), session)
@@ -231,41 +194,27 @@ class SessionManager:
             meta = to_bridge_meta(viewer_meta)
             return meta, decode_buffer(meta, raw)
 
-        # The ping is functional, not a liveness probe: it returns the
-        # current stop generation, which keys the per-stop cache. Ping,
-        # cache lookup, and (only on a miss) get_buffer all run on the SAME
-        # client inside ONE retry scope, and the key takes its pid from the
-        # record that scope actually resolved -- a mid-call re-resolution
-        # (endpoint restart, possibly under a new pid) can therefore never
-        # split the key across two endpoints, and a retry re-pings so the
-        # generation always matches the client that served the bytes.
-        used_info = None
-
-        def resolve():
-            nonlocal used_info
-            used_info = self._resolve(session)
-            return used_info
-
-        def ping_then_fetch(client):
+        # ping is functional here (not a liveness probe): it returns the
+        # current stop generation, which keys the per-stop cache. One
+        # connection serves ping + cache-miss get_buffer, so the key always
+        # matches the endpoint that produced the bytes. info.token is
+        # included because it is per-instance (a restarted endpoint
+        # publishes a fresh random token): pid alone can be reused by an
+        # unrelated later session that happens to reach the same stop
+        # generation, and without the token that session would read back
+        # the previous session's cached bytes.
+        info = self._resolve(session)
+        client = self._connect(info)
+        try:
             generation = client.ping()
-            key = (used_info.pid, symbol, generation)
+            key = (info.pid, info.token, symbol, generation)
             cached = self._cache.get(key)
             if cached is not None:
-                return key, cached, None
-            meta, raw = client.get_buffer(symbol,
-                                          max_bytes=self._max_bytes)
-            return key, None, (meta, raw)
-
-        key, cached, fetched = self._call_with_retry(
-            self._clients, resolve, ping_then_fetch)
-        if cached is not None:
-            return cached
-        meta, raw = fetched
+                return cached
+            meta, raw = client.get_buffer(symbol, max_bytes=self._max_bytes)
+        finally:
+            client.close()
         arr = decode_buffer(meta, raw)
-        # Store under the same key we looked up (the ping generation), not
-        # meta['stop_generation']: if the stop advanced between ping and
-        # get_buffer those differ, and keying the entry off the lookup value
-        # is what guarantees the next same-stop fetch finds it.
         self._cache.put(key, (meta, arr))
         return meta, arr
 

--- a/resources/oidmcp/tests/conftest.py
+++ b/resources/oidmcp/tests/conftest.py
@@ -169,15 +169,15 @@ class _FakeViewerEndpoint:
         self._listener.listen(4)
         self.port = self._listener.getsockname()[1]
         # Every accepted connection is tracked so `close()` can shut them
-        # all down, not just the listener: a `SessionManager`'s pooled
-        # `ControlClient` reuses one connection across many calls and is
-        # never explicitly closed by test code, so leaving it open past
-        # this fixture's teardown would let a later test's viewer (a new
+        # all down, not just the listener: `SessionManager` connects a
+        # fresh `ControlClient` per call and closes it right after, so no
+        # test code holds a reference to any of these sockets. Without
+        # tracking them here, a stray open connection surviving past this
+        # fixture's teardown would let a later test's endpoint (a new
         # `_FakeViewerEndpoint` on a new port, but possibly the same
         # declared pid if the global `_manager` singleton is reused
-        # across tests) silently keep talking to this dead one instead of
-        # failing the pooled client's next call with an ``OSError``,
-        # which `_call_with_retry` answers by rebuilding the client once.
+        # across tests) be silently reachable through this dead socket
+        # instead of a clean, freshly resolved connection.
         self._conns_lock = threading.Lock()
         self._conns = []
         self._thread = threading.Thread(target=self._accept_loop,
@@ -276,8 +276,10 @@ class _FakeViewerEndpoint:
             pass  # already closed or never connected; nothing to wake
         self._listener.close()
         # Also force-close every still-open accepted connection (see the
-        # comment in __init__): otherwise a pooled ControlClient's next
-        # ping() would still succeed against an orphaned serving thread.
+        # comment in __init__): connect-per-call means each call opens and
+        # closes its own connection, so nothing here is pooled -- this just
+        # stops this fixture's teardown from leaving a leftover socket that
+        # a later same-pid test could otherwise reach.
         with self._conns_lock:
             conns = list(self._conns)
         for conn in conns:
@@ -287,15 +289,6 @@ class _FakeViewerEndpoint:
                 pass  # peer already gone; nothing to shut down
             conn.close()
         self._thread.join(timeout=2)
-
-    def drop_connections(self):
-        """Sever every accepted connection (the listener stays up),
-        simulating a pooled client whose socket died while the viewer
-        lives on."""
-        with self._conns_lock:
-            conns = list(self._conns)
-        for conn in conns:
-            conn.close()
 
 
 class FakeViewer:

--- a/resources/oidmcp/tests/test_endpoint_lifecycle.py
+++ b/resources/oidmcp/tests/test_endpoint_lifecycle.py
@@ -171,8 +171,8 @@ def test_pre_auth_trickle_cannot_hold_slot(endpoint_session, monkeypatch):
 
 def test_authenticated_client_may_idle_past_handshake_timeout(
         endpoint_session, monkeypatch):
-    # After a successful hello the timeout is lifted: a pooled client
-    # idling between requests must not be dropped.
+    # After a successful hello the timeout is lifted: an authenticated
+    # client idling between requests must not be dropped.
     monkeypatch.setattr(ep, 'HANDSHAKE_TIMEOUT', 0.2)
     path, _ = endpoint_session
     sock, info = _connect(path)

--- a/resources/oidmcp/tests/test_server_tools.py
+++ b/resources/oidmcp/tests/test_server_tools.py
@@ -286,24 +286,14 @@ def test_list_sessions_pairs_debugger_and_viewer(live_endpoint, live_viewer):
               for v in result['viewers'])
 
 
-# --- pooled-client retry (no per-call liveness ping) --------------------
+# --- connect-per-call ------------------------------------------------
 
-def test_warm_control_calls_are_single_round_trips(live_viewer):
+def test_each_call_is_a_single_round_trip_no_ping(live_viewer):
     viewer = live_viewer()
     mgr = server.SessionManager()
     mgr.set_view(None, zoom=1.5)
     mgr.get_view(None)
     # Two calls, two wire requests: no ping precedes a warm call.
-    assert viewer.endpoint.requests_served == 2
-
-
-def test_stale_pooled_client_is_rebuilt_once(live_viewer):
-    viewer = live_viewer()
-    mgr = server.SessionManager()
-    mgr.set_view(None, zoom=1.5)
-    viewer.endpoint.drop_connections()
-    view = mgr.get_view(None)  # transparent reconnect + single retry
-    assert view['zoom'] == pytest.approx(1.5)
     assert viewer.endpoint.requests_served == 2
 
 
@@ -316,25 +306,110 @@ def test_control_error_reply_is_not_retried(live_viewer):
     assert viewer.endpoint.requests_served == 1
 
 
-def test_dead_viewer_propagates_after_one_rebuild(live_viewer):
-    viewer = live_viewer()
-    mgr = server.SessionManager()
-    mgr.set_view(None, zoom=1.0)
-    viewer.endpoint.close()
-    with pytest.raises(OSError):
-        mgr.get_view(None)
-
-
-def test_retry_re_resolves_a_restarted_viewer(live_viewer):
-    # The rebuild must target freshly re-resolved discovery, not the record
-    # captured before the failure: a restarted viewer publishes a new port
-    # and token (same pool key here: both fixtures default to os.getpid()).
+def test_restarted_endpoint_is_reached_on_the_next_call(live_viewer):
+    # A viewer that restarts between calls publishes a new port and token.
+    # Connect-per-call re-resolves discovery each time, so the next call
+    # reaches the new endpoint with no retry logic present.
     old = live_viewer(start_time=100.0)
     mgr = server.SessionManager()
-    mgr.set_view(None, zoom=1.5)         # pools a client to `old`
-    old.endpoint.close()                 # viewer "restarts"...
-    new = live_viewer(start_time=200.0)  # ...republishing discovery
-    view = mgr.set_view(None, zoom=2.0)  # stale socket -> re-resolve -> new
+    mgr.set_view(None, zoom=1.5)          # connects to old, closes
+    old.endpoint.close()                  # old viewer "restarts"...
+    new = live_viewer(start_time=200.0)   # ...republishing discovery
+    view = mgr.set_view(None, zoom=2.0)   # fresh resolve + connect -> new
     assert view['zoom'] == pytest.approx(2.0)
     assert new.endpoint.requests_served == 1
     assert old.endpoint.requests_served == 1
+
+
+def test_fetch_cache_does_not_bleed_across_pid_reused_debugger_sessions(
+        live_endpoint):
+    # A debug session that exits and a new one that starts under the same
+    # OS pid (pid reuse) must not read back the previous session's cached
+    # bytes, even though both sessions reach the same stop generation (a
+    # freshly started endpoint's stop generation always starts at 0). The
+    # cache key must therefore also discriminate on the endpoint's token,
+    # which is re-randomized on every `agentendpoint.start()`.
+    from conftest import FakeBridge, FakeWindow, make_meta
+    from oidmcp import discovery
+    from oidscripts import agentendpoint
+    import numpy as np
+
+    _, _ = live_endpoint
+    mgr = server.SessionManager()
+    _, arr = mgr.fetch(None, 'grad')
+    assert arr[0, 0, 0] == pytest.approx(0.0)  # original gradient value
+
+    old_pid = discovery.live_sessions()[0].pid
+    old_token = discovery.live_sessions()[0].token
+    agentendpoint.shutdown()
+
+    new_raw = np.full((3, 4, 1), 42.0, dtype=np.float32)
+    new_bridge = FakeBridge(
+        symbols=['img', 'grad'],
+        buffers={'grad': make_meta(4, 3, channels=1, type_value=5,
+                                    raw=new_raw.tobytes())})
+    agentendpoint.start(new_bridge, FakeWindow(ready=True))
+
+    sessions = discovery.live_sessions()
+    assert len(sessions) == 1
+    assert sessions[0].pid == old_pid            # same OS pid (reused)
+    assert sessions[0].token != old_token         # but a fresh token
+
+    _, arr2 = mgr.fetch(None, 'grad')
+    assert arr2[0, 0, 0] == pytest.approx(42.0)  # new session's bytes
+
+
+def test_client_is_closed_when_a_call_raises(live_viewer, monkeypatch):
+    live_viewer()
+    mgr = server.SessionManager()
+    closed = []
+    real_close = server.ControlClient.close
+
+    def spy_close(self):
+        closed.append(self)
+        return real_close(self)
+
+    monkeypatch.setattr(server.ControlClient, 'close', spy_close)
+    with pytest.raises(ControlError):
+        mgr.fetch(None, 'missing')  # viewer get_buffer('missing') -> ControlError
+    assert len(closed) == 1  # the per-call client is closed despite the error
+
+
+def test_client_is_closed_after_a_successful_call(live_viewer, monkeypatch):
+    live_viewer()
+    mgr = server.SessionManager()
+    closed = []
+    real_close = server.ControlClient.close
+
+    def spy_close(self):
+        closed.append(self)
+        return real_close(self)
+
+    monkeypatch.setattr(server.ControlClient, 'close', spy_close)
+    mgr.get_view(None)
+    assert len(closed) == 1  # the per-call client is closed after success too
+
+
+def test_client_is_closed_on_fetch_including_cache_hit(live_endpoint,
+                                                        monkeypatch):
+    _, bridge = live_endpoint
+    mgr = server.SessionManager()
+    closed = []
+    real_close = server.ControlClient.close
+
+    def spy_close(self):
+        closed.append(self)
+        return real_close(self)
+
+    monkeypatch.setattr(server.ControlClient, 'close', spy_close)
+
+    mgr.fetch(None, 'grad')
+    fetches = bridge.fetch_count
+    mgr.fetch(None, 'grad')  # same stop generation: served from cache
+
+    # The cache hit still went through fetch()'s try/finally, so it never
+    # re-called the bridge...
+    assert bridge.fetch_count == fetches
+    # ...but both calls -- the cache miss and the cache hit -- still each
+    # opened and closed their own per-call client.
+    assert len(closed) == 2

--- a/src/host/frame_pacer.cpp
+++ b/src/host/frame_pacer.cpp
@@ -38,19 +38,6 @@ void FramePacer::wake() {
     cv_.notify_one();
 }
 
-void FramePacer::set_period(std::chrono::nanoseconds period) {
-    {
-        const std::scoped_lock lock(mutex_);
-        period_ = period;
-        // Re-anchor so the new cadence applies now, not after the old
-        // deadline expires.
-        deadline_ = Clock::now() + period;
-    }
-    // A pace() parked on the old (possibly much later) deadline must
-    // re-evaluate against the new one.
-    cv_.notify_one();
-}
-
 void FramePacer::pace(const std::function<void()>& on_wake) {
     std::unique_lock lock(mutex_);
     for (;;) {

--- a/src/host/frame_pacer.h
+++ b/src/host/frame_pacer.h
@@ -49,11 +49,6 @@ class FramePacer {
     // none in progress, it is served on the next pace() entry.
     void wake();
 
-    // Thread-safe; the new cadence takes effect immediately (the current
-    // deadline is re-anchored to now + period). Used when the window moves
-    // to a monitor with a different refresh rate.
-    void set_period(std::chrono::nanoseconds period);
-
     // GL-thread only. Serves all pending burst wake() calls, one per
     // on_wake() invocation, until the frame deadline passes, advances the
     // deadline by one period -- clamped to now + period on overrun so a

--- a/src/host/glfw_host_backend.cpp
+++ b/src/host/glfw_host_backend.cpp
@@ -134,53 +134,12 @@ bool platform_supports_window_position() {
 
 } // namespace
 
-int GlfwHostBackend::refresh_rate_hz() const {
-    // Pace from the monitor actually showing the window -- the one whose
-    // area overlaps it most -- not the primary: on mixed-refresh
-    // multi-monitor setups the primary's rate would pace an agent run too
-    // slow (or needlessly fast) on the other monitor.
-    // (glfwGetWindowMonitor only answers for fullscreen windows.) Falls
-    // back to the primary when undetermined, and to 60 Hz when GLFW
-    // cannot say.
-    GLFWmonitor* best = glfwGetPrimaryMonitor();
-    // Overlap needs the window's global position, which Wayland (and the
-    // Emscripten shim) never provide -- there the primary is the best
-    // answer available, without error-callback spam.
-    if (window_ != nullptr && platform_supports_window_position()) {
-        int wx = 0;
-        int wy = 0;
-        int ww = 0;
-        int wh = 0;
-        glfwGetWindowPos(window_, &wx, &wy);
-        glfwGetWindowSize(window_, &ww, &wh);
-        int monitor_count = 0;
-        GLFWmonitor** monitors = glfwGetMonitors(&monitor_count);
-        int best_overlap = 0;
-        for (int i = 0; i < monitor_count; ++i) {
-            const GLFWvidmode* m = glfwGetVideoMode(monitors[i]);
-            if (m == nullptr) {
-                continue;
-            }
-            int mx = 0;
-            int my = 0;
-            glfwGetMonitorPos(monitors[i], &mx, &my);
-            const int ox = (std::max)(0,
-                                      (std::min)(wx + ww, mx + m->width) -
-                                          (std::max)(wx, mx));
-            const int oy = (std::max)(0,
-                                      (std::min)(wy + wh, my + m->height) -
-                                          (std::max)(wy, my));
-            const int overlap = ox * oy;
-            if (overlap > best_overlap) {
-                best_overlap = overlap;
-                best = monitors[i];
-            }
-        }
-    }
-    if (best == nullptr) {
+int GlfwHostBackend::primary_refresh_rate_hz() const {
+    GLFWmonitor* primary = glfwGetPrimaryMonitor();
+    if (primary == nullptr) {
         return 60; // headless: no monitor to ask
     }
-    const GLFWvidmode* mode = glfwGetVideoMode(best);
+    const GLFWvidmode* mode = glfwGetVideoMode(primary);
     return (mode != nullptr && mode->refreshRate > 0) ? mode->refreshRate : 60;
 }
 

--- a/src/host/glfw_host_backend.h
+++ b/src/host/glfw_host_backend.h
@@ -62,10 +62,10 @@ class GlfwHostBackend final : public HostBackend {
     // OS may throttle for a background window.
     void set_vsync(bool enabled);
 
-    // Refresh rate, in Hz, of the monitor showing the window (greatest
-    // overlap); the primary's when undetermined (no window yet, or the
-    // platform hides window positions), 60 when GLFW cannot say.
-    [[nodiscard]] int refresh_rate_hz() const;
+    // Refresh rate (Hz) of the primary monitor; 60 when GLFW cannot say
+    // (headless / null video mode / non-positive rate). Queried once at
+    // agent startup to pace the render loop.
+    [[nodiscard]] int primary_refresh_rate_hz() const;
 
     [[nodiscard]] GLFWwindow* window() const {
         return window_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -391,19 +391,6 @@ void drain_agent(FrameContext& ctx) {
     }
 }
 
-// Re-derives the agent-run pacing period from the monitor currently under
-// the window (the display can change when the window is dragged to a
-// different-Hz monitor). Render cadence only -- agent latency is
-// wake-driven regardless of the period.
-void repace_if_monitor_changed(const oid::host::GlfwHostBackend& backend,
-                               oid::host::FramePacer& pacer,
-                               int& paced_hz) {
-    if (const int hz = backend.refresh_rate_hz(); hz != paced_hz) {
-        paced_hz = hz;
-        pacer.set_period(std::chrono::nanoseconds{std::chrono::seconds{1}} /
-                         hz);
-    }
-}
 #else
 void drain_agent(FrameContext& /*ctx*/) {}
 #endif
@@ -932,7 +919,7 @@ int main(int argc, char** argv) {
                                  oid::host::agent::AgentServerConfig{
                                      /*enabled=*/true, cli.agent_debugger_pid});
             pacer.emplace(std::chrono::nanoseconds{std::chrono::seconds{1}} /
-                          backend.refresh_rate_hz());
+                          backend.primary_refresh_rate_hz());
             agent_server->set_enqueue_listener([&p = *pacer] { p.wake(); });
             oid::platform::begin_agent_activity();
             // Only after the endpoint is actually up, and as the very last
@@ -1091,16 +1078,7 @@ int main(int argc, char** argv) {
         // pace() owns the frame cadence. A request wakes the pacing wait
         // and is drained within ~1 ms regardless of focus/occlusion,
         // instead of once per (possibly OS-throttled) present.
-        // The display can change under us (window dragged to a monitor
-        // with a different refresh rate); re-derive the pacing period about
-        // once a second. Render cadence only -- agent latency is
-        // wake-driven regardless of the period.
-        constexpr int REFRESH_RECHECK_FRAMES = 60;
-        int paced_hz = backend.refresh_rate_hz();
         while (loop.tick()) {
-            if (loop.frame_count() % REFRESH_RECHECK_FRAMES == 0) {
-                repace_if_monitor_changed(backend, *pacer, paced_hz);
-            }
             pacer->pace([&ctx] {
                 // Same poll-before-read contract as the frame lambda: the
                 // agent is a model consumer, so inbound IPC is reconciled

--- a/tests/host/frame_pacer_test.cpp
+++ b/tests/host/frame_pacer_test.cpp
@@ -112,17 +112,4 @@ TEST(FramePacer, WakeAfterPaceReturnsIsSafeAndCarriesOver) {
     EXPECT_EQ(calls, 1);
 }
 
-TEST(FramePacer, SetPeriodKeepsServingWakes) {
-    // A cadence change (window moved to a different-Hz monitor) must not
-    // disrupt wake service: a pending wake is still served on the next
-    // pace() entry, and pace() still returns.
-    FramePacer pacer{std::chrono::milliseconds(100)};
-    int calls = 0;
-    pacer.pace([&calls] { ++calls; });
-    pacer.set_period(std::chrono::milliseconds(50));
-    pacer.wake();
-    pacer.pace([&calls] { ++calls; });
-    EXPECT_EQ(calls, 1);
-}
-
 } // namespace


### PR DESCRIPTION
## Simplify the agent-responsiveness machinery (post-#988)

Follow-up to #988. Net change is a **net-negative simplification** of the agent path: keep #988's `FramePacer` (its condition-variable wake is required — see below), simplify how its period is chosen, and make the oid-mcp client connect per call.

### What ships
- **Reduced Lever B — primary-rate-once pacing.** The `FramePacer` period is now derived once from the primary monitor (`primary_refresh_rate_hz()`), deleting `refresh_rate_hz()`'s best-overlap monitor loop, the once-a-second `repace_if_monitor_changed` recheck, and `FramePacer::set_period`. Cost: a window dragged/restored onto a different-Hz monitor keeps the primary cadence (render smoothness only; agent latency is wake-driven and period-independent).
- **Lever C — connect-per-call in oid-mcp.** Each tool call dials a fresh `ControlClient` and closes it, deleting the connection pool and its retry. ~2–3 ms/call vs ~1 ms warm, far inside the budget; restart-between-calls is trivially correct. New tests cover close-on-success, close-on-error, the fetch cache-hit close path, and a restart→next-call guard.

### Lever A was tried and reverted — do not reintroduce it
The original plan's Lever A replaced the `FramePacer` condition-variable wake with `glfwWaitEventsTimeout` + `glfwPostEmptyEvent`. It passed all unit tests, whole-branch review, and the downstream wasm build — then **failed live acceptance on macOS**. Measured backgrounded `get_view` (persistent single round-trip, identical setup):

| build | wake | median |
|---|---|---|
| pre-#988 | drain per vsync present | 16.63 ms |
| #988 (FramePacer) | **condition variable** | **0.09 ms** |
| Lever A | `glfwPostEmptyEvent` | 8.49 ms |

`glfwWaitEventsTimeout` is interruptible only by `glfwPostEmptyEvent` (a Cocoa event), and macOS throttles Cocoa event delivery to a **non-active window** — so the wake lands only at timeout expiry. The CV wake never touches the OS event loop, so it's immune. Unfixable within Lever A (a tiny timeout would busy-spin).

### Verification
- Native `ctest` (FramePacer suite retained), oid-mcp pytest.
- Downstream non-native port: `build:viewer`, `tsc`, node tests.
- **Live acceptance:** backgrounded persistent `get_view` median **0.099 ms** on the shipped branch (FramePacer wake preserved).
