### PR TITLE
feat(oidscripts): resolve buffers to JSON for embedded-Python hosts

### DIFF
--- a/resources/oidmcp/tests/conftest.py
+++ b/resources/oidmcp/tests/conftest.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import threading
 import time
+import types
 from pathlib import Path
 
 # Make `import oidscripts.agentendpoint` work: the endpoint lives in the
@@ -15,8 +16,153 @@ RESOURCES_DIR = str(Path(__file__).resolve().parents[2])
 if RESOURCES_DIR not in sys.path:
     sys.path.append(RESOURCES_DIR)
 
+# resources/oidscripts/debuggers/lldbbridge.py hard-imports `lldb`, which is
+# only available inside a live debugger's embedded interpreter -- never in
+# a plain pytest run. Several test modules exercise lldbbridge (directly, or
+# indirectly through oid_resolve_host's lazy imports), so something has to
+# put a stub `lldb` in sys.modules before any of them get collected.
+#
+# This MUST be the only place that does it. lldbbridge.py's own
+# `import lldb` runs once, the first time lldbbridge is imported in the
+# process, and permanently binds its module-level `lldb` name to whatever
+# object was in sys.modules at that instant -- later replacing
+# sys.modules['lldb'] does not rebind it. conftest.py is always imported
+# before any test module, so installing the stub here (with setdefault, so
+# a real `lldb` -- present when this suite runs inside a debugger's
+# interpreter -- always wins) guarantees every test sees the same object,
+# regardless of collection order or which file pytest starts with. A second
+# stub installed locally in a test module only "wins" by accident of
+# collection order (setdefault is a no-op once this one has already run),
+# which is exactly the flake this stub exists to prevent -- do not add
+# another one.
+_LLDB_STUB = types.ModuleType('lldb')
+_LLDB_STUB.eTypeIsInteger = 1 << 8
+_LLDB_STUB.SBValue = object
+sys.modules.setdefault('lldb', _LLDB_STUB)
+
 from oidscripts import wireframe as wf
 from oidscripts.debuggers.interfaces import raise_if_too_large
+
+
+class FakeSBType:
+    """Just enough of lldb.SBType for SymbolWrapper's constructor."""
+
+    def __init__(self, name):
+        self._name = name
+
+    def IsValid(self):
+        return True
+
+    def GetCanonicalType(self):
+        return self
+
+    def GetName(self):
+        return self._name
+
+
+class FakeSBValue:
+    """A minimal SBValue-like tree node for exercising
+    lldbbridge.observable_symbols()'s recursive member traversal without a
+    real debugger. `children` may itself reference an ancestor node to
+    build a genuine cycle."""
+
+    def __init__(self, name, typename, children=()):
+        self.name = name
+        self._typename = typename
+        self._children = list(children)
+
+    def GetTypeName(self):
+        return self._typename
+
+    def GetType(self):
+        return FakeSBType(self._typename)
+
+    def GetNumChildren(self):
+        return len(self._children)
+
+    def GetChildAtIndex(self, index):
+        return self._children[index]
+
+    def set_children(self, children):
+        """Populated after construction so a node can point back at an
+        already-built ancestor (a real cycle)."""
+        self._children = list(children)
+
+
+class FakeTypeBridge:
+    """Type-bridge stand-in for the traversal tests: a symbol is
+    observable iff its type name is one of `observable_typenames`.
+    `SymbolWrapper.type` is a TemplateTypeName (a str subclass), which
+    compares and hashes as the plain type-name string."""
+
+    def __init__(self, observable_typenames):
+        self._observable_typenames = set(observable_typenames)
+
+    def is_symbol_observable(self, symbol_wrapper, _name):
+        return symbol_wrapper.type in self._observable_typenames
+
+
+class FakeStopReason:
+    """Stop-reason constants matching lldb's eStopReasonNone/eStopReason
+    Invalid pair, for frame_from_debugger()/current_host() tests."""
+
+    NONE = 0
+    INVALID = 1
+    STOPPED = 2
+
+
+class FakeThread:
+    def __init__(self, stop_reason, frame=None):
+        self._stop_reason = stop_reason
+        self._frame = frame
+
+    def GetStopReason(self):
+        return self._stop_reason
+
+    def GetSelectedFrame(self):
+        return self._frame
+
+
+class FakeProcess:
+    def __init__(self, threads):
+        self._threads = threads
+
+    def __iter__(self):
+        return iter(self._threads)
+
+
+class FakeTarget:
+    def __init__(self, process):
+        self.process = process
+
+
+class FakeDebugger:
+    def __init__(self, target):
+        self._target = target
+
+    def GetSelectedTarget(self):
+        return self._target
+
+
+class FakeFrame:
+    """A stand-in for a valid SBFrame: truthy, identity-comparable."""
+
+
+def fake_lldb_module(frame_attr=None, selected_frame=None):
+    """A minimal `lldb`-module stand-in with one not-stopped and one
+    stopped thread, for frame_from_debugger()/current_host() tests."""
+    fake_lldb = types.ModuleType('lldb')
+    fake_lldb.eStopReasonNone = FakeStopReason.NONE
+    fake_lldb.eStopReasonInvalid = FakeStopReason.INVALID
+    if frame_attr is not None:
+        fake_lldb.frame = frame_attr
+
+    not_stopped = FakeThread(FakeStopReason.NONE)
+    stopped = FakeThread(FakeStopReason.STOPPED, frame=selected_frame)
+    process = FakeProcess([not_stopped, stopped])
+    target = FakeTarget(process)
+    fake_lldb.debugger = FakeDebugger(target)
+    return fake_lldb
 
 
 class FakeBridge:

