### PR TITLE
chore(oid-mcp): bump to 0.3.1 and pin Commisery version-prefix

### DIFF
--- a/.commisery.yml
+++ b/.commisery.yml
@@ -1,0 +1,11 @@
+# Commisery only manages the "v"-prefixed viewer release tags (e.g. v2.9.0).
+#
+# Without this, version-prefix defaults to "*", which means "the closest
+# existing version tag regardless of prefix". That made the auto-bumper latch
+# onto the manually-created oid-mcp-v* PyPI tags and mint further oid-mcp-v*
+# tags on merges to main -- without bumping the static oid-mcp version -- so
+# those PyPI publishes failed as duplicate uploads.
+#
+# The oid-mcp PyPI package is released manually and independently: bump
+# resources/oidmcp/pyproject.toml and push a matching oid-mcp-vX.Y.Z tag.
+version-prefix: "v"

--- a/resources/oidmcp/pyproject.toml
+++ b/resources/oidmcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oid-mcp"
-version = "0.3.0"
+version = "0.3.1"
 description = "MCP server giving AI agents eyes on OpenImageDebugger buffers in live gdb/lldb sessions"
 requires-python = ">=3.10"
 dependencies = [

--- a/resources/oidmcp/uv.lock
+++ b/resources/oidmcp/uv.lock
@@ -578,7 +578,7 @@ wheels = [
 
 [[package]]
 name = "oid-mcp"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
Bumps the `oid-mcp` PyPI package to **0.3.1** and fixes the Commisery config that was mis-minting `oid-mcp-v*` tags.

## Version bump

`resources/oidmcp/pyproject.toml` and `uv.lock` → `0.3.1`. This package ships the discovery-dir fix from #996 (home-based agent rendezvous dir, environment-independent) so an editor-spawned MCP subprocess and a GUI-launched viewer resolve the same directory.

Verified: wheel builds `oid_mcp-0.3.1-py3-none-any.whl`, `uv lock --check` clean, pytest **206/206**.

## Commisery `version-prefix` fix

`oid-mcp` uses a **static** version (hatchling), so a release is a `pyproject` bump plus a pushed `oid-mcp-vX.Y.Z` tag. But Commisery's `version-prefix` defaulted to `"*"` — "the closest existing version tag regardless of prefix" — so the auto-bumper latched onto the manual `oid-mcp-v0.3.0` tag and minted `oid-mcp-v0.3.1` / `oid-mcp-v0.3.2` on merges to main **without** bumping the static version. Those PyPI publishes then failed as duplicate uploads.

`.commisery.yml` now sets `version-prefix: "v"`, so Commisery only considers and creates the `v*` viewer tags and ignores `oid-mcp-v*`. The `oid-mcp` release stays fully manual.

The two burned `oid-mcp-v0.3.1` / `oid-mcp-v0.3.2` tags+releases (no PyPI artifact) are cleared, so `0.3.1` can be re-tagged from this merge for the real publish.
