### PR TITLE
fix: render single-channel buffers whose layout does not start with red

### DIFF
--- a/doc/declarative-types.md
+++ b/doc/declarative-types.md
@@ -76,7 +76,7 @@ happens once per debug session; edits take effect the next session.
 | `dtype` | — (required) | value node → pixel type (see dtype rule) |
 | `channels` | `1` | value node → int; `0` is rejected downstream when the buffer is plotted, not at load |
 | `row_stride` | `"{width}"` | value node → int (pixels per row of the containing buffer) |
-| `pixel_layout` | `"rgba"` | 4 chars from `r g b a` (repeats allowed), or an if/else over such literals |
+| `pixel_layout` | `"rgba"` | 4 chars from `r g b a` (repeats allowed), or an if/else over such literals. Describes channel **order**, so it only carries meaning for multi-channel data: a single-channel buffer is always displayed from its one channel whatever the layout says. Use the `{channels} >= 3` if/else when an entry can be either |
 | `transpose` | `false` | value node → bool |
 | `display_name` | `"{name} ({type})"` | template string; placeholders `{name}` (variable name), `{type}` (type string), `{targ:…}`; not debugger-evaluated |
 | `language` | `"cpp"` | expression dialect; entries a backend can't evaluate are skipped |

--- a/resources/oidmcp/tests/test_declarative_conformance.py
+++ b/resources/oidmcp/tests/test_declarative_conformance.py
@@ -286,19 +286,19 @@ CLEAN_CASES = [
          {'display_name': 'm (%s)' % _EIGEN_STATIC, 'pointer': 16384,
           'width': 4, 'height': 3, 'channels': 1,
           'type': T.OID_TYPES_FLOAT32, 'row_stride': 4,
-          'pixel_layout': 'bgra', 'transpose_buffer': False}),
+          'pixel_layout': 'rgba', 'transpose_buffer': False}),
     Case('eigen_dynamic',
          _eigen_dynamic(_EIGEN_DYNAMIC, 5, 7, 16384), 'm', 'Eigen::Matrix',
          {'display_name': 'm (%s)' % _EIGEN_DYNAMIC, 'pointer': 16384,
           'width': 5, 'height': 7, 'channels': 1,
           'type': T.OID_TYPES_FLOAT64, 'row_stride': 5,
-          'pixel_layout': 'bgra', 'transpose_buffer': True}),
+          'pixel_layout': 'rgba', 'transpose_buffer': True}),
     Case('eigen_map',
          _eigen_map(_EIGEN_MAP, 20480), 'm', 'Eigen::Map',
          {'display_name': 'm (%s)' % _EIGEN_STATIC, 'pointer': 20480,
           'width': 4, 'height': 3, 'channels': 1,
           'type': T.OID_TYPES_FLOAT32, 'row_stride': 4,
-          'pixel_layout': 'bgra', 'transpose_buffer': False}),
+          'pixel_layout': 'rgba', 'transpose_buffer': False}),
 ]
 
 
@@ -390,6 +390,30 @@ def test_diff3_legacy_signed_iplimage_stride_collapses_to_zero():
     metadata = _legacy_metadata('IplImage', symbol, 'ipl')
     assert metadata['type'] == T.OID_TYPES_INT16   # dtype was already correct
     assert metadata['row_stride'] == 0            # the bug the JSON path fixes
+
+
+def test_diff7_single_channel_entries_declare_an_r_first_layout():
+    # #7: pixel_layout names the channel ORDER of multi-channel data, and its
+    # first character also selects which channel the viewer samples. A
+    # single-channel buffer is uploaded as GL_RED, where only .r carries data,
+    # so a layout starting with 'g'/'b'/'a' makes the fragment shader sample a
+    # constant 0 and the whole buffer renders black. The Eigen entries declared
+    # 'bgra' unconditionally even though Eigen matrices are always
+    # single-channel; the OpenCV entries already conditioned on {channels}.
+    for case in CLEAN_CASES:
+        metadata = _new_metadata(case.symbol, case.obj_name)
+        if metadata['channels'] == 1:
+            assert metadata['pixel_layout'][0] == 'r', (
+                '%s is single-channel but declares layout %r'
+                % (case.id, metadata['pixel_layout']))
+
+
+@legacy_only
+def test_diff7_legacy_eigen_declared_bgra_for_single_channel():
+    metadata = _legacy_metadata('Eigen::Matrix',
+                                _eigen_static(_EIGEN_STATIC, 16384), 'm')
+    assert metadata['channels'] == 1
+    assert metadata['pixel_layout'] == 'bgra'  # the bug the JSON path fixes
 
 
 # --- Editor schema tightness: schema-valid must imply loader-loadable ------

