### PR TITLE
feat(oidmcp): oid-mcp PyPI distribution + out-of-tree agent platform seam

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,75 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2015-2026 OpenImageDebugger contributors
+# (https://github.com/OpenImageDebugger/OpenImageDebugger)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+name: Publish oid-mcp to PyPI
+
+on:
+  push:
+    tags:
+      - "oid-mcp-v*"
+
+jobs:
+  test:
+    uses: ./.github/workflows/python-tests.yml
+
+  publish:
+    needs: [test]
+    runs-on: ubuntu-24.04
+    environment: pypi
+    permissions:
+      # Trusted publishing (OIDC): PyPI verifies the workflow identity;
+      # no stored API token anywhere.
+      id-token: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.28"
+
+      # Wheel-only: the wheel force-includes ../oidscripts, which an
+      # unpacked sdist could not resolve, so no sdist is built or uploaded.
+      - name: Build wheel
+        shell: bash
+        working-directory: resources/oidmcp
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          uv build --wheel
+
+      - name: Smoke-import the wheel
+        shell: bash
+        working-directory: resources/oidmcp
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          uv run --isolated --no-project \
+            --with "$(ls dist/oid_mcp-*.whl)" \
+            python -c "import oidmcp.protocol, oidmcp.discovery; print('wheel import OK')"
+
+      - name: Publish to PyPI (trusted publishing)
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1
+        with:
+          packages-dir: resources/oidmcp/dist

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -69,9 +69,14 @@ jobs:
         working-directory: resources/oidmcp
         run: |
           export PATH="$HOME/.local/bin:$PATH"
-          uv run --isolated --no-project \
-            --with "$(ls dist/oid_mcp-*.whl)" \
-            python -c "import oidmcp.protocol, oidmcp.discovery; print('wheel import OK')"
+          # Import needs only stdlib + the wheel itself; installing
+          # --no-deps keeps the publish job from resolving unpinned
+          # transitive dependency versions just to smoke-test the wheel.
+          uv venv /tmp/smoke
+          uv pip install --python /tmp/smoke/bin/python --no-deps \
+            "$(ls dist/oid_mcp-*.whl)"
+          /tmp/smoke/bin/python \
+            -c "import oidmcp.protocol, oidmcp.discovery; print('wheel import OK')"
 
       - name: Publish to PyPI (trusted publishing)
         uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -28,6 +28,9 @@ on:
     tags:
       - "oid-mcp-v*"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     uses: ./.github/workflows/python-tests.yml
@@ -39,6 +42,7 @@ jobs:
     permissions:
       # Trusted publishing (OIDC): PyPI verifies the workflow identity;
       # no stored API token anywhere.
+      contents: read
       id-token: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -68,14 +68,14 @@ jobs:
         shell: bash
         working-directory: resources/oidmcp
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
-          # Import needs only stdlib + the wheel itself; installing
-          # --no-deps keeps the publish job from resolving unpinned
-          # transitive dependency versions just to smoke-test the wheel.
-          uv venv /tmp/smoke
-          uv pip install --python /tmp/smoke/bin/python --no-deps \
-            "$(ls dist/oid_mcp-*.whl)"
-          /tmp/smoke/bin/python \
+          # oidmcp is pure Python, so the freshly built wheel imports
+          # directly off sys.path via zipimport — no package-manager
+          # install runs, so there are no dependency versions to lock.
+          # Run from a neutral directory so this checkout's source tree
+          # does not shadow the wheel on the import path.
+          wheel="$(ls "$PWD"/dist/oid_mcp-*.whl)"
+          cd /tmp
+          PYTHONPATH="$wheel" python3 \
             -c "import oidmcp.protocol, oidmcp.discovery; print('wheel import OK')"
 
       - name: Publish to PyPI (trusted publishing)

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -73,9 +73,14 @@ jobs:
           # install runs, so there are no dependency versions to lock.
           # Run from a neutral directory so this checkout's source tree
           # does not shadow the wheel on the import path.
