### PR TITLE
fix: resolve agent discovery dir from home, not $TMPDIR

### DIFF
--- a/resources/oidmcp/README.md
+++ b/resources/oidmcp/README.md
@@ -113,16 +113,13 @@ the same directory** (see [Troubleshooting](#troubleshooting)).
    | Variable | Default | Purpose |
    | --- | --- | --- |
    | `OID_MCP_MAX_BYTES` | `268435456` (256 MiB) | Reject buffers larger than this before transfer |
-   | `OID_AGENT_DIR` | `$TMPDIR/oid-agent-<user>/` | Discovery directory shared by debugger and server |
+   | `OID_AGENT_DIR` | `~/.oid-agent/` (`%LOCALAPPDATA%\oid-agent` on Windows) | Discovery directory shared by debugger and server |
 
-   > **Desktop editors and discovery.** A GUI client spawns `oid-mcp`
-   > from the app's environment, which may carry a different `$TMPDIR`
-   > than the terminal running your debugger — so the two default
-   > `$TMPDIR/oid-agent-<user>` paths won't match and `list_sessions`
-   > comes back empty. If that happens, pin `OID_AGENT_DIR` to the same
-   > private directory (e.g. `~/.oid-agent`) in both the client's `env`
-   > and the debugger's environment. See
-   > [Troubleshooting](#troubleshooting).
+   > **Discovery location.** The default directory is derived from your home
+   > directory (via the password database), so a GUI-spawned `oid-mcp` and a
+   > terminal debugger resolve the same path regardless of `$TMPDIR`/`$HOME`.
+   > To relocate it, set `OID_AGENT_DIR` in both environments to the same
+   > **absolute** path (`~` is not expanded).
 
 ## Use
 
@@ -207,7 +204,7 @@ debugger pid paired to a live viewer.
 
 - The endpoint only starts when `OID_AGENT=1` is set; it binds
   localhost with a per-session token (discovery files under
-  `$TMPDIR/oid-agent-<user>/`, override with `OID_AGENT_DIR`). It
+  `~/.oid-agent/`, override with `OID_AGENT_DIR`). It
   exposes debuggee memory to local processes that can read those
   files — the same trust domain as your user account.
 - Buffers transfer fully on first access per stop and are cached;

--- a/resources/oidmcp/oidmcp/discovery.py
+++ b/resources/oidmcp/oidmcp/discovery.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import getpass
 import json
 import os
 import stat
@@ -36,15 +35,40 @@ class ViewerSessionInfo:
     debugger_pid: int | None
 
 
+def _home_dir():
+    # Passwd-based home so a stripped-env MCP subprocess and the GUI-launched
+    # viewer resolve the same dir independent of $HOME/$TMPDIR/$XDG_*. Returns
+    # None when the uid has no (or an empty) passwd entry and $HOME is unset;
+    # discovery_dir() then uses a per-uid temp dir so uids do not collide.
+    try:
+        import pwd
+        home = pwd.getpwuid(os.getuid()).pw_dir
+        if home:
+            return home
+    except (KeyError, ImportError, OSError):
+        pass  # no passwd entry -> try $HOME, then a per-uid temp dir
+    return os.environ.get('HOME') or None
+
+
 def discovery_dir() -> Path:
     override = os.environ.get('OID_AGENT_DIR')
     if override:
         return Path(override)
-    try:
-        user = getpass.getuser()
-    except Exception:
-        user = str(os.getuid()) if hasattr(os, 'getuid') else 'user'
-    return Path(tempfile.gettempdir()) / f'oid-agent-{user}'
+    if os.name == 'nt':
+        local = os.environ.get('LOCALAPPDATA')
+        if local:
+            return Path(local) / 'oid-agent'
+        profile = os.environ.get('USERPROFILE')
+        if profile:
+            return Path(profile) / 'AppData' / 'Local' / 'oid-agent'
+        # No LOCALAPPDATA/USERPROFILE: %TEMP% is already per-user.
+        return Path(tempfile.gettempdir()) / 'oid-agent'  # NOSONAR
+    home = _home_dir()
+    if home:
+        return Path(home) / '.oid-agent'
+    # No passwd entry and no $HOME: /tmp is shared, so key the fallback by uid
+    # to avoid collisions (a dir owned by another uid would be refused).
+    return Path(tempfile.gettempdir()) / f'oid-agent-{os.getuid()}'  # NOSONAR
 
 
 def viewer_discovery_dir() -> Path:

--- a/resources/oidmcp/tests/test_discovery.py
+++ b/resources/oidmcp/tests/test_discovery.py
@@ -1,6 +1,8 @@
 import json
 import os
 import sys
+import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -286,3 +288,49 @@ def test_pid_alive_nonpositive_is_dead_without_probing(monkeypatch):
 
     assert discovery._pid_alive(0) is False
     assert discovery._pid_alive(-1) is False
+
+
+@pytest.mark.skipif(sys.platform == 'win32', reason='POSIX passwd home')
+def test_discovery_dir_is_home_based_and_env_independent(monkeypatch):
+    # The dir must come from the passwd database, not $HOME/$TMPDIR/$XDG_*,
+    # so a stripped-env MCP subprocess and the GUI viewer agree. Skip where
+    # the uid has no passwd entry: _home_dir() then falls back to $HOME, which
+    # this env-independence assertion cannot hold for.
+    import pwd
+    try:
+        home = pwd.getpwuid(os.getuid()).pw_dir
+    except (KeyError, OSError):
+        pytest.skip('no passwd entry for this uid')
+    if not home:
+        pytest.skip('empty passwd home for this uid')
+    monkeypatch.delenv('OID_AGENT_DIR', raising=False)
+    for var in ('TMPDIR', 'HOME', 'XDG_RUNTIME_DIR', 'XDG_CACHE_HOME',
+                'USER', 'LOGNAME'):
+        monkeypatch.delenv(var, raising=False)
+    assert discovery.discovery_dir() == Path(home) / '.oid-agent'
+    # Skewing TMPDIR/HOME must not move it (passwd-based, not env-based).
+    monkeypatch.setenv('TMPDIR', '/env/ignored-tmpdir')
+    monkeypatch.setenv('HOME', '/env/ignored-home')
+    assert discovery.discovery_dir() == Path(home) / '.oid-agent'
+
+
+def test_discovery_dir_respects_override(monkeypatch):
+    monkeypatch.setenv('OID_AGENT_DIR', '/custom/base')
+    assert discovery.discovery_dir() == Path('/custom/base')
+
+
+@pytest.mark.skipif(sys.platform == 'win32', reason='POSIX temp fallback')
+def test_discovery_dir_temp_fallback_is_per_uid(monkeypatch):
+    # No passwd entry and no $HOME: the fallback must be a per-uid temp dir so
+    # different uids do not contend for one shared /tmp/.oid-agent (which the
+    # owner check would then refuse).
+    import pwd
+
+    def _no_passwd(_uid):
+        raise KeyError('no passwd entry')
+
+    monkeypatch.delenv('OID_AGENT_DIR', raising=False)
+    monkeypatch.delenv('HOME', raising=False)
+    monkeypatch.setattr(pwd, 'getpwuid', _no_passwd)
+    expected = Path(tempfile.gettempdir()) / f'oid-agent-{os.getuid()}'
+    assert discovery.discovery_dir() == expected

--- a/resources/oidscripts/agentendpoint.py
+++ b/resources/oidscripts/agentendpoint.py
@@ -229,7 +229,6 @@ class AgentEndpoint(object):
 
 
 import atexit
-import getpass
 import json
 import socket
 import tempfile
@@ -238,19 +237,47 @@ import time
 from oidscripts.logger import log
 
 
+def _home_dir():
+    """Passwd-database home so a debugger endpoint and a stripped-env client
+    resolve the same dir independent of $HOME/$TMPDIR/$XDG_*. Returns None when
+    the uid has no (or an empty) passwd entry and $HOME is unset; discovery_dir()
+    then uses a per-uid temp dir so uids do not collide. Mirrors the native
+    home_dir()."""
+    try:
+        import pwd
+        home = pwd.getpwuid(os.getuid()).pw_dir
+        if home:
+            return home
+    except (KeyError, ImportError, OSError):
+        pass  # no passwd entry -> try $HOME, then a per-uid temp dir
+    return os.environ.get('HOME') or None
+
+
 def discovery_dir():
     """
     Directory holding per-session discovery files. Overridable with
-    OID_AGENT_DIR; defaults to <tempdir>/oid-agent-<user>.
+    OID_AGENT_DIR (an absolute path; ~ is not expanded); defaults to the
+    passwd-database home / .oid-agent (%LOCALAPPDATA%\\oid-agent on Windows),
+    stable across launch contexts.
     """
     override = os.environ.get('OID_AGENT_DIR')
     if override:
         return override
-    try:
-        user = getpass.getuser()
-    except Exception:
-        user = str(os.getuid()) if hasattr(os, 'getuid') else 'user'
-    return os.path.join(tempfile.gettempdir(), 'oid-agent-%s' % user)
+    if os.name == 'nt':
+        local = os.environ.get('LOCALAPPDATA')
+        if local:
+            return os.path.join(local, 'oid-agent')
+        profile = os.environ.get('USERPROFILE')
+        if profile:
+            return os.path.join(profile, 'AppData', 'Local', 'oid-agent')
+        # No LOCALAPPDATA/USERPROFILE: %TEMP% is already per-user.
+        return os.path.join(tempfile.gettempdir(), 'oid-agent')  # NOSONAR
+    home = _home_dir()
+    if home:
+        return os.path.join(home, '.oid-agent')
+    # No passwd entry and no $HOME: /tmp is shared, so key the fallback by uid.
+    return os.path.join(tempfile.gettempdir(),
+                        'oid-agent-%d' % os.getuid())  # NOSONAR
 
 
 def _prepare_discovery_dir():

--- a/src/host/agent/agent_server.cpp
+++ b/src/host/agent/agent_server.cpp
@@ -292,7 +292,7 @@ const std::string& AgentServer::token() const {
 
 void AgentServer::publish_discovery() {
     const std::filesystem::path dir = viewer_discovery_dir();
-    // Harden the predictable base dir (dir's parent, tempdir/oid-agent-<user>)
+    // Harden the predictable base dir (dir's parent, <home>/.oid-agent)
     // before the viewer subdir. Previously only the leaf was checked, so a
     // base pre-planted as a symlink or owned by another user could redirect
     // where this token-bearing discovery file lands. Rejecting a symlinked /

--- a/src/host/agent/discovery_file.cpp
+++ b/src/host/agent/discovery_file.cpp
@@ -27,6 +27,7 @@
 
 #include <cerrno>
 #include <cstdlib>
+#include <format>
 #include <string_view>
 #include <system_error>
 #include <vector>
@@ -45,29 +46,28 @@ namespace oid::host::agent {
 
 namespace {
 
-// Mirrors oidmcp.discovery's user lookup (itself matching Python's
-// getpass.getuser()): the environment first, then the password database,
-// then the numeric uid as a last resort so this never throws.
-std::string current_user() {
-    // Mirror Python's getpass.getuser() (which oid-mcp's discovery.py uses) so
-    // the default discovery dir path agrees on both sides: try LOGNAME, USER,
-    // LNAME, USERNAME in that exact order before any platform fallback. (A
-    // different order here would break discovery whenever these env vars
-    // disagree.)
-    for (const char* var : {"LOGNAME", "USER", "LNAME", "USERNAME"}) {
-        if (const char* name = std::getenv(var); name && *name) { // NOSONAR
-            return name;
-        }
-    }
+// The home-directory base: the password database on POSIX (or
+// LOCALAPPDATA/USERPROFILE on Windows), so a stripped-env MCP subprocess and
+// the GUI-launched viewer resolve the same directory, agreeing byte-for-byte
+// with oid-mcp's discovery.py. Returns an empty path when the uid has no home;
+// base_discovery_dir() then uses a per-uid temp dir. $HOME is a POSIX fallback
+// only -- reading it (or $TMPDIR/$XDG_*) for the primary path would reintroduce
+// the launch-context mismatch this avoids.
+std::filesystem::path home_dir() {
 #ifdef _WIN32
-    // No POSIX password database on Windows: getpass.getuser() raises there and
-    // oid-mcp's discovery_dir() falls back to "user" (no os.getuid either).
-    return "user";
+    if (const char* local = std::getenv("LOCALAPPDATA");
+        local && *local) { // NOSONAR
+        return std::filesystem::path{local};
+    }
+    if (const char* profile = std::getenv("USERPROFILE"); // NOSONAR
+        profile != nullptr && *profile != '\0') {
+        return std::filesystem::path{profile} / "AppData" / "Local";
+    }
+    return {};
 #else
     // NOSONAR(cpp:S1912): ::getpwuid returns a pointer into shared static
-    // storage that another thread's lookup can overwrite; ::getpwuid_r fills
-    // our own buffer instead. Matches Python's pwd.getpwuid() fallback, then
-    // the uid string (discovery.py's final fallback when getpass raises).
+    // storage another thread's lookup can overwrite; ::getpwuid_r fills our
+    // own buffer instead.
     passwd pwd{};
     passwd* result = nullptr;
     long n = ::sysconf(_SC_GETPW_R_SIZE_MAX);
@@ -76,10 +76,16 @@ std::string current_user() {
     }
     if (std::vector<char> buf(static_cast<std::size_t>(n));
         getpwuid_r(getuid(), &pwd, buf.data(), buf.size(), &result) == 0 &&
-        result != nullptr && result->pw_name != nullptr) {
-        return std::string(result->pw_name);
+        result != nullptr && result->pw_dir != nullptr &&
+        *result->pw_dir != '\0') {
+        return std::filesystem::path{result->pw_dir};
     }
-    return std::to_string(static_cast<long>(getuid()));
+    // No passwd entry: fall back to $HOME, else signal "no home" so the caller
+    // uses a per-uid temp dir.
+    if (const char* home = std::getenv("HOME"); home && *home) { // NOSONAR
+        return std::filesystem::path{home};
+    }
+    return {};
 #endif
 }
 
@@ -88,11 +94,24 @@ std::filesystem::path base_discovery_dir() {
         override_dir != nullptr && *override_dir != '\0') {
         return std::filesystem::path{override_dir};
     }
-    // NOSONAR(cpp:S5443): the discovery dir must be the shipped
-    // $TMPDIR/oid-agent-<user> path that oid-mcp (discovery.py) globs to find
-    // viewers; prepare_private_dir hardens it (owner check, O_NOFOLLOW, 0700).
+    // Per-user home so the path is stable across launch contexts and agrees
+    // with oid-mcp's discovery.py; prepare_private_dir hardens it (owner check,
+    // O_NOFOLLOW, 0700).
+#ifdef _WIN32
+    if (const std::filesystem::path home = home_dir(); !home.empty()) {
+        return home / "oid-agent";
+    }
+    // No LOCALAPPDATA/USERPROFILE: %TEMP% is already per-user.
+    return std::filesystem::temp_directory_path() / "oid-agent"; // NOSONAR
+#else
+    if (const std::filesystem::path home = home_dir(); !home.empty()) {
+        return home / ".oid-agent";
+    }
+    // No passwd entry and no $HOME: /tmp is shared, so key the fallback by uid
+    // to avoid collisions (a dir owned by another uid would be refused).
     return std::filesystem::temp_directory_path() / // NOSONAR
-           ("oid-agent-" + current_user());
+           std::format("oid-agent-{}", getuid());
+#endif
 }
 
 } // namespace

--- a/src/host/agent/discovery_file.h
+++ b/src/host/agent/discovery_file.h
@@ -41,7 +41,7 @@ class DiscoveryError : public std::runtime_error {
 };
 
 // Directory holding per-viewer discovery files: <OID_AGENT_DIR> (if set)
-// or <tempdir>/oid-agent-<user>, plus a "viewer" subdirectory. That
+// or <home>/.oid-agent, plus a "viewer" subdirectory. That
 // subdirectory is what keeps the shipped flat *.json glob (which only
 // scans the parent directory for debugger sessions) from ever seeing a
 // viewer's discovery file, even though it never looks here regardless.

--- a/tests/host/agent/agent_server_test.cpp
+++ b/tests/host/agent/agent_server_test.cpp
@@ -72,7 +72,10 @@ long current_pid() {
 class ScopedEnvVar {
   public:
     ScopedEnvVar(const char* name, const std::string& value) : name_(name) {
-        if (const char* prev = std::getenv(name)) {
+        // The prior value is only saved to restore on teardown; it is never
+        // used to open or create files, so reading a TMPDIR or *_DIR env var
+        // here is safe.
+        if (const char* prev = std::getenv(name)) { // NOSONAR(cpp:S5443)
             had_prev_ = true;
             prev_ = prev;
         }
@@ -467,3 +470,19 @@ TEST_F(AgentServerTest, EnqueueListenerFiresWhenARequestIsQueued) {
     EXPECT_EQ(notifications.load(), 1);
     server.stop();
 }
+
+#ifndef _WIN32
+// The default discovery dir must come from the passwd-database home, not
+// $HOME/$TMPDIR, so a stripped-env MCP subprocess and the GUI-launched viewer
+// resolve the same directory. (An empty OID_AGENT_DIR reads as "no override".)
+TEST(AgentDiscoveryDir, DefaultIsHomeBasedAndEnvIndependent) {
+    const ScopedEnvVar no_override("OID_AGENT_DIR", "");
+    const std::filesystem::path base = viewer_discovery_dir();
+    EXPECT_EQ(base.filename(), "viewer");
+    EXPECT_EQ(base.parent_path().filename(), ".oid-agent");
+    // Skewing TMPDIR/HOME must not move it (passwd-based, not env-based).
+    const ScopedEnvVar skew_tmp("TMPDIR", "/env/ignored-tmpdir");
+    const ScopedEnvVar skew_home("HOME", "/env/ignored-home");
+    EXPECT_EQ(viewer_discovery_dir(), base);
+}
+#endif


### PR DESCRIPTION
Move the agent discovery directory off `$TMPDIR` to a per-user, environment-independent location so a GUI-launched viewer and a stripped-env MCP subprocess always resolve the same directory.

## Problem

`$TMPDIR` differs between launch contexts on macOS: a GUI-launched viewer has the per-user `/var/folders/<hash>/T`, but an MCP subprocess (e.g. `uvx oid-mcp` spawned by an editor) runs with `$TMPDIR` **unset**, so `tempfile.gettempdir()` falls back to `/tmp`. Writer and reader then look in different discovery dirs and the client finds no viewer (`list_sessions` returns empty even though the viewer is up).

## Fix

Resolve the default discovery base from the **passwd database** — `~/.oid-agent` (POSIX) / `%LOCALAPPDATA%\oid-agent` (Windows) — with no dependence on `$HOME`/`$TMPDIR`/`$XDG_*` and no per-user suffix (home is already per-user, which also removes the `getpass.getuser()` vs `os.userInfo().username` mismatch).

All three participants in this repo move together, computing byte-identical paths:
- the `oid-mcp` reader — `resources/oidmcp/oidmcp/discovery.py`
- the native viewer writer — `src/host/agent/discovery_file.cpp`
- the debugger-endpoint writer — `resources/oidscripts/agentendpoint.py`

The extension's own writer follows in the extension repo (clean break — no legacy-dir scanning).

**Fallbacks (edge-case environments):** a missing/empty passwd entry falls back to `$HOME`; with neither available, a **per-uid** temp dir (`<tmpdir>/oid-agent-<uid>` on POSIX) is used so different uids never contend for one shared `/tmp/.oid-agent` (which the owner check would then refuse). The `OID_AGENT_DIR` override (absolute path; `~` is not expanded) and all `0700`/owner/symlink hardening are unchanged.

## Tests

- Env-invariance: the dir stays `~/.oid-agent` when `$TMPDIR`/`$HOME`/`$XDG_*` are unset or skewed; skipped where the uid has no passwd entry.
- Per-uid fallback: with the passwd lookup forced to fail and `$HOME` unset, the dir resolves to `<tmpdir>/oid-agent-<uid>`.
- `oid-mcp` pytest **206/206**, native `agent_server_test` **12/12**, clang-format clean.
