### PR TITLE
ci: publish oid-mcp to the MCP registry

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,8 @@
+# clang-format's JSON formatter would reflow our hand-authored JSON to the
+# C/C++ style in .clang-format (IndentWidth 4, ColumnLimit 80), wrapping long
+# string values. git-clang-format lists .json in its default extensions, so
+# the CI formatting gate would rewrite files like resources/oidmcp/server.json.
+# JSON in this repo is 2-space and clang-format does not own it. The globstar
+# is required: a bare `*` pattern is anchored to this directory and does not
+# cross `/` into subdirectories.
+**/*.json

--- a/.github/workflows/publish-oid-mcp.yml
+++ b/.github/workflows/publish-oid-mcp.yml
@@ -21,7 +21,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-name: Publish oid-mcp to PyPI
+name: Publish oid-mcp
 
 on:
   push:
@@ -35,7 +35,7 @@ jobs:
   test:
     uses: ./.github/workflows/python-tests.yml
 
-  publish:
+  publish-pypi:
     needs: [test]
     runs-on: ubuntu-24.04
     environment: pypi
@@ -87,3 +87,61 @@ jobs:
         uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1
         with:
           packages-dir: resources/oidmcp/dist
+
+  # Runs after the PyPI publish so the version server.json points at
+  # already exists on PyPI -- the registry validates the package/version
+  # pair by querying PyPI directly, and a same-version-in-parallel race
+  # would fail that check.
+  publish-mcp-registry:
+    needs: [publish-pypi]
+    runs-on: ubuntu-24.04
+    permissions:
+      # GitHub OIDC (login github-oidc): the registry verifies the workflow
+      # identity, so no stored token is needed for the org namespace.
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Read package version
+        id: version
+        working-directory: resources/oidmcp
+        run: |
+          version=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # Pinned to a fixed release with a hardcoded digest (not
+      # `releases/latest`) so the tool that performs the authenticated
+      # publish is reproducible and can't silently change under us. The
+      # runner is always linux/amd64, so a single digest covers it.
+      # --proto/--proto-redir keep the fetch (and any redirect) on HTTPS.
+      - name: Install mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.8.0
+          MCP_PUBLISHER_SHA256: 1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf
+        run: |
+          curl --proto '=https' --tlsv1.2 --proto-redir '=https' -fsSL \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" \
+            -o mcp-publisher.tar.gz
+          echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum -c -
+          tar xzf mcp-publisher.tar.gz mcp-publisher
+          sudo mv mcp-publisher /usr/local/bin/
+
+      # server.json is checked in with a placeholder version; stamp it with
+      # the version actually just published to PyPI so the two never drift.
+      - name: Stamp server.json version
+        working-directory: resources/oidmcp
+        run: |
+          jq --arg v "${{ steps.version.outputs.version }}" \
+            '.version = $v | .packages[0].version = $v' server.json > server.json.tmp
+          mv server.json.tmp server.json
+
+      - name: Authenticate to MCP Registry
+        run: mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        working-directory: resources/oidmcp
+        run: mcp-publisher publish

--- a/resources/oidmcp/README.md
+++ b/resources/oidmcp/README.md
@@ -1,5 +1,7 @@
 # oid-mcp
 
+<!-- mcp-name: io.github.openimagedebugger/oid-mcp -->
+
 MCP server that gives AI agents eyes on OpenImageDebugger buffers in a
 live gdb/lldb session: list observable symbols at a breakpoint, view
 renderings, read exact values, dump lossless `.npy` copies, and mirror

--- a/resources/oidmcp/server.json
+++ b/resources/oidmcp/server.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.openimagedebugger/oid-mcp",
+  "title": "OpenImageDebugger MCP",
+  "description": "MCP server giving AI agents eyes on OpenImageDebugger buffers in live gdb/lldb sessions",
+  "version": "0.3.1",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "oid-mcp",
+      "version": "0.3.1",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a `publish-mcp-registry` job to the release workflow, running after the PyPI publish succeeds
- Stamp `server.json` with the just-published version and register it via `mcp-publisher` using GitHub OIDC auth
- Add the `mcp-name` meta tag to the README so the registry can validate repo ownership

## Test plan
- [ ] Tag a release and confirm the `publish-mcp-registry` job runs after `publish-pypi` and completes successfully
- [ ] Confirm `io.github.openimagedebugger/oid-mcp` appears in the MCP registry with the correct version