-          wheel="$(ls "$PWD"/dist/oid_mcp-*.whl)"
+          shopt -s nullglob
+          wheels=("$PWD"/dist/oid_mcp-*.whl)
+          if [ "${#wheels[@]}" -ne 1 ]; then
+            echo "expected exactly one built wheel, got ${#wheels[@]}: ${wheels[*]}" >&2
+            exit 1
+          fi
           cd /tmp
-          PYTHONPATH="$wheel" python3 \
+          PYTHONPATH="${wheels[0]}" python3 \
             -c "import oidmcp.protocol, oidmcp.discovery; print('wheel import OK')"
 
       - name: Publish to PyPI (trusted publishing)

--- a/resources/oidmcp/oidmcp/_wireframe.py
+++ b/resources/oidmcp/oidmcp/_wireframe.py
@@ -42,10 +42,12 @@ from pathlib import Path
 _RESOURCES_DIR = Path(__file__).resolve().parents[2]
 _SITE_DIR = Path(__file__).resolve().parents[1]
 _PURELIB_DIR = Path(sysconfig.get_path('purelib'))
+# Single-sourced to avoid repeating the path components below.
+_OIDSCRIPTS_WIREFRAME = Path('oidscripts') / 'wireframe.py'
 _EXPECTED_WIREFRAMES = (
-    _RESOURCES_DIR / 'oidscripts' / 'wireframe.py',
-    _SITE_DIR / 'oidscripts' / 'wireframe.py',
-    _PURELIB_DIR / 'oidscripts' / 'wireframe.py',
+    _RESOURCES_DIR / _OIDSCRIPTS_WIREFRAME,
+    _SITE_DIR / _OIDSCRIPTS_WIREFRAME,
+    _PURELIB_DIR / _OIDSCRIPTS_WIREFRAME,
 )
 if str(_RESOURCES_DIR) not in sys.path:
     sys.path.append(str(_RESOURCES_DIR))

--- a/resources/oidmcp/oidmcp/_wireframe.py
+++ b/resources/oidmcp/oidmcp/_wireframe.py
@@ -22,11 +22,31 @@ silently.
 
 import os
 import sys
+import sysconfig
 from pathlib import Path
 
-# resources/oidmcp/oidmcp/_wireframe.py -> parents[2] == resources/
+# Three supported layouts for the shared scripts tree:
+#   repo layout:      resources/oidmcp/oidmcp/_wireframe.py with the tree at
+#                     resources/oidscripts (parents[2] == resources/)
+#   installed layout: site-packages/oidmcp/_wireframe.py with oidscripts
+#                     shipped in the same site-packages by the wheel
+#                     (parents[1] == site-packages)
+#   editable-install layout: a local `uv run`/`pip install -e` dev sync
+#                     redirects oidmcp/_wireframe.py's own __file__ back to
+#                     this repo file (so parents[1] above is not the venv's
+#                     site-packages), yet the build backend still has to
+#                     materialize the force-included oidscripts tree as a
+#                     real copy in the running interpreter's site-packages,
+#                     since there is no editable/redirect mechanism for a
+#                     force-include mapped from outside the project root.
 _RESOURCES_DIR = Path(__file__).resolve().parents[2]
-_EXPECTED_WIREFRAME = _RESOURCES_DIR / 'oidscripts' / 'wireframe.py'
+_SITE_DIR = Path(__file__).resolve().parents[1]
+_PURELIB_DIR = Path(sysconfig.get_path('purelib'))
+_EXPECTED_WIREFRAMES = (
+    _RESOURCES_DIR / 'oidscripts' / 'wireframe.py',
+    _SITE_DIR / 'oidscripts' / 'wireframe.py',
+    _PURELIB_DIR / 'oidscripts' / 'wireframe.py',
+)
 if str(_RESOURCES_DIR) not in sys.path:
     sys.path.append(str(_RESOURCES_DIR))
 
@@ -44,14 +64,13 @@ except ImportError as exc:  # pragma: no cover - deployment misconfiguration
 # different module could encode frames incompatibly, so treat it as a
 # misconfiguration to fix, not a protocol to trust.
 _loaded = getattr(_wireframe, '__file__', None)
-if _loaded is not None and (
-        os.path.realpath(_loaded)
-        != os.path.realpath(_EXPECTED_WIREFRAME)):
+if _loaded is not None and os.path.realpath(_loaded) not in {
+        os.path.realpath(str(p)) for p in _EXPECTED_WIREFRAMES}:
     raise ImportError(  # pragma: no cover - conflicting oidscripts on path
-        'oid-mcp imported a foreign oidscripts.wireframe from %s; expected '
-        'the copy shipped with the debugger scripts at %s. Remove the '
-        'conflicting oidscripts from sys.path / PYTHONPATH.'
-        % (_loaded, _EXPECTED_WIREFRAME))
+        'oid-mcp imported a foreign oidscripts.wireframe %s; expected '
+        'one of %s. Remove the conflicting oidscripts from sys.path / '
+        'PYTHONPATH.'
+        % (_loaded, [str(p) for p in _EXPECTED_WIREFRAMES]))
 
 MAX_FRAME_BYTES = _wireframe.MAX_FRAME_BYTES
 recv_frame = _wireframe.recv_frame

--- a/resources/oidmcp/oidmcp/server.py
+++ b/resources/oidmcp/oidmcp/server.py
@@ -25,7 +25,7 @@ else:
 
 from .analysis import compute_stats, dump_npy, extract_values
 from .buffers import BufferCache, decode_buffer
