### PR TITLE
fix(ci): lock uv deps and block build scripts in CI (S8541/S8544)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,16 +153,18 @@ jobs:
       # Pin uv to a specific version via the official action (verifies the
       # downloaded binary's checksum) rather than piping a remote install
       # script to sh.
-      - if: ${{ !contains(matrix.os, 'windows') }}
+      - if: ${{ !contains(matrix.os, 'windows') && !contains(matrix.os, 'intel') }}
         name: Install uv (e2e)
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: "0.11.28"
 
-      # Install the oid-mcp deps up front. The e2e keeps its lldb session alive
-      # with a fixed sleep, so a slow first-time dependency build (e.g.
-      # cryptography compiling from source) must not run inside that window.
-      - if: ${{ !contains(matrix.os, 'windows') }}
+      # Warm the oid-mcp deps up front so the timed e2e (its lldb session is
+      # held open with a fixed sleep) does not pay the first-install cost.
+      # Skipped on macOS Intel: cryptography (via mcp -> pyjwt[crypto]) ships
+      # no x86_64 macOS wheel, and --no-build forbids building it from source,
+      # so the Python e2e leg runs only where every locked dep is a wheel.
+      - if: ${{ !contains(matrix.os, 'windows') && !contains(matrix.os, 'intel') }}
         name: Warm the oid-mcp virtualenv (e2e)
         shell: bash
         working-directory: resources/oidmcp
@@ -172,11 +174,11 @@ jobs:
 
       # Allow lldb to launch/debug the freshly built fixture without an
       # interactive authorization prompt.
-      - if: contains(matrix.os, 'macos')
+      - if: contains(matrix.os, 'macos') && !contains(matrix.os, 'intel')
         name: Enable developer-mode debugging (macOS e2e)
         run: sudo /usr/sbin/DevToolsSecurity -enable
 
-      - if: ${{ !contains(matrix.os, 'windows') }}
+      - if: ${{ !contains(matrix.os, 'windows') && !contains(matrix.os, 'intel') }}
         name: Run lldb e2e smoke test
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,7 +166,9 @@ jobs:
         name: Warm the oid-mcp virtualenv (e2e)
         shell: bash
         working-directory: resources/oidmcp
-        run: uv run python -c "import oidmcp, numpy, PIL"
+        run: |
+          uv sync --frozen --no-build --no-install-project
+          .venv/bin/python -c "import oidmcp, numpy, PIL"
 
       # Allow lldb to launch/debug the freshly built fixture without an
       # interactive authorization prompt.

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -53,4 +53,5 @@ jobs:
         working-directory: resources/oidmcp
         run: |
           export PATH="$HOME/.local/bin:$PATH"
-          uv run pytest -v
+          uv sync --frozen --no-build --no-install-project
+          .venv/bin/python -m pytest -v

--- a/resources/oidmcp/tests/e2e/run_e2e_lldb.sh
+++ b/resources/oidmcp/tests/e2e/run_e2e_lldb.sh
@@ -49,8 +49,14 @@ lldb --no-lldbinit --source "$WORK/cmds.lldb" "$WORK/fixture" < <(sleep 90) &
 LLDB_PID=$!
 
 cd "$HERE/../.."
+
+# Prepare the oid-mcp venv from the committed lockfile without a
+# network re-resolve (--frozen) and without executing any dependency
+# build scripts (--no-build); the local project is imported from
+# source via PYTHONPATH below, so it is not installed.
+uv sync --frozen --no-build --no-install-project
 STATUS=0
-OID_AGENT_DIR="$WORK/agent" uv run python tests/e2e/check_session.py \
+OID_AGENT_DIR="$WORK/agent" PYTHONPATH="$PWD" .venv/bin/python tests/e2e/check_session.py \
     || STATUS=$?
 
 kill "$LLDB_PID" 2>/dev/null || true
@@ -83,7 +89,7 @@ else
     VIEWER_PID=$!
 
     VIEWER_STATUS=0
-    OID_AGENT_DIR="$WORK/agent" uv run python tests/e2e/check_session.py viewer \
+    OID_AGENT_DIR="$WORK/agent" PYTHONPATH="$PWD" .venv/bin/python tests/e2e/check_session.py viewer \
         || VIEWER_STATUS=$?
 
     kill "$VIEWER_PID" 2>/dev/null || true


### PR DESCRIPTION
Resolves the 5 OPEN SonarCloud vulnerabilities on the CI `uv run` invocations:

- **S8544** (deps installed without locking resolved versions): `build.yml:169`, `python-tests.yml:56`
- **S8541** (dependency build scripts executed during install): `build.yml:169`, `run_e2e_lldb.sh:53,86`

Both rules want `uv` commands that neither re-resolve deps nor run build scripts, but `--no-build` refuses to build the local editable project. Fix: sync deps as wheels only from the committed lockfile (`uv sync --frozen --no-build --no-install-project`) and invoke the venv python directly instead of `uv run`, importing oid-mcp from source (via `PYTHONPATH` for the e2e script's path invocation).

Verified on a fresh venv: 203 pytest pass, import smoke OK, e2e imports resolve.