--- a/resources/oidscripts/oidtypes/builtin_types.json
+++ b/resources/oidscripts/oidtypes/builtin_types.json
@@ -55,7 +55,7 @@
         "else": { "first_valid": [ { "expr": "{targ:1}", "min": 1 }, "{sym}.m_storage.m_rows" ] } },
       "pointer": { "first_valid": [ "{sym}.m_storage.m_data.array", "{sym}.m_storage.m_data" ] },
       "row_stride": "{width}",
-      "pixel_layout": "bgra"
+      "pixel_layout": "rgba"
     },
     {
       "name": "Eigen::Map",
@@ -71,7 +71,7 @@
         "else": { "first_valid": [ { "expr": "{targ:0.1}", "min": 1 }, "{sym}.m_rows.m_value" ] } },
       "pointer": "{sym}.m_data",
       "row_stride": { "first_valid": [ { "expr": "{sym}.m_stride.m_outer.m_value", "min": 1 }, "{width}" ] },
-      "pixel_layout": "bgra"
+      "pixel_layout": "rgba"
     }
   ]
 }

--- a/src/host/agent/native_view_model.cpp
+++ b/src/host/agent/native_view_model.cpp
@@ -251,6 +251,12 @@ bool NativeViewModel::set_channel(const std::string_view name,
     if (index < 0 || index > 2) {
         return false;
     }
+    // A buffer only carries the channels it has. Isolating one it does not
+    // would leave view_of() reporting a channel that is not the one being
+    // rendered, since a single-channel buffer always renders from red.
+    if (index >= buffer->channels()) {
+        return false;
+    }
     buffer->set_pixel_layout(isolated_layout(index));
     buffer->set_display_channel_mode(1);
     return true;

--- a/src/visualization/components/buffer.cpp
+++ b/src/visualization/components/buffer.cpp
@@ -38,6 +38,7 @@
 #include "math/linear_algebra.h"
 #include "platform/gl_dialect.h"
 #include "visualization/game_object.h"
+#include "visualization/shader_pixel_layout.h"
 #include "visualization/shaders/oid_shaders.h"
 #include "visualization/stage.h"
 
@@ -476,13 +477,7 @@ int Buffer::get_display_channel_mode() const {
 }
 
 int Buffer::get_selected_channel_index() const {
-    if (pixel_layout_[0] == 'g') {
-        return 1;
-    }
-    if (pixel_layout_[0] == 'b') {
-        return 2;
-    }
-    return 0;
+    return selected_channel_index(pixel_layout_, channels_);
 }
 
 float Buffer::tile_coord_x(const int x) const {
@@ -578,10 +573,12 @@ bool Buffer::create_shader_program() {
         channel_type = ShaderProgram::TexelChannels::FORMAT_RGBA;
     }
 
+    // pixel_layout_ keeps whatever the type declared or the user selected; the
+    // shader gets the layout that is actually samplable for this texture.
     return buff_prog_.create(shader::BUFF_VERT_SHADER,
                              shader::BUFF_FRAG_SHADER,
                              channel_type,
-                             pixel_layout_,
+                             shader_pixel_layout(pixel_layout_, channels_),
                              {"mvp",
                               "sampler",
                               "brightness_contrast",

--- a/src/visualization/shader_pixel_layout.h
+++ b/src/visualization/shader_pixel_layout.h
@@ -1,0 +1,84 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef VISUALIZATION_SHADER_PIXEL_LAYOUT_H_
+#define VISUALIZATION_SHADER_PIXEL_LAYOUT_H_
+
+#include <string>
+
+// Deliberately free of GL and canvas headers so the rule can be unit tested
+// without a GL context.
+
+namespace oid {
+
+// Returns the pixel layout the buffer fragment shader must be compiled with.
+//
+// A layout names the channel order of the buffer's data, and the shader takes
+// its source component from the layout's first character. A single-channel
+// buffer is uploaded as a GL_RED texture, whose samples are (r, 0, 0, 1): only
+// the red component carries data. A declared layout starting with 'g', 'b' or
+// 'a' would therefore make the shader read a component that is constant zero,
+// rendering the whole buffer black at every contrast setting. Channel order is
+// meaningless for a single channel, so such a buffer always samples red.
+//
+// Multi-channel buffers keep their declared layout, including the case where
+// the user has selected one channel of an RGB buffer for display: there the
+// texture really does carry that component and the first character is what
+// selects it.
+[[nodiscard]] inline std::string
+shader_pixel_layout(const std::string& declared_layout,
+                    const int texture_channels) {
+    return texture_channels == 1 ? std::string{"rgba"} : declared_layout;
+}
+
+// Returns the channel index a layout selects for display, given how many
+// channels the buffer actually has.
+//
+// The layout's first character names the channel, so this must agree with
+// shader_pixel_layout() or the viewer reports one channel while rendering
+// another. A buffer only carries `texture_channels` components, so a layout
+// naming one beyond that resolves to red -- which is what a single-channel
+// buffer renders, and the only component a GL_RG texture is guaranteed to
+// have when blue is asked for.
+//
+// This also bounds the loop in BufferValues::draw_pixel_values(), which reads
+// the pixel as buffer[pos + channel] without clamping to the channel count.
+[[nodiscard]] inline int selected_channel_index(const std::string& layout,
+                                                const int texture_channels) {
+    if (layout.empty()) {
+        return 0;
+    }
+    auto index = 0;
+    if (layout[0] == 'g') {
+        index = 1;
+    } else if (layout[0] == 'b') {
+        index = 2;
+    }
+    return index < texture_channels ? index : 0;
+}
+
+} // namespace oid
+
+#endif // VISUALIZATION_SHADER_PIXEL_LAYOUT_H_

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -662,6 +662,25 @@ if(OID_BUILD_IMGUI_FRONTEND)
 
     add_test(NAME GlyphAtlasTests COMMAND glyph_atlas_test)
 
+    # Which layout the buffer fragment shader is compiled with, given the
+    # texture's channel count. Header-only rule, deliberately free of GL and
+    # canvas types so it needs no GL context.
+    add_executable(shader_pixel_layout_test
+        visualization/shader_pixel_layout_test.cpp
+    )
+
+    target_include_directories(shader_pixel_layout_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    )
+
+    target_link_libraries(shader_pixel_layout_test
+        PRIVATE
+        GTest::gtest_main
+        GTest::gtest
+    )
+
+    add_test(NAME ShaderPixelLayoutTests COMMAND shader_pixel_layout_test)
+
     # Test stb_glyph_atlas() out of host/text/stb_glyph_atlas.cpp: bakes
     # oid::GLYPH_TEXT from the embedded Roboto-Regular font (stb_truetype)
     # through the same finalize_strip_atlas() pipeline glyph_atlas_test above

--- a/tests/visualization/shader_pixel_layout_test.cpp
+++ b/tests/visualization/shader_pixel_layout_test.cpp
@@ -1,0 +1,86 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "visualization/shader_pixel_layout.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+using oid::shader_pixel_layout;
+
+// A single-channel buffer is a GL_RED texture, sampled as (r, 0, 0, 1). The
+// fragment shader derives its source component from the layout's first
+// character, so any layout not starting with 'r' would read a constant zero
+// and render the buffer uniformly black regardless of contrast. This is the
+// defect a declared "bgra" on an always-single-channel type (Eigen) produced.
+TEST(ShaderPixelLayoutTest, SingleChannelAlwaysSamplesRed) {
+    for (const auto* declared : {"bgra", "grba", "abgr", "rgba"}) {
+        EXPECT_EQ(shader_pixel_layout(std::string{declared}, 1), "rgba")
+            << "declared layout: " << declared;
+    }
+}
+
+// Channel order is real data for multi-channel buffers and must survive: BGRA
+// image data would otherwise come out with red and blue swapped.
+TEST(ShaderPixelLayoutTest, MultiChannelKeepsDeclaredOrder) {
+    EXPECT_EQ(shader_pixel_layout(std::string{"bgra"}, 3), "bgra");
+    EXPECT_EQ(shader_pixel_layout(std::string{"bgra"}, 4), "bgra");
+    EXPECT_EQ(shader_pixel_layout(std::string{"rgba"}, 2), "rgba");
+}
+
+// Selecting one channel of a multi-channel buffer for display rotates the
+// layout so the wanted component comes first. The texture still carries that
+// component, so the rotation must not be flattened back to red.
+TEST(ShaderPixelLayoutTest, ChannelSelectionOnMultiChannelIsPreserved) {
+    EXPECT_EQ(shader_pixel_layout(std::string{"grba"}, 3), "grba");
+    EXPECT_EQ(shader_pixel_layout(std::string{"bgra"}, 3), "bgra");
+}
+
+// The selected index must agree with what shader_pixel_layout() causes to be
+// sampled, or the viewer reports one channel while rendering another. It also
+// bounds the channel loop in BufferValues::draw_pixel_values(), which indexes
+// the pixel as buffer[pos + channel] without clamping to the channel count.
+TEST(SelectedChannelIndexTest, LayoutNamesTheChannelForMultiChannelBuffers) {
+    EXPECT_EQ(oid::selected_channel_index(std::string{"rrra"}, 3), 0);
+    EXPECT_EQ(oid::selected_channel_index(std::string{"ggga"}, 3), 1);
+    EXPECT_EQ(oid::selected_channel_index(std::string{"bbba"}, 3), 2);
+    EXPECT_EQ(oid::selected_channel_index(std::string{"bgra"}, 4), 2);
+}
+
+TEST(SelectedChannelIndexTest, ChannelTheBufferDoesNotHaveResolvesToZero) {
+    // Single channel: shader_pixel_layout() forces "rgba", so red is what is
+    // actually rendered and red is what must be reported.
+    EXPECT_EQ(oid::selected_channel_index(std::string{"ggga"}, 1), 0);
+    EXPECT_EQ(oid::selected_channel_index(std::string{"bbba"}, 1), 0);
+    // Two channels: a GL_RG texture has no blue component to select.
+    EXPECT_EQ(oid::selected_channel_index(std::string{"bbba"}, 2), 0);
+    EXPECT_EQ(oid::selected_channel_index(std::string{"ggga"}, 2), 1);
+}
+
+TEST(SelectedChannelIndexTest, EmptyLayoutIsZero) {
+    EXPECT_EQ(oid::selected_channel_index(std::string{}, 1), 0);
+    EXPECT_EQ(oid::selected_channel_index(std::string{}, 3), 0);
+}


### PR DESCRIPTION
## The bug

Eigen matrices rendered as a solid black rectangle at every contrast setting, while the value text drawn on the cells stayed correct — which made it look like a value-rendering problem rather than a buffer-rendering one.

## Root cause

`pixel_layout` describes the channel *order* of a buffer's data, and the buffer fragment shader takes its source component from the layout's **first character**. A single-channel buffer is uploaded as a `GL_RED` texture, whose samples are `(r, 0, 0, 1)` — only red carries data.

`builtin_types.json` declared `"pixel_layout": "bgra"` unconditionally for `Eigen::Matrix` and `Eigen::Map`, which are always single-channel. The shader was compiled with `SOURCE_CHANNEL bbba`, read a component that is constant zero, and every pixel came out black regardless of contrast. `text_fs.cpp` reads `.r` directly, which is why the numbers kept working and masked the defect.

Not a regression from the declarative port — the retired `eigen3.py` hardcoded `'bgra'` too. It also contradicted the documented convention (`doc/python-inspectors.md`: `bgra` for 3–4 channels, `rgba` for 1–2) that the OpenCV entries already follow via `{channels} >= 3`.

## Changes

- Both Eigen entries now declare `"rgba"`.
- A single-channel buffer samples red whatever its declared layout says, so a layout string can no longer blank a render.
- The reported channel index follows the same rule, so it cannot name a channel the buffer doesn't carry. Selecting green on a two-channel buffer stays valid.
- Documented that `pixel_layout` is meaningful only for multi-channel data.

## Verification

- New conformance test pins the invariant across every built-in entry; verified red before the fix, green after.
- New unit tests cover the layout and channel-index rules.
- 37/37 ctest, 363 passed / 11 skipped pytest.
- Confirmed live against `testbench/realtypes.cpp` under lldb: `eig_dyn` reports `pixel_layout: rgba` and renders as a gradient.

## Notes

The channel-index change fixes no reachable bug — the toolbar disables the format combo below three channels and `AgentCore` rejects an index above `min(channels, 3) - 1`. It makes reported and rendered channel agree as a property of the code rather than of two distant validators.

No test asserts a rendered pixel; both new tests pin the *inputs* to the render. Closing that needs an offscreen GL context in the test suite — the readback itself already exists (`render_buffer_icon` → `glReadPixels` → `Stage::get_buffer_icon`). Tracked separately.