--- a/resources/oidmcp/tests/test_declarative_numeric_coercion.py
+++ b/resources/oidmcp/tests/test_declarative_numeric_coercion.py
@@ -8,9 +8,6 @@ holds a buffer address. Both regressed under LLDB: ``int('0x10')`` raised
 integer value (the address of the temporary) instead of the value itself.
 """
 
-import sys
-import types
-
 from oidscripts.oidtypes.declarative import _to_int
 
 
@@ -36,16 +33,12 @@ def test_to_int_passthrough_int():
 # --- LLDB SymbolWrapper numeric / pointer accessors --------------------------
 #
 # lldbbridge hard-imports the `lldb` module, which is unavailable off a live
-# debugger. Install a minimal stub carrying the one constant the code reads
-# (eTypeIsInteger) so the pure Python of SymbolWrapper can be exercised.
+# debugger. conftest.py installs the shared stub carrying the constant this
+# file reads (eTypeIsInteger) before any test module is collected, so the
+# pure Python of SymbolWrapper can be exercised here without a local one.
 
-_LLDB_STUB = types.ModuleType('lldb')
-_LLDB_STUB.eTypeIsInteger = 1 << 8
-_LLDB_STUB.SBValue = object
-sys.modules.setdefault('lldb', _LLDB_STUB)
-
-import lldb  # noqa: E402  (the stub above, unless a real lldb is present)
-from oidscripts.debuggers.lldbbridge import SymbolWrapper  # noqa: E402
+import lldb
+from oidscripts.debuggers.lldbbridge import SymbolWrapper
 
 
 class _FakeSBType:

--- a/resources/oidmcp/tests/test_lldbbridge.py
+++ b/resources/oidmcp/tests/test_lldbbridge.py
@@ -1,0 +1,345 @@
+"""lldbbridge's module-level shared functions -- frame_from_debugger(),
+evaluate_in_frame(), observable_symbols() -- plus the thin LldbBridge
+wrappers around them. oid_resolve_host.py delegates to these same
+functions; see test_oid_resolve_host.py for its (smaller) delegation and
+result-shaping tests.
+
+conftest.py installs the one shared `lldb` stub every test in this suite
+sees; nothing module-level is needed here.
+"""
+
+import sys
+
+import pytest
+from conftest import (
+    FakeDebugger,
+    FakeFrame,
+    FakeSBType,
+    FakeSBValue,
+    FakeTarget,
+    FakeTypeBridge,
+    fake_lldb_module,
+)
+from oidscripts.debuggers import lldbbridge
+from oidscripts.debuggers.lldbbridge import (
+    LldbBridge,
+    evaluate_in_frame,
+    frame_from_debugger,
+    observable_symbols,
+)
+
+# --- frame_from_debugger(): the process -> thread -> frame walk, including
+# the stop-reason filtering that used to live only in LldbBridge._get_thread.
+
+def test_frame_from_debugger_returns_the_stopped_threads_frame(monkeypatch):
+    expected_frame = FakeFrame()
+    fake_lldb = fake_lldb_module(selected_frame=expected_frame)
+    monkeypatch.setitem(sys.modules, 'lldb', fake_lldb)
+
+    assert frame_from_debugger(fake_lldb.debugger) is expected_frame
+
+
+def test_frame_from_debugger_returns_none_without_a_stopped_thread(monkeypatch):
+    # No selected_frame: neither thread carries a real stop reason.
+    fake_lldb = fake_lldb_module()
+    monkeypatch.setitem(sys.modules, 'lldb', fake_lldb)
+
+    assert not frame_from_debugger(fake_lldb.debugger)
+
+
+def test_frame_from_debugger_guards_falsy_debugger_target_and_process(monkeypatch):
+    fake_lldb = fake_lldb_module()
+    monkeypatch.setitem(sys.modules, 'lldb', fake_lldb)
+
+    assert not frame_from_debugger(None)
+    assert not frame_from_debugger(FakeDebugger(None))
+    assert not frame_from_debugger(FakeDebugger(FakeTarget(None)))
+
+
+# --- evaluate_in_frame(): the FindVariable fast path for a plain
+# identifier, EvaluateExpression() otherwise, and the error guards around
+# both.
+
+class _FakeSBError:
+    def __init__(self, fail=False, message=None):
+        self._fail = fail
+        self._message = message
+
+    def Fail(self):
+        return self._fail
+
+    def GetCString(self):
+        return self._message
+
+
+class _FakeEvalValue:
+    """Just enough of lldb.SBValue for SymbolWrapper's constructor plus the
+    checks in evaluate_in_frame."""
+
+    def __init__(self, valid=True, error=None):
+        self._valid = valid
+        self._error = error if error is not None else _FakeSBError()
+
+    def __bool__(self):
+        return self._valid
+
+    def IsValid(self):
+        return self._valid
+
+    def GetType(self):
+        return FakeSBType('int')
+
+    def GetTypeName(self):
+        return 'int'
+
+    def GetError(self):
+        return self._error
+
+
+class _FakeErrorlessInvalidValue:
+    """A truthy-but-invalid SB value whose GetError() returns None outright,
+    rather than a non-failing error object. Composing the RuntimeError
+    message must not crash trying to call None.GetCString()."""
+
+    def __bool__(self):
+        return True
+
+    def IsValid(self):
+        return False
+
+    def GetError(self):
+        return None
+
+
+def test_evaluate_in_frame_prefers_find_variable_for_a_plain_identifier():
+    class Frame:
+        def __init__(self):
+            self.evaluate_called = False
+
+        def FindVariable(self, name):
+            assert name == 'my_var'
+            return _FakeEvalValue(valid=True)
+
+        def EvaluateExpression(self, expr):
+            self.evaluate_called = True
+            raise AssertionError(
+                'a plain identifier must resolve via FindVariable, not '
+                'the expression JIT')
+
+    frame = Frame()
+
+    result = evaluate_in_frame(frame, 'my_var')
+
+    assert result is not None
+    assert not frame.evaluate_called
+
+
+def test_evaluate_in_frame_falls_back_to_evaluate_expression_when_find_variable_is_invalid():
+    class Frame:
+        def FindVariable(self, name):
+            return _FakeEvalValue(valid=False)
+
+        def EvaluateExpression(self, expr):
+            return _FakeEvalValue(valid=True)
+
+    result = evaluate_in_frame(Frame(), 'my_var')
+
+    assert result is not None
+
+
+def test_evaluate_in_frame_skips_find_variable_for_a_non_identifier_expression():
+    class Frame:
+        def __init__(self):
+            self.find_variable_called = False
+
+        def FindVariable(self, name):
+            self.find_variable_called = True
+            raise AssertionError(
+                'a dotted/complex expression is not a plain identifier '
+                'and must go straight to EvaluateExpression')
+
+        def EvaluateExpression(self, expr):
+            return _FakeEvalValue(valid=True)
+
+    frame = Frame()
+
+    evaluate_in_frame(frame, 'this.image')
+
+    assert not frame.find_variable_called
+
+
+def test_evaluate_in_frame_raises_runtime_error_when_get_error_returns_none():
+    class Frame:
+        def EvaluateExpression(self, expr):
+            return _FakeErrorlessInvalidValue()
+
+    frame = Frame()
+
+    with pytest.raises(RuntimeError):
+        evaluate_in_frame(frame, '1 + 1')
+
+
+def test_evaluate_in_frame_raises_runtime_error_for_an_invalid_but_truthy_value():
+    # A value can be truthy but still invalid; a non-failing error object
+    # (Fail() == False) must not mask that.
+    class Frame:
+        def EvaluateExpression(self, expr):
+            return _FakeEvalValue(valid=False, error=_FakeSBError(fail=False))
+
+    frame = Frame()
+
+    with pytest.raises(RuntimeError):
+        evaluate_in_frame(frame, '1 + 1')
+
+
+def test_evaluate_in_frame_raises_runtime_error_for_a_falsy_result():
+    class DeadFrame:
+        def EvaluateExpression(self, expr):
+            return None
+
+    frame = DeadFrame()
+
+    with pytest.raises(RuntimeError):
+        evaluate_in_frame(frame, '1 + 1')
+
+
+# --- observable_symbols(): top-level frame variables plus the recursive
+# observable-member traversal, and its cycle guard.
+
+class _VariablesFrame:
+    """Minimal SBFrame stand-in: GetVariables() returns a fixed list."""
+
+    def __init__(self, variables):
+        self._variables = variables
+
+    def GetVariables(self, *args):
+        return self._variables
+
+
+def _observable_names(root, observable_typenames):
+    """Run observable_symbols() over a fake single-variable frame and
+    return the qualified names it found."""
+    frame = _VariablesFrame([root])
+    bridge = FakeTypeBridge(observable_typenames)
+    return {name for name, _wrapped in observable_symbols(frame, bridge)}
+
+
+def test_observable_symbols_finds_a_buffer_three_levels_deep():
+    # this.wrapper.inner.image -- must be found by its full dotted name.
+    # The old guard marked the *child's* type just before recursing into
+    # it, so the recursive call's very first check tripped on that same
+    # mark and returned at once -- a member's name (e.g. "image") almost
+    # never equals its own type name (e.g. "cv::Mat"), so the mark nearly
+    # always landed and the walk nearly always stopped after one hop.
+    image = FakeSBValue('image', 'Buffer')
+    inner = FakeSBValue('inner', 'Inner', children=[image])
+    wrapper = FakeSBValue('wrapper', 'Wrapper', children=[inner])
+    root = FakeSBValue('root', 'Root', children=[wrapper])
+
+    found = _observable_names(root, observable_typenames={'Buffer'})
+
+    assert found == {'root.wrapper.inner.image'}
+
+
+def test_observable_symbols_terminates_on_a_genuine_cycle():
+    # node_b points back to node_a: an actual cycle, not just a deep
+    # chain. The guard must still stop the walk (no RecursionError, no
+    # hang) now that it no longer stops after a single hop regardless.
+    node_a = FakeSBValue('a', 'NodeA')
+    node_b = FakeSBValue('b', 'NodeB', children=[node_a])
+    node_a.set_children([node_b])
+
+    found = _observable_names(node_a, observable_typenames={'Buffer'})
+
+    assert found == set()
+
+
+def test_observable_symbols_visits_both_siblings_through_the_same_type():
+    # Two sibling branches ('a' and 'b') share the same intermediate type
+    # ('Wrapper'). A visited-set *shared* across siblings would let the
+    # first branch's mark silently block the second from being descended
+    # into at all; a set *copied* per branch -- so the guard means
+    # "already on this path", not "visited anywhere" -- must still find
+    # both. This is the shared-vs-copied-set decision the fix makes.
+    image_a = FakeSBValue('image', 'Buffer')
+    branch_a = FakeSBValue('a', 'Wrapper', children=[image_a])
+    image_b = FakeSBValue('image', 'Buffer')
+    branch_b = FakeSBValue('b', 'Wrapper', children=[image_b])
+    root = FakeSBValue('root', 'Root', children=[branch_a, branch_b])
+
+    found = _observable_names(root, observable_typenames={'Buffer'})
+
+    assert found == {'root.a.image', 'root.b.image'}
+
+
+# --- LldbBridge.evaluate_expression / get_available_symbols: thin wrappers
+# around the shared functions above. These only prove delegation and
+# LldbBridge's own result shaping (a set of names), not the traversal
+# itself.
+
+def _make_bridge(observable_typenames):
+    # Bypass LldbBridge.__init__: it starts a background event-loop thread
+    # and reaches into a real lldb.debugger, neither of which these tests
+    # need.
+    bridge = LldbBridge.__new__(LldbBridge)
+    bridge._type_bridge = FakeTypeBridge(observable_typenames)
+    # get_lldb_backend() reads this; its value is irrelevant once
+    # frame_from_debugger is monkeypatched below.
+    bridge._debugger = None
+    return bridge
+
+
+def test_get_available_symbols_returns_empty_set_without_a_frame(monkeypatch):
+    monkeypatch.setattr(lldbbridge, 'frame_from_debugger', lambda debugger: None)
+
+    bridge = _make_bridge(observable_typenames=set())
+
+    assert bridge.get_available_symbols() == set()
+
+
+def test_get_available_symbols_shapes_pairs_into_a_set_of_names(monkeypatch):
+    monkeypatch.setattr(lldbbridge, 'frame_from_debugger', lambda debugger: object())
+    monkeypatch.setattr(
+        lldbbridge, 'observable_symbols',
+        lambda frame, type_bridge: [('a', object()), ('a.b', object())])
+
+    bridge = _make_bridge(observable_typenames=set())
+    result = bridge.get_available_symbols()
+
+    assert result == {'a', 'a.b'}
+    assert isinstance(result, set)
+
+
+def test_evaluate_expression_raises_no_stopped_frame_without_a_frame(monkeypatch):
+    monkeypatch.setattr(lldbbridge, 'frame_from_debugger', lambda debugger: None)
+
+    bridge = _make_bridge(observable_typenames=set())
+
+    with pytest.raises(RuntimeError) as excinfo:
+        bridge.evaluate_expression('x')
+    assert 'no stopped frame' in str(excinfo.value)
+
+
+def test_evaluate_expression_delegates_to_the_shared_evaluator_on_success(monkeypatch):
+    sentinel = object()
+    monkeypatch.setattr(lldbbridge, 'frame_from_debugger', lambda debugger: object())
+    monkeypatch.setattr(
+        lldbbridge, 'evaluate_in_frame', lambda frame, expression: sentinel)
+
+    bridge = _make_bridge(observable_typenames=set())
+
+    assert bridge.evaluate_expression('x') is sentinel
+
+
+def test_evaluate_expression_wraps_a_non_runtime_error_from_the_shared_evaluator(monkeypatch):
+    monkeypatch.setattr(lldbbridge, 'frame_from_debugger', lambda debugger: object())
+
+    def boom(frame, expression):
+        raise ValueError('kaboom')
+
+    monkeypatch.setattr(lldbbridge, 'evaluate_in_frame', boom)
+
+    bridge = _make_bridge(observable_typenames=set())
+
+    with pytest.raises(RuntimeError):
+        bridge.evaluate_expression('x')

--- a/resources/oidmcp/tests/test_oid_resolve.py
+++ b/resources/oidmcp/tests/test_oid_resolve.py
@@ -1,0 +1,203 @@
+"""oid_resolve: JSON resolver entry point for embedded-Python debugger hosts."""
+
+import json
+import sys
+
+from oidscripts import oid_resolve
+
+SENTINEL = '|OIDEND'
+
+
+class FakeSymbol:
+    def __init__(self, type_name):
+        self.type = type_name
+
+
+class FakeHost:
+    """Stands in for the debugger-specific half oid_resolve delegates to."""
+
+    def __init__(self, metadata=None, symbols=None, error=None):
+        self._metadata = metadata
+        self._symbols = symbols or []
+        self._error = error
+
+    def buffer_metadata(self, name):
+        if self._error is not None:
+            raise self._error
+        return dict(self._metadata)
+
+    def observable_symbols(self):
+        return list(self._symbols)
+
+
+BASE = {
+    'display_name': 'm (cv::Mat)', 'width': 4, 'height': 2, 'channels': 3,
+    'type': 0, 'row_stride': 4, 'pixel_layout': 'bgra',
+    'transpose_buffer': False, 'pointer': 4096,
+}
+
+
+def _payload(text):
+    assert text.endswith(SENTINEL), 'payload must carry the sentinel'
+    return json.loads(text[:-len(SENTINEL)])
+
+
+def test_resolve_emits_every_contract_key():
+    out = _payload(oid_resolve.resolve('m', host=FakeHost(metadata=BASE)))
+    assert set(out) == {
+        'display_name', 'width', 'height', 'channels', 'type', 'row_stride',
+        'pixel_layout', 'transpose_buffer', 'pointer', 'byte_count'}
+
+
+def test_byte_count_uses_row_stride_not_width():
+    """A padded buffer must be sized from row_stride; sizing from width
+    under-reads it. row_stride 12 vs width 6 is a 2x under-read."""
+    padded = dict(BASE, width=6, height=8, channels=1, type=5, row_stride=12)
+    out = _payload(oid_resolve.resolve('m', host=FakeHost(metadata=padded)))
+    assert out['byte_count'] == 4 * 1 * 12 * 8          # 384, from row_stride
+    assert out['byte_count'] != 4 * 1 * 6 * 8           # 192, the wrong answer
+
+
+def test_pointer_is_normalised_to_int():
+    class Weird:
+        def __int__(self):
+            return 8192
+    out = _payload(oid_resolve.resolve('m', host=FakeHost(
+        metadata=dict(BASE, pointer=Weird()))))
+    assert out['pointer'] == 8192
+    assert isinstance(out['pointer'], int)
+
+
+def test_unresolvable_symbol_reports_an_error_payload():
+    out = _payload(oid_resolve.resolve('m', host=FakeHost(
+        error=RuntimeError('no inspector matched'))))
+    assert out['error'] == 'no inspector matched'
+
+
+def test_null_pointer_is_an_error_not_a_plot():
+    out = _payload(oid_resolve.resolve('m', host=FakeHost(
+        metadata=dict(BASE, pointer=0))))
+    assert 'error' in out
+
+
+def test_metadata_missing_a_key_reports_an_error_payload():
+    """A host that returns metadata missing a contract key must not let the
+    KeyError from the CONTRACT_KEYS comprehension escape as a traceback."""
+    incomplete = dict(BASE)
+    del incomplete['row_stride']
+    out = _payload(oid_resolve.resolve('m', host=FakeHost(metadata=incomplete)))
+    assert 'error' in out
+    assert 'm' in out['error']
+
+
+def test_non_int_pointer_reports_an_error_payload():
+    """A pointer that int() cannot convert must not let the
+    TypeError/ValueError escape as a traceback."""
+    out = _payload(oid_resolve.resolve('m', host=FakeHost(
+        metadata=dict(BASE, pointer='not-a-pointer'))))
+    assert 'error' in out
+    assert 'm' in out['error']
+
+
+def test_list_observable_paginates():
+    syms = [{'name': 'v%d' % i, 'type': 'cv::Mat'} for i in range(5)]
+    host = FakeHost(symbols=syms)
+    first = _payload(oid_resolve.list_observable(0, 2, host=host))
+    assert [s['name'] for s in first['items']] == ['v0', 'v1']
+    assert first['total'] == 5
+    rest = _payload(oid_resolve.list_observable(2, 99, host=host))
+    assert [s['name'] for s in rest['items']] == ['v2', 'v3', 'v4']
+
+
+def test_list_observable_clamps_a_negative_offset_to_the_start():
+    syms = [{'name': 'v%d' % i, 'type': 'cv::Mat'} for i in range(5)]
+    host = FakeHost(symbols=syms)
+
+    out = _payload(oid_resolve.list_observable(-3, 2, host=host))
+
+    assert out['offset'] == 0
+    assert [s['name'] for s in out['items']] == ['v0', 'v1']
+
+
+def test_list_observable_clamps_a_negative_limit_to_a_single_item():
+    syms = [{'name': 'v%d' % i, 'type': 'cv::Mat'} for i in range(5)]
+    host = FakeHost(symbols=syms)
+
+    out = _payload(oid_resolve.list_observable(0, -7, host=host))
+
+    assert [s['name'] for s in out['items']] == ['v0']
+
+
+def test_list_observable_clamps_a_limit_above_the_maximum():
+    """An unbounded limit would defeat the reason this function pages at
+    all: the transports it serves truncate long strings silently, so a
+    caller asking for too much must still get a bounded page, not
+    everything."""
+    total_symbols = oid_resolve.MAX_OBSERVABLE_PAGE_LIMIT + 20
+    syms = [{'name': 'v%d' % i, 'type': 'cv::Mat'} for i in range(total_symbols)]
+    host = FakeHost(symbols=syms)
+
+    out = _payload(oid_resolve.list_observable(0, total_symbols, host=host))
+
+    assert len(out['items']) == oid_resolve.MAX_OBSERVABLE_PAGE_LIMIT
+    assert out['total'] == total_symbols
+
+
+def test_payloads_always_carry_the_sentinel():
+    assert oid_resolve.resolve('m', host=FakeHost(metadata=BASE)).endswith(SENTINEL)
+    assert oid_resolve.list_observable(0, 1, host=FakeHost()).endswith(SENTINEL)
+
+
+# --- C1: host acquisition on the default (no explicit host) path must be
+# guarded too, since current_host() raises RuntimeError for entirely
+# routine conditions (no stopped frame, no debugger at all). This is the
+# primary calling mode real callers use.
+
+def test_resolve_with_no_host_and_no_debugger_returns_error_not_traceback(monkeypatch):
+    monkeypatch.delitem(sys.modules, 'lldb', raising=False)
+    monkeypatch.delitem(sys.modules, 'gdb', raising=False)
+
+    result = oid_resolve.resolve('m')
+
+    assert result.endswith(SENTINEL), \
+        'a raised RuntimeError from host acquisition must not escape as a traceback'
+    assert 'error' in _payload(result)
+
+
+def test_list_observable_with_no_host_and_no_debugger_returns_error_not_traceback(monkeypatch):
+    monkeypatch.delitem(sys.modules, 'lldb', raising=False)
+    monkeypatch.delitem(sys.modules, 'gdb', raising=False)
+
+    result = oid_resolve.list_observable()
+
+    assert result.endswith(SENTINEL), \
+        'a raised RuntimeError from host acquisition must not escape as a traceback'
+    assert 'error' in _payload(result)
+
+
+# --- I3: emission itself must stay inside the guard. A host is free to
+# hand back a contract value of any type (that is why `pointer` is
+# normalised elsewhere); one that is not JSON-serializable must still
+# yield an error payload rather than a bare TypeError traceback.
+
+class _Unserializable:
+    """A value json.dumps cannot encode, standing in for a debugger-native
+    object a host forgot to normalise before returning it."""
+
+
+def test_resolve_with_unserializable_contract_value_reports_error_not_traceback():
+    bad_metadata = dict(BASE, pixel_layout=_Unserializable())
+
+    result = oid_resolve.resolve('m', host=FakeHost(metadata=bad_metadata))
+
+    assert result.endswith(SENTINEL)
+    assert 'error' in _payload(result)
+
+
+def test_list_observable_with_unserializable_symbol_reports_error_not_traceback():
+    host = FakeHost(symbols=[{'name': 'v', 'type': _Unserializable()}])
+
+    result = oid_resolve.list_observable(host=host)
+
+    assert result.endswith(SENTINEL)
+    assert 'error' in _payload(result)

--- a/resources/oidmcp/tests/test_oid_resolve_host.py
+++ b/resources/oidmcp/tests/test_oid_resolve_host.py
@@ -1,0 +1,165 @@
+"""The debugger-facing half: bridge adapter plus host selection."""
+
+import sys
+import types
+
+import pytest
+from conftest import FakeFrame, fake_lldb_module
+from oidscripts import oid_resolve_host
+from oidscripts.debuggers import lldbbridge
+
+# conftest.py installs the one shared `lldb` stub every test in this suite
+# sees (see the comment there for why it must stay the sole owner); nothing
+# module-level is needed here.
+
+
+def test_current_host_without_a_debugger_raises_a_named_error(monkeypatch):
+    monkeypatch.delitem(sys.modules, 'lldb', raising=False)
+    monkeypatch.delitem(sys.modules, 'gdb', raising=False)
+    with pytest.raises(RuntimeError) as excinfo:
+        oid_resolve_host.current_host()
+    assert 'no supported debugger' in str(excinfo.value).lower()
+
+
+def test_current_host_with_gdb_present_names_gdb_not_no_debugger(monkeypatch):
+    # gdb is a real, supported backend elsewhere in this repo
+    # (debuggers/gdbbridge.py); this entry point just doesn't serve it
+    # yet. The error must say that, not claim no debugger is available.
+    monkeypatch.delitem(sys.modules, 'lldb', raising=False)
+    monkeypatch.setitem(sys.modules, 'gdb', types.ModuleType('gdb'))
+    with pytest.raises(RuntimeError) as excinfo:
+        oid_resolve_host.current_host()
+    message = str(excinfo.value).lower()
+    assert 'gdb' in message
+    assert 'no supported debugger' not in message
+
+
+def test_current_host_falls_back_to_walking_lldb_debugger_when_frame_attribute_is_absent(monkeypatch):
+    monkeypatch.delitem(sys.modules, 'gdb', raising=False)
+    expected_frame = FakeFrame()
+    # No `.frame` attribute at all: matches interpreters where the
+    # convenience global was never populated.
+    fake_lldb = fake_lldb_module(selected_frame=expected_frame)
+    monkeypatch.setitem(sys.modules, 'lldb', fake_lldb)
+
+    host = oid_resolve_host.current_host()
+
+    assert isinstance(host, oid_resolve_host.LldbHost)
+    assert host._frame is expected_frame
+
+
+def test_current_host_falls_back_when_lldb_frame_is_present_but_falsy(monkeypatch):
+    # LLDB SB objects are falsy when invalid but are not None -- a stale,
+    # present-but-falsy `lldb.frame` must not be trusted as-is.
+    class _StaleFrame:
+        def __bool__(self):
+            return False
+
+    monkeypatch.delitem(sys.modules, 'gdb', raising=False)
+    expected_frame = FakeFrame()
+    fake_lldb = fake_lldb_module(
+        frame_attr=_StaleFrame(), selected_frame=expected_frame)
+    monkeypatch.setitem(sys.modules, 'lldb', fake_lldb)
+
+    host = oid_resolve_host.current_host()
+
+    assert isinstance(host, oid_resolve_host.LldbHost)
+    assert host._frame is expected_frame
+
+
+def test_current_host_with_importable_but_inert_lldb_prefers_gdb(monkeypatch):
+    # `import lldb` can succeed merely because the package is installed
+    # and importable, without lldb actually hosting this interpreter --
+    # e.g. running under gdb on a machine with both debuggers present. No
+    # session marker (neither lldb.frame nor lldb.debugger) is set in that
+    # case; the probe must not claim lldb is active and must fall through
+    # to the real gdb underneath, rather than raising the lldb-specific
+    # "no stopped frame" error and masking gdb entirely.
+    inert_lldb = types.ModuleType('lldb')
+    monkeypatch.setitem(sys.modules, 'lldb', inert_lldb)
+    monkeypatch.setitem(sys.modules, 'gdb', types.ModuleType('gdb'))
+
+    with pytest.raises(RuntimeError) as excinfo:
+        oid_resolve_host.current_host()
+
+    message = str(excinfo.value).lower()
+    assert 'gdb' in message
+    assert 'lldb' not in message
+    assert 'no supported debugger' not in message
+
+
+def test_current_host_with_lldb_present_but_no_stopped_frame_names_lldb_not_no_debugger(monkeypatch):
+    # lldb is loaded but there is no stopped frame (inferior running, or
+    # never launched) -- a routine condition, distinct from "no debugger at
+    # all". Falling through to the gdb probe and beyond would end on the
+    # misleading "no supported debugger" message; this must name lldb
+    # instead, the same defect class already fixed for gdb above.
+    monkeypatch.delitem(sys.modules, 'gdb', raising=False)
+    # No frame_attr and no selected_frame: the walk finds no stopped thread.
+    fake_lldb = fake_lldb_module()
+    monkeypatch.setitem(sys.modules, 'lldb', fake_lldb)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        oid_resolve_host.current_host()
+
+    message = str(excinfo.value).lower()
+    assert 'lldb' in message
+    assert 'no stopped frame' in message
+    assert 'no supported debugger' not in message
+
+
+def test_adapter_exposes_the_two_bridge_methods():
+    # The declarative engine calls exactly these two on the bridge.
+    for method in ('evaluate_expression', 'get_casted_pointer'):
+        assert callable(getattr(oid_resolve_host.LldbAdapter, method))
+
+
+# --- LldbAdapter.evaluate_expression and LldbHost.observable_symbols now
+# delegate to lldbbridge's shared functions; the traversal/evaluate/
+# frame-walk behaviour itself is tested once, there (test_lldbbridge.py).
+# These tests only prove each caller delegates and shapes its own result.
+
+def test_adapter_evaluate_expression_delegates_to_the_shared_evaluator(monkeypatch):
+    sentinel = object()
+    calls = []
+
+    def fake_evaluate_in_frame(frame, expression):
+        calls.append((frame, expression))
+        return sentinel
+
+    monkeypatch.setattr(lldbbridge, 'evaluate_in_frame', fake_evaluate_in_frame)
+
+    frame = object()
+    adapter = oid_resolve_host.LldbAdapter(frame)
+
+    assert adapter.evaluate_expression('my_expr') is sentinel
+    assert calls == [(frame, 'my_expr')]
+
+
+def test_adapter_evaluate_expression_propagates_runtime_error(monkeypatch):
+    def raising_evaluate_in_frame(frame, expression):
+        raise RuntimeError('boom')
+
+    monkeypatch.setattr(lldbbridge, 'evaluate_in_frame', raising_evaluate_in_frame)
+
+    adapter = oid_resolve_host.LldbAdapter(object())
+    with pytest.raises(RuntimeError):
+        adapter.evaluate_expression('my_expr')
+
+
+def test_host_observable_symbols_shapes_pairs_into_name_type_dicts(monkeypatch):
+    class _Wrapped:
+        def __init__(self, type_name):
+            self.type = type_name
+
+    def fake_observable_symbols(frame, type_bridge):
+        return [('a', _Wrapped('int')), ('a.b', _Wrapped('Buffer'))]
+
+    monkeypatch.setattr(lldbbridge, 'observable_symbols', fake_observable_symbols)
+
+    host = oid_resolve_host.LldbHost(object())
+
+    assert host.observable_symbols() == [
+        {'name': 'a', 'type': 'int'},
+        {'name': 'a.b', 'type': 'Buffer'},
+    ]

--- a/resources/oidscripts/debuggers/lldbbridge.py
+++ b/resources/oidscripts/debuggers/lldbbridge.py
@@ -23,6 +23,109 @@ instance = None
 _PLAIN_IDENTIFIER_RE = re.compile(r'^[A-Za-z_]\w*$')
 
 
+def frame_from_debugger(debugger):
+    # type: (lldb.SBDebugger) -> lldb.SBFrame
+    """Walk debugger -> process -> thread -> frame, picking the thread with
+    a real stop reason. Every step is guarded with `not x` rather than
+    `is None`: SB objects are falsy when invalid but are not None."""
+    # Local, not the module import above: re-resolves sys.modules at call
+    # time. The module import binds once, permanently, on first import, so
+    # a caller holding a different `lldb` (oid_resolve_host.py, under test)
+    # would otherwise never be seen here.
+    import lldb
+    if not debugger:
+        return None
+    target = debugger.GetSelectedTarget()
+    if not target:
+        return None
+    process = target.process
+    if not process:
+        return None
+    for thread in process:
+        stop_reason = thread.GetStopReason()
+        if stop_reason != lldb.eStopReasonNone and \
+                stop_reason != lldb.eStopReasonInvalid:
+            return thread.GetSelectedFrame()
+    return None
+
+
+def evaluate_in_frame(frame, expression):
+    # type: (lldb.SBFrame, str) -> SymbolWrapper
+    """Evaluate `expression` in `frame`: FindVariable fast path for a plain
+    identifier (sidesteps lldb's expression JIT, which struggles with heavy
+    templated types e.g. Eigen), else EvaluateExpression. Raises
+    RuntimeError on failure."""
+    if _PLAIN_IDENTIFIER_RE.match(expression):
+        variable = frame.FindVariable(expression)
+        if variable.IsValid():
+            return SymbolWrapper(variable)
+
+    result = frame.EvaluateExpression(expression)
+    # A result can be truthy yet invalid, and GetError() need not return an
+    # object, so guard both rather than chaining off either; result itself
+    # may also be falsy/None outright (e.g. a dead frame).
+    error = result.GetError() if result else None
+    if not result or not result.IsValid() or \
+            (error is not None and error.Fail()):
+        message = error.GetCString() if error is not None else None
+        raise RuntimeError(
+            f'Expression "{expression}" failed: '
+            f'{message or "invalid result"}')
+    return SymbolWrapper(result)
+
+
+def _walk_members(symbol, member_name_chain, visited_typenames, type_bridge,
+                   record_hit):
+    # type: (lldb.SBValue, list, frozenset, TypeInspectorInterface, callable) -> None
+    """Recursive descent into `symbol`'s members, calling
+    `record_hit(qualified_name, SymbolWrapper)` for each observable one."""
+    if symbol.GetTypeName() in visited_typenames:
+        return  # this type is already on the path from the root
+    # Mark this symbol's type, not the child's, before descending: the
+    # latter trips the recursive call's own guard on its first check,
+    # stopping traversal after one hop. Copy rather than mutate, so
+    # sibling branches don't block each other from descending a type.
+    visited_typenames = visited_typenames | {symbol.GetTypeName()}
+
+    for member_idx in range(symbol.GetNumChildren()):
+        symbol_member = symbol.GetChildAtIndex(member_idx)
+        chain = member_name_chain + [str(symbol_member.name)]
+        wrapped = SymbolWrapper(symbol_member)
+        if type_bridge.is_symbol_observable(wrapped, symbol_member.name):
+            record_hit('.'.join(chain), wrapped)
+        else:
+            _walk_members(symbol_member, chain, visited_typenames,
+                          type_bridge, record_hit)
+
+
+def observable_symbols(frame, type_bridge):
+    # type: (lldb.SBFrame, TypeInspectorInterface) -> list
+    """Every observable symbol in `frame`: top-level plus struct/class
+    members reached by recursive descent (e.g. `this.image`). Returns
+    (qualified_name, SymbolWrapper) pairs, deduped, in discovery order --
+    callers shape the pairs into whatever result they need."""
+    found = []
+    seen = set()
+
+    def emit(qualified_name, wrapped):
+        if qualified_name not in seen:
+            seen.add(qualified_name)
+            found.append((qualified_name, wrapped))
+
+    for symbol in frame.GetVariables(True, True, True, True):
+        name = symbol.name
+        if not name:
+            continue
+        wrapped = SymbolWrapper(symbol)
+        if type_bridge.is_symbol_observable(wrapped, name):
+            emit(name, wrapped)
+        member_name_chain = [name] if name != 'this' else []
+        _walk_members(symbol, member_name_chain, frozenset(), type_bridge,
+                      emit)
+
+    return found
+
+
 class LldbBridge(BridgeInterface):
     """
     LLDB Bridge class, exposing the common expected interface for the OpenImageDebugger