-from .discovery import (NoSessionError, _pid_alive, live_sessions,
+from .discovery import (NoSessionError, _pid_alive, _reap, live_sessions,
                         live_viewers, pick_session)
 from .protocol import DEFAULT_MAX_BYTES, ControlClient, ControlError
 from .render import render_view
@@ -92,11 +92,27 @@ class SessionManager:
             client.close()
 
     def _call_viewer(self, session, fn):
-        client = self._connect(self._resolve_viewer(session))
-        try:
-            return fn(client)
-        finally:
-            client.close()
+        # A viewer discovery file can outlive its endpoint while the pid
+        # that wrote it lives on (a long-lived embedding host whose bridge
+        # is gone): the reader's pid probe passes but the port refuses.
+        # Treat connection-refused as "dead viewer": reap that file and
+        # re-resolve so another live viewer can win. Bounded, so a
+        # pathological discovery dir cannot loop forever.
+        for _ in range(8):
+            info = self._resolve_viewer(session)
+            try:
+                client = self._connect(info)
+            except ConnectionRefusedError:
+                if info.path is not None:
+                    _reap(info.path)
+                continue
+            try:
+                return fn(client)
+            finally:
+                client.close()
+        raise NoSessionError(
+            'viewer discovery entries kept refusing connections; restart '
+            'the viewer window and retry.')
 
     def _resolve(self, session):
         return pick_session(live_sessions(), session)

--- a/resources/oidmcp/oidmcp/server.py
+++ b/resources/oidmcp/oidmcp/server.py
@@ -96,23 +96,30 @@ class SessionManager:
         # that wrote it lives on (a long-lived embedding host whose bridge
         # is gone): the reader's pid probe passes but the port refuses.
         # Treat connection-refused as "dead viewer": reap that file and
-        # re-resolve so another live viewer can win. Bounded, so a
-        # pathological discovery dir cannot loop forever.
-        for _ in range(8):
+        # re-resolve so another live viewer can win. The walk is bounded by
+        # the live viewers themselves -- each refusal reaps one entry, and
+        # an entry we cannot make progress on (no path, or a reap that left
+        # the file in place) stops the walk -- so many stale entries can
+        # never hide an older live viewer, yet a pathological discovery dir
+        # cannot loop forever.
+        reaped = set()
+        while True:
             info = self._resolve_viewer(session)
             try:
                 client = self._connect(info)
             except ConnectionRefusedError:
-                if info.path is not None:
-                    _reap(info.path)
+                if info.path is None or str(info.path) in reaped:
+                    raise NoSessionError(
+                        'viewer discovery entries kept refusing '
+                        'connections; restart the viewer window and '
+                        'retry.') from None
+                reaped.add(str(info.path))
+                _reap(info.path)
                 continue
             try:
                 return fn(client)
             finally:
                 client.close()
-        raise NoSessionError(
-            'viewer discovery entries kept refusing connections; restart '
-            'the viewer window and retry.')
 
     def _resolve(self, session):
         return pick_session(live_sessions(), session)

--- a/resources/oidmcp/pyproject.toml
+++ b/resources/oidmcp/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "oidmcp"
+name = "oid-mcp"
 version = "0.2.0"
 description = "MCP server giving AI agents eyes on OpenImageDebugger buffers in live gdb/lldb sessions"
 requires-python = ">=3.10"
@@ -21,6 +21,15 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["oidmcp"]
+
+# The wire codec is single-sourced in the debugger-scripts tree
+# (resources/oidscripts). An installed wheel has no sibling resources/
+# checkout, so ship that tree inside the wheel as a top-level `oidscripts`
+# package (oidmcp/_wireframe.py accepts it there). Wheel-only publishing:
+# an sdist cannot reference ../oidscripts once unpacked, so Task 4 builds
+# and uploads the wheel only.
+[tool.hatch.build.targets.wheel.force-include]
+"../oidscripts" = "oidscripts"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/resources/oidmcp/tests/test_installed_layout.py
+++ b/resources/oidmcp/tests/test_installed_layout.py
@@ -1,0 +1,69 @@
+"""The wheel must be importable without the repo's resources/ tree.
+
+Simulates an installed site-packages: copy oidmcp and oidscripts side by
+side into a temp dir and import oidmcp._wireframe from there. Guards both
+the _wireframe path acceptance and (indirectly) the wheel's need to ship
+oidscripts as a top-level package.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+RESOURCES = Path(__file__).resolve().parents[2]
+
+
+def test_wireframe_imports_from_installed_layout(tmp_path):
+    site = tmp_path / 'site-packages'
+    shutil.copytree(RESOURCES / 'oidmcp' / 'oidmcp', site / 'oidmcp')
+    shutil.copytree(RESOURCES / 'oidscripts', site / 'oidscripts')
+
+    # A fresh interpreter whose sys.path starts at the fake site-packages;
+    # cwd is neutral so the repo layout cannot mask a failure.
+    code = ('import oidmcp._wireframe as w; '
+            'print(w.MAX_FRAME_BYTES)')
+    result = subprocess.run(
+        [sys.executable, '-c', code],
+        cwd=tmp_path,
+        env={'PYTHONPATH': str(site),
+             'PATH': os.environ.get('PATH', ''),
+             'HOME': os.environ.get('HOME', str(tmp_path))},
+        capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(1 << 20)
+
+
+def test_wireframe_still_imports_from_repo_layout():
+    import oidmcp._wireframe as w
+    assert w.MAX_FRAME_BYTES == 1 << 20
+
+
+def test_wireframe_imports_from_purelib_layout(tmp_path):
+    # oidmcp lives at pkgs/oidmcp (so parents[1]=pkgs, parents[2]=tmp_path);
+    # oidscripts lives ONLY under a separate purelib dir. Neither the repo
+    # candidate (parents[2]/oidscripts) nor the site candidate
+    # (parents[1]/oidscripts) exists, so the import can only succeed via the
+    # third _PURELIB_DIR candidate. sysconfig.get_path('purelib') is patched
+    # to that dir before oidmcp._wireframe computes _PURELIB_DIR at import.
+    pkgs = tmp_path / 'pkgs'
+    purelib = tmp_path / 'purelib'
+    shutil.copytree(RESOURCES / 'oidmcp' / 'oidmcp', pkgs / 'oidmcp')
+    shutil.copytree(RESOURCES / 'oidscripts', purelib / 'oidscripts')
+
+    code = (
+        'import sysconfig; '
+        'sysconfig.get_path = lambda *a, **k: {purelib!r}; '
+        'import oidmcp._wireframe as w; '
+        'print(w.MAX_FRAME_BYTES)'
+    ).format(purelib=str(purelib))
+    result = subprocess.run(
+        [sys.executable, '-c', code],
+        cwd=tmp_path,
+        env={'PYTHONPATH': os.pathsep.join([str(pkgs), str(purelib)]),
+             'PATH': os.environ.get('PATH', ''),
+             'HOME': os.environ.get('HOME', str(tmp_path))},
+        capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(1 << 20)

--- a/resources/oidmcp/tests/test_viewer_refused.py
+++ b/resources/oidmcp/tests/test_viewer_refused.py
@@ -1,0 +1,73 @@
+"""A live-pid viewer discovery file whose port refuses is 'dead, skip'."""
+
+import os
+
+import pytest
+
+from oidmcp import server as srv
+from oidmcp.discovery import NoSessionError, ViewerSessionInfo
+
+
+class _FakeClient:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def _viewer(path, port, start_time):
+    return ViewerSessionInfo(path=path, pid=os.getpid(), port=port,
+                             token='t' * 64, start_time=start_time,
+                             debugger_pid=None)
+
+
+def test_refused_viewer_is_reaped_and_next_one_serves(monkeypatch, tmp_path):
+    stale_path = tmp_path / '101.json'
+    good_path = tmp_path / '102.json'
+    stale_path.write_text('{}')
+    good_path.write_text('{}')
+    # The stale entry is newer, so selection tries it first.
+    stale = _viewer(stale_path, port=1, start_time=2.0)
+    good = _viewer(good_path, port=2, start_time=1.0)
+
+    def fake_live_viewers():
+        return [v for v in (stale, good) if v.path.exists()]
+
+    monkeypatch.setattr(srv, 'live_viewers', fake_live_viewers)
+
+    client = _FakeClient()
+
+    def fake_connect(self, info):
+        if info.port == 1:
+            raise ConnectionRefusedError()
+        return client
+
+    monkeypatch.setattr(srv.SessionManager, '_connect', fake_connect)
+
+    result = srv.SessionManager()._call_viewer(None, lambda c: 'served')
+
+    assert result == 'served'
+    assert not stale_path.exists()   # refused entry reaped
+    assert good_path.exists()        # serving entry untouched
+    assert client.closed
+
+
+def test_all_viewers_refused_raises_no_session(monkeypatch, tmp_path):
+    path = tmp_path / '103.json'
+    path.write_text('{}')
+    only = _viewer(path, port=1, start_time=1.0)
+
+    def fake_live_viewers():
+        return [only] if path.exists() else []
+
+    monkeypatch.setattr(srv, 'live_viewers', fake_live_viewers)
+
+    def fake_connect(self, info):
+        raise ConnectionRefusedError()
+
+    monkeypatch.setattr(srv.SessionManager, '_connect', fake_connect)
+
+    with pytest.raises(NoSessionError):
+        srv.SessionManager()._call_viewer(None, lambda c: 'never')
+    assert not path.exists()

--- a/resources/oidmcp/tests/test_viewer_refused.py
+++ b/resources/oidmcp/tests/test_viewer_refused.py
@@ -71,3 +71,57 @@ def test_all_viewers_refused_raises_no_session(monkeypatch, tmp_path):
     with pytest.raises(NoSessionError):
         srv.SessionManager()._call_viewer(None, lambda c: 'never')
     assert not path.exists()
+
+
+def test_many_stale_viewers_do_not_hide_an_older_live_one(monkeypatch, tmp_path):
+    # Nine newer stale entries that all refuse, plus one older live viewer.
+    # A fixed small retry cap would give up before reaching the live one; the
+    # live-viewer-bounded walk must reap all nine and still serve the tenth.
+    stale = []
+    for i in range(9):
+        p = tmp_path / f'2{i:02d}.json'
+        p.write_text('{}')
+        stale.append(_viewer(p, port=1, start_time=100.0 + i))
+    good_path = tmp_path / '100.json'
+    good_path.write_text('{}')
+    good = _viewer(good_path, port=2, start_time=1.0)  # oldest -> tried last
+
+    def fake_live_viewers():
+        return [v for v in (*stale, good) if v.path.exists()]
+
+    monkeypatch.setattr(srv, 'live_viewers', fake_live_viewers)
+
+    client = _FakeClient()
+
+    def fake_connect(self, info):
+        if info.port == 2:
+            return client
+        raise ConnectionRefusedError()
+
+    monkeypatch.setattr(srv.SessionManager, '_connect', fake_connect)
+
+    result = srv.SessionManager()._call_viewer(None, lambda c: 'served')
+
+    assert result == 'served'
+    assert good_path.exists()                        # live entry untouched
+    assert all(not v.path.exists() for v in stale)   # every stale entry reaped
+    assert client.closed
+
+
+def test_unreapable_refused_viewer_does_not_loop_forever(monkeypatch, tmp_path):
+    # If a refused entry cannot be reaped (its file survives _reap), the walk
+    # must still terminate rather than spin forever on the same entry.
+    path = tmp_path / '300.json'
+    path.write_text('{}')
+    only = _viewer(path, port=1, start_time=1.0)
+
+    monkeypatch.setattr(srv, 'live_viewers', lambda: [only])  # never disappears
+    monkeypatch.setattr(srv, '_reap', lambda p: None)         # reap is a no-op
+
+    def fake_connect(self, info):
+        raise ConnectionRefusedError()
+
+    monkeypatch.setattr(srv.SessionManager, '_connect', fake_connect)
+
+    with pytest.raises(NoSessionError):
+        srv.SessionManager()._call_viewer(None, lambda c: 'never')

--- a/resources/oidmcp/tests/test_viewer_refused.py
+++ b/resources/oidmcp/tests/test_viewer_refused.py
@@ -68,8 +68,9 @@ def test_all_viewers_refused_raises_no_session(monkeypatch, tmp_path):
 
     monkeypatch.setattr(srv.SessionManager, '_connect', fake_connect)
 
+    mgr = srv.SessionManager()
     with pytest.raises(NoSessionError):
-        srv.SessionManager()._call_viewer(None, lambda c: 'never')
+        mgr._call_viewer(None, lambda c: 'never')
     assert not path.exists()
 
 
@@ -123,5 +124,6 @@ def test_unreapable_refused_viewer_does_not_loop_forever(monkeypatch, tmp_path):
 
     monkeypatch.setattr(srv.SessionManager, '_connect', fake_connect)
 
+    mgr = srv.SessionManager()
     with pytest.raises(NoSessionError):
-        srv.SessionManager()._call_viewer(None, lambda c: 'never')
+        mgr._call_viewer(None, lambda c: 'never')

--- a/resources/oidmcp/uv.lock
+++ b/resources/oidmcp/uv.lock
@@ -577,7 +577,7 @@ wheels = [
 ]
 
 [[package]]
-name = "oidmcp"
+name = "oid-mcp"
 version = "0.2.0"
 source = { editable = "." }
 dependencies = [

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -890,6 +890,11 @@ int main(int argc, char** argv) {
 
     oid::host::StageView view{*canvas};
 
+    // Platform seam: hand non-native ports the same model/stages/ui/canvas
+    // this frontend renders through, for the port's own agent glue.
+    // Native's implementation is a no-op (its endpoint is assembled below).
+    oid::platform::register_agent_targets(model, stages, ui, canvas);
+
 #if !defined(__EMSCRIPTEN__)
     // Native agent endpoint: off unless OID_AGENT=1. `agent_model` adapts
     // the same model/stages/ui/canvas the ImGui frontend already renders

--- a/src/platform/app_services.cpp
+++ b/src/platform/app_services.cpp
@@ -46,6 +46,16 @@ void install_platform_hooks() {
      * above */
 }
 
+// No-op on native: the native agent endpoint is assembled directly in
+// main.cpp (NativeViewModel + AgentServer); only a non-native platform
+// port needs these objects handed across the platform seam.
+void register_agent_targets(oid::host::IpcBufferModel& /*model*/,
+                            oid::host::StageManager& /*stages*/,
+                            oid::host::UiState& /*ui*/,
+                            std::shared_ptr<RenderCanvas> /*canvas*/) {
+    // Nothing to register on native; see the header comment.
+}
+
 struct SettingsBackend::Impl {
     host::SettingsStore store{host::config_file_path()};
 };

--- a/src/platform/app_services.h
+++ b/src/platform/app_services.h
@@ -33,6 +33,7 @@
 #include <vector>
 
 #include "host/settings/app_settings.h"
+#include "visualization/render_canvas.h"
 
 struct GLFWwindow;
 
@@ -43,6 +44,8 @@ class Buffer;
 namespace oid::host {
 class IpcClient;
 class IpcBufferModel;
+class StageManager;
+class UiState;
 struct ExportDialogState;
 } // namespace oid::host
 
@@ -66,6 +69,17 @@ void install_platform_hooks();
 // dialog and the frame-loop file-open queue. Call once, after the model is
 // constructed and before the main loop starts.
 void register_file_open_sink(host::IpcBufferModel& model);
+
+// Non-native: hands the out-of-tree platform port the same
+// model/stages/ui/canvas this frontend renders through, so the port's own
+// agent glue can adapt them behind the shared agent ViewModel seam
+// (host/agent/view_model.h). Native: no-op -- the native agent endpoint is
+// assembled directly in main.cpp (NativeViewModel + AgentServer). Call
+// once, after StageManager construction and before the frame loop starts.
+void register_agent_targets(oid::host::IpcBufferModel& model,
+                            oid::host::StageManager& stages,
+                            oid::host::UiState& ui,
+                            std::shared_ptr<RenderCanvas> canvas);
 
 // Settings persistence backend. Native: on-disk JSON store at the platform
 // config path. Non-native: no local file -- load() yields defaults (real


### PR DESCRIPTION
## Summary

OID-side groundwork so that a non-native, out-of-tree platform port can expose the **same** agent control/readback endpoint the native viewer already serves — reusing the shared `AgentCore` request handler, with **zero new IPC message types** and the native path byte-for-byte unchanged. It also promotes the `oid-mcp` client to a real, installable PyPI distribution so a single client serves every viewer.

## Changes

- **`oid-mcp` client — skip & reap refused viewer discovery entries.** A discovery file can outlive its endpoint while the pid that wrote it lives on (e.g. a long-lived embedding host whose endpoint is gone): the reader's pid probe passes but the port refuses. `SessionManager._call_viewer` now treats connection-refused as a dead viewer, reaps the stale discovery file, and re-resolves so another live viewer wins; a bounded walk raises `NoSessionError` when nothing serves.

- **Distribution renamed to `oid-mcp`; self-contained wheel.** The wheel force-includes the single-sourced `oidscripts` wire codec as a top-level package, and `oidmcp._wireframe` accepts it from the repo layout, the installed site-packages layout, and the editable-dev layout (the foreign-`oidscripts` guard stays a strict realpath check). Wheel-only publishing, since an unpacked sdist cannot resolve `../oidscripts`.

- **PyPI trusted-publishing workflow.** Version tags run the test suite, build and smoke-import the wheel, then upload via `pypa/gh-action-pypi-publish` using OIDC (`id-token: write`, no stored token). Actions are SHA-pinned and `uv` is version-pinned, matching the repo's CI house style.

- **`register_agent_targets` platform seam** — a native no-op mirroring the existing `register_file_open_sink` idiom, so an out-of-tree platform port can wire a live `StageManager` / `UiState` / `RenderCanvas` into `AgentCore`.

## Testing

- `oid-mcp`: full pytest suite green (refused-reap, installed-layout, and purelib-layout isolated-import regressions included); ruff clean.
- Native build + `ctest` green; `clang-format` clean.
- CI, SonarCloud quality gate, and CodeQL all green.
