### PR TITLE
chore(oid-mcp): bump version to 0.3.0

### DIFF
--- a/resources/oidmcp/pyproject.toml
+++ b/resources/oidmcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oid-mcp"
-version = "0.2.0"
+version = "0.3.0"
 description = "MCP server giving AI agents eyes on OpenImageDebugger buffers in live gdb/lldb sessions"
 requires-python = ">=3.10"
 dependencies = [
@@ -26,8 +26,8 @@ packages = ["oidmcp"]
 # (resources/oidscripts). An installed wheel has no sibling resources/
 # checkout, so ship that tree inside the wheel as a top-level `oidscripts`
 # package (oidmcp/_wireframe.py accepts it there). Wheel-only publishing:
-# an sdist cannot reference ../oidscripts once unpacked, so Task 4 builds
-# and uploads the wheel only.
+# an sdist cannot reference ../oidscripts once unpacked, so the publish
+# workflow builds and uploads the wheel only.
 [tool.hatch.build.targets.wheel.force-include]
 "../oidscripts" = "oidscripts"
 

--- a/resources/oidmcp/uv.lock
+++ b/resources/oidmcp/uv.lock
@@ -578,7 +578,7 @@ wheels = [
 
 [[package]]
 name = "oid-mcp"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
Bumps the `oid-mcp` distribution to 0.3.0 for its first tagged PyPI release; `uv.lock` synced to match. Also rewords a wheel-packaging comment to drop a stray internal note.

Local: 203 pytest pass, wheel builds and smoke-imports clean.