@@ -196,89 +299,26 @@ class LldbBridge(BridgeInterface):
         # intentional RuntimeErrors below carry the best message; any other
         # backend exception is normalized to RuntimeError in the fallback.
         try:
-            frame = self._get_frame(
-                self._get_thread(self._get_process(
-                    self.get_lldb_backend())))
-            # _get_frame() can return an invalid SBFrame (falsy but not
-            # None), so use the same truthiness guard as
-            # get_available_symbols() rather than an "is None" check.
+            # frame_from_debugger() can return an invalid SBFrame (falsy but
+            # not None), so use a truthiness guard rather than "is None".
+            frame = frame_from_debugger(self.get_lldb_backend())
             if not frame:
                 raise RuntimeError(
                     f'Expression "{expression}" failed: no stopped frame')
-
-            # Prefer a direct variable lookup for plain symbol names: it is
-            # the same robust path get_buffer_metadata() uses and avoids
-            # lldb's expression JIT, which can fail to resolve heavy templated
-            # types (e.g. Eigen) on some architectures. Dotted or otherwise
-            # complex expressions still fall through to EvaluateExpression().
-            if _PLAIN_IDENTIFIER_RE.match(expression):
-                variable = frame.FindVariable(expression)
-                if variable.IsValid():
-                    return SymbolWrapper(variable)
-
-            result = frame.EvaluateExpression(expression)
-            error = result.GetError()
-            if not result.IsValid() or (error is not None
-                                        and error.Fail()):
-                message = error.GetCString() if error is not None else None
-                raise RuntimeError(
-                    f'Expression "{expression}" failed: '
-                    f'{message or "invalid result"}')
-            return SymbolWrapper(result)
+            return evaluate_in_frame(frame, expression)
         except RuntimeError:
             raise
         except Exception as error:
             raise RuntimeError(
                 f'Expression "{expression}" failed: {error}') from error
 
-    def _get_observable_children_members(self, symbol, member_name_chain,
-                                         output_set, visited_typenames=None):
-        # type: (lldb.SBValue, list[str], set, set) -> None
-        if visited_typenames is None:
-            visited_typenames = set()
-        if symbol.GetTypeName() in visited_typenames:
-            # Prevent endless recursion in cyclic data types
-            return
-
-        for member_idx in range(symbol.GetNumChildren()):
-            symbol_member = symbol.GetChildAtIndex(
-                member_idx)  # type: lldb.SBValue
-
-            member_name_chain_current = member_name_chain.copy()
-            member_name_chain_current.append(str(symbol_member.name))
-
-            symbol_wrapper = SymbolWrapper(symbol_member)
-            if self._type_bridge.is_symbol_observable(symbol_wrapper,
-                                                      symbol_member.name):
-                member_name_current = '.'.join(member_name_chain_current)
-                output_set.add(member_name_current)
-            else:
-                if symbol_member.name != symbol_member.GetTypeName():
-                    visited_typenames.add(symbol_member.GetTypeName())
-                self._get_observable_children_members(symbol_member,
-                                                      member_name_chain_current,
-                                                      output_set,
-                                                      visited_typenames)
-
     def get_available_symbols(self):
-        frame = self._get_frame(
-            self._get_thread(self._get_process(self.get_lldb_backend())))
+        frame = frame_from_debugger(self.get_lldb_backend())
         if not frame:
             return set()
-
-        available_symbols = set()
-
-        for symbol in frame.GetVariables(True, True, True, True):
-            symbol_wrapper = SymbolWrapper(symbol)
-            if self._type_bridge.is_symbol_observable(symbol_wrapper,
-                                                      symbol.name):
-                available_symbols.add(symbol.name)
-            # Check for members of current field, if it is a class
-            member_name_chain = [symbol.name] if symbol.name != 'this' else []
-            self._get_observable_children_members(symbol, member_name_chain,
-                                                  available_symbols)
-
-        return available_symbols
+        # Callers historically get bare names; observable_symbols() returns
+        # richer (name, wrapper) pairs so other callers can shape their own.
+        return {name for name, _ in observable_symbols(frame, self._type_bridge)}
 
     def stop_hook(self, *args):
         with self._lock:

--- a/resources/oidscripts/oid_resolve.py
+++ b/resources/oidscripts/oid_resolve.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+
+"""JSON resolver entry point for hosts that embed a debugger's Python.
+
+A host with an embedded interpreter (lldb, gdb) can import this module and
+call resolve()/list_observable() to obtain buffer metadata as JSON, without
+reimplementing type inspection. Every payload ends with a sentinel so a
+caller can detect a result its transport truncated: several debug adapters
+clip long expression results silently, and a clipped JSON document can
+still parse into something plausible but wrong.
+"""
+
+import json
+
+from oidscripts import sysinfo
+
+SENTINEL = '|OIDEND'
+
+CONTRACT_KEYS = ('display_name', 'width', 'height', 'channels', 'type',
+                 'row_stride', 'pixel_layout', 'transpose_buffer')
+
+# Guards against a page overrunning a transport's ~1024-character string
+# ceiling -- the exact failure mode paging exists to prevent. Each item
+# carries a name plus a type string, and a canonical Eigen type name alone
+# can exceed 70 characters, so even a modest item count adds up fast.
+MAX_OBSERVABLE_PAGE_LIMIT = 8
+
+
+def _emit(payload):
+    # Compact separators: the default ", "/": " spend bytes of the same
+    # ceiling MAX_OBSERVABLE_PAGE_LIMIT exists to stay under. ensure_ascii
+    # stays on, so a non-ASCII type name crosses as \uXXXX rather than as
+    # raw bytes the transport would have to carry intact.
+    return json.dumps(payload, separators=(',', ':')) + SENTINEL
+
+
+def _default_host():
+    # Imported lazily so the module is testable without a live debugger.
+    from oidscripts.oid_resolve_host import current_host
+    return current_host()
+
+
+def resolve(name, host=None):
+    """Resolve one symbol to a buffer-metadata JSON payload."""
+    try:
+        host = host if host is not None else _default_host()
+        metadata = host.buffer_metadata(name)
+    except Exception as exc:                       # noqa: BLE001
+        return _emit({'error': str(exc)})
+
+    if metadata is None:
+        return _emit({'error': 'no inspector matched %r' % name})
+
+    try:
+        out = {key: metadata[key] for key in CONTRACT_KEYS}
+
+        # Bridges disagree on the pointer's Python type: one yields an int,
+        # one yields a debugger value object. Normalise here so the
+        # contract is a plain address.
+        pointer = int(metadata['pointer'])
+        if pointer == 0:
+            return _emit({'error': 'null buffer pointer for %r' % name})
+        out['pointer'] = pointer
+
+        # Authoritative size. Deriving it from width instead of row_stride
+        # under-reads every padded or strided buffer.
+        out['byte_count'] = sysinfo.get_buffer_size(
+            out['height'], out['channels'], out['type'], out['row_stride'])
+        if out['byte_count'] <= 0:
+            return _emit({'error': 'buffer of zero bytes for %r' % name})
+
+        # Serialization stays inside the guard too: a host that hands back
+        # a contract value json can't encode (e.g. a debugger-specific
+        # object left in place of a plain string) must still yield an
+        # error payload, not a bare TypeError traceback.
+        return _emit(out)
+    except Exception as exc:                        # noqa: BLE001
+        return _emit({'error': 'malformed metadata for %r: %s' % (name, exc)})
+
+
+def list_observable(offset=0, limit=MAX_OBSERVABLE_PAGE_LIMIT, host=None):
+    """A page of plottable symbols, so a long list cannot overrun a
+    transport's string ceiling.
+
+    offset and limit are caller-supplied and clamped rather than trusted:
+    a negative offset would silently read from the end of the list, a
+    negative limit would silently read as an empty page, and an unbounded
+    limit would defeat the reason this function pages at all. Clamping is
+    silent -- a caller asking for too much gets a valid page back, not an
+    error.
+    """
+    try:
+        offset = max(0, offset)
+        limit = min(max(1, limit), MAX_OBSERVABLE_PAGE_LIMIT)
+        host = host if host is not None else _default_host()
+        symbols = host.observable_symbols()
+        page = symbols[offset:offset + limit]
+        total = len(symbols)
+        return _emit({'items': page, 'total': total, 'offset': offset})
+    except Exception as exc:                       # noqa: BLE001
+        return _emit({'error': str(exc)})

--- a/resources/oidscripts/oid_resolve_host.py
+++ b/resources/oidscripts/oid_resolve_host.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+
+"""Debugger-facing half of the JSON resolver: the bridge adapter the
+declarative engine needs, plus selection of whichever debugger module is
+present in the host interpreter.
+
+Only lldb is wired in today. gdb is supported elsewhere in this repo
+(debuggers/gdbbridge.py), but routing this entry point through it is
+unproven. A GdbHost slots in beside LldbHost, selected the same way from
+current_host(), with no change to oid_resolve.py."""
+
+from oidscripts.typebridge import TypeBridge
+
+_BRIDGE = None
+
+
+def _type_bridge():
+    global _BRIDGE
+    if _BRIDGE is None:
+        _BRIDGE = TypeBridge()
+    return _BRIDGE
+
+
+class LldbAdapter(object):
+    """The whole bridge contract the engine exercises: evaluate an
+    expression, and cast a symbol to its buffer address."""
+
+    def __init__(self, frame):
+        self._frame = frame
+
+    def evaluate_expression(self, expression):
+        # Delegates to lldbbridge's shared evaluator: the fast-path lookup,
+        # the error guards, and the RuntimeError-on-failure contract all
+        # live there now.
+        from oidscripts.debuggers.lldbbridge import evaluate_in_frame
+        return evaluate_in_frame(self._frame, expression)
+
+    def get_casted_pointer(self, typename, obj):  # NOSONAR
+        """Address of the buffer `obj` points at.
+
+        `typename` is the cast target the bridge contract passes; it is
+        ignored, since an lldb value already carries its own type.
+        """
+        return obj.get_casted_pointer()
+
+
+class LldbHost(object):
+    """Binds oid_resolve's host contract to one already-selected lldb frame.
+
+    The frame is captured at construction and never re-derived, so a host
+    held across debugger stops queries a stale frame. current_host() builds
+    a fresh one per call, so only explicit-host callers need care.
+    """
+
+    def __init__(self, frame):
+        self._frame = frame
+        self._adapter = LldbAdapter(frame)
+
+    def buffer_metadata(self, name):
+        from oidscripts.debuggers.lldbbridge import SymbolWrapper
+        symbol = self._frame.FindVariable(name)
+        if not symbol.IsValid():
+            symbol = self._frame.EvaluateExpression(name)
+        return _type_bridge().get_buffer_metadata(
+            name, SymbolWrapper(symbol), self._adapter)
+
+    def observable_symbols(self):
+        """Every observable symbol in the current frame, including buffers
+        held as struct/class members (e.g. `this.image`)."""
+        from oidscripts.debuggers.lldbbridge import (
+            observable_symbols as shared_observable_symbols,
+        )
+        pairs = shared_observable_symbols(self._frame, _type_bridge())
+        return [{'name': name, 'type': str(wrapped.type)}
+                for name, wrapped in pairs]
+
+
+def _frame_from_lldb_debugger(lldb):
+    """Walk from lldb.debugger down to the selected frame, rather than
+    trusting lldb.frame -- a convenience global that only exists in some
+    lldb script contexts. Delegates the actual walk to lldbbridge's shared
+    helper once lldb.debugger is extracted."""
+    from oidscripts.debuggers.lldbbridge import frame_from_debugger
+    return frame_from_debugger(getattr(lldb, 'debugger', None))
+
+
+def current_host():
+    """The host for whichever debugger this interpreter is embedded in."""
+    try:
+        import lldb
+    except ImportError:
+        lldb = None
+
+    if lldb is not None:
+        # lldb.frame is a convenience global some lldb script contexts
+        # populate; prefer it, but it can be absent or a stale-but-present
+        # (falsy) SBFrame, so fall back to the explicit walk lldbbridge.py
+        # itself always uses.
+        frame = getattr(lldb, 'frame', None)
+        if not frame:
+            frame = _frame_from_lldb_debugger(lldb)
+        if frame:
+            return LldbHost(frame)
+        # `import lldb` succeeding only proves the package is importable --
+        # not that lldb is actually hosting this interpreter. On a machine
+        # with both debuggers installed, running under gdb, lldb is
+        # importable but inert, and its session globals are absent/falsy.
+        # Only commit to the lldb-specific error below when some real
+        # session marker shows lldb genuinely is hosting this interpreter
+        # (a truthy lldb.debugger here; a truthy lldb.frame would already
+        # have returned above) -- otherwise fall through to the gdb probe
+        # so a merely-importable-but-inert lldb does not mask a real gdb.
+        if getattr(lldb, 'debugger', None):
+            # lldb is loaded but there is no stopped frame to inspect (e.g.
+            # the inferior is running or hasn't been launched yet). That is
+            # a routine, distinct condition from "no debugger at all" --
+            # say so instead of falling through to the gdb probe and
+            # ending on the misleading "no supported debugger" message
+            # below.
+            raise RuntimeError(
+                'lldb is available in this interpreter, but no stopped '
+                'frame is available')
+
+    try:
+        import gdb
+    except ImportError:
+        gdb = None
+    if gdb is not None:
+        # gdb is a real, supported backend in this repo (see the module
+        # docstring) -- it just is not served from this entry point yet.
+        # Say so plainly instead of claiming no debugger is available.
+        raise RuntimeError(
+            'gdb is available in this interpreter, but this entry point '
+            'does not serve it yet')
+
+    raise RuntimeError(
+        'no supported debugger module is available in this interpreter')

--- a/testbench/.vscode/launch.json
+++ b/testbench/.vscode/launch.json
@@ -24,6 +24,33 @@
             "preRunCommands": [
                 "breakpoint set --file main.cpp --line 351"
             ]
+        },
+        {
+            // The real-library fixture: one live instance of every built-in
+            // buffer type (cv::Mat, CvMat, IplImage, and five Eigen variants)
+            // against the actual OpenCV and Eigen headers, for plotting by
+            // hand. Build it first -- it is a separate target, and CMake only
+            // offers it when both libraries are found:
+            //     cmake --build build --target testbench_realtypes
+            "name": "(CodeLLDB) Launch realtypes fixture (no build)",
+            "type": "lldb",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/testbench_realtypes",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "initCommands": [
+                "platform shell dsymutil ${workspaceFolder}/build/testbench_realtypes"
+            ],
+            "preRunCommands": [
+                // The oid_breakpoint marker. Every fixture is constructed by
+                // this line, and breaking earlier catches half-built objects,
+                // which read as garbage dimensions rather than failing
+                // visibly. It is also the only nearby line that emits code:
+                // the (void) casts below it generate none, so a breakpoint
+                // set on one of those cannot bind and silently slides down to
+                // the closing return.
+                "breakpoint set --file realtypes.cpp --line 252"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## What this adds

A host that embeds a debugger's Python interpreter can now import `oidscripts.oid_resolve` and get buffer metadata as JSON, instead of reimplementing type inspection against the declarative engine.

```python
>>> from oidscripts import oid_resolve
>>> oid_resolve.resolve('eig_dyn')
'{"display_name": "eig_dyn (Eigen::MatrixXd)", "width": 5, "height": 7, ...,
  "pointer": 140702... , "byte_count": 280}|OIDEND'
```

Two modules:

- **`oid_resolve.py`** — shapes, sizes and emits the payload. No debugger dependency, so it imports and tests in an ordinary interpreter.
- **`oid_resolve_host.py`** — the debugger-facing half: an adapter satisfying the declarative engine's bridge contract, and selection of whichever debugger module the surrounding interpreter provides.

## Three decisions worth knowing

**The size comes from the row stride, not the width.** `byte_count` is computed with `sysinfo.get_buffer_size(height, channels, type, row_stride)`. A padded or strided buffer is larger than its visible extent — sizing from width silently under-reads it, by 2× on a `6×8` Eigen map with stride 12.

**Every payload ends with `|OIDEND`.** Transports that carry expression results commonly clip long strings without signalling it, and a clipped JSON document can still parse into a plausible but wrong object. The sentinel lets a caller tell a complete answer from a truncated one.

**Failures return a payload, never a traceback.** `{"error": "..."}` with the same sentinel, so one code path handles both and an error is never mistaken for truncation.

## Scope

lldb only. `gdb` is detected and reported distinctly — "available in this interpreter, but this entry point does not serve it yet" — rather than being reported as no debugger at all. A gdb host slots in beside the lldb one without changing `oid_resolve.py`.

## Verification

387 passed, 11 skipped. Against a live lldb session on `testbench/realtypes.cpp`, all eleven buffers resolve with no error, including `Eigen::MatrixXd` (which needs canonical-type resolution) and the strided `Eigen::Map` at stride 12.