### PR TITLE
fix(ipc): deliver large buffers correctly, and refuse the ones we cannot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ build/
 
 # Visual Studio Code project settings
 .vscode/
+# ...except the testbench debug configs, which are part of the fixtures:
+# they carry the breakpoints and build steps needed to drive them under a
+# debugger, so they are shared rather than per-developer settings.
+!testbench/.vscode/
+!testbench/.vscode/launch.json
 
 # Qt Creator project settings
 CMakeLists.txt.user

--- a/src/host/ipc/ipc_client.cpp
+++ b/src/host/ipc/ipc_client.cpp
@@ -50,6 +50,19 @@ void IpcClient::poll() {
             dispatch(header);
         } catch (const std::runtime_error&) { // SocketTimeoutError, base catch
             return; // cross-shared-lib RTTI-safe; drop the partial message
+        } catch (const std::length_error&) {
+            // MessageDecoder's own size guards keep resize() from throwing
+            // this, but other allocations driven by peer-supplied sizes and
+            // reachable from dispatch() (e.g. BufferAssembler::begin(), on a
+            // 32-bit size_t) are not guarded that way. Only length_error is
+            // caught, not its logic_error base: the siblings of that base
+            // signal bugs here rather than hostile input, and swallowing
+            // them would hide them. Its type_info is a single shared symbol
+            // like std::runtime_error's above, so this is RTTI-safe across
+            // the same shared-lib boundary.
+            std::cerr << "[OID] container limit exceeded decoding a message; "
+                         "dropped\n";
+            return;
         } catch (const std::bad_alloc&) {
             // A buffer's size comes from the peer. Sizes are capped before
             // any allocation, but the cap is generous enough that the request
@@ -236,7 +249,7 @@ void IpcClient::handle_plot_buffer_begin() {
         std::cerr << "[OID] rejected PLOT_BUFFER_BEGIN for '" << name << "': ";
         if (!known_type) {
             std::cerr << "unknown buffer type " << type_int << "\n";
-        } else if (received > MAX_BUFFER_BYTES) {
+        } else if (exceeds_max_buffer_bytes(received)) {
             std::cerr << received << " bytes exceeds the " << MAX_BUFFER_BYTES
                       << " byte limit\n";
         } else if (!displayable) {
@@ -277,9 +290,14 @@ void IpcClient::handle_plot_buffer_chunk() {
     // drops, so every later chunk -- of that transfer, or of a name that
     // never had a BEGIN -- finds nothing and stays silent.
     if (assembler_.abort(name)) {
+        // row_offset and row_count are logged separately rather than as a
+        // computed row_offset + row_count endpoint: that sum is unchecked
+        // std::size_t addition, and a peer sending huge values -- already
+        // rejected for the transfer itself -- would wrap it into an end row
+        // smaller than the start row.
         std::cerr << "[OID] rejected PLOT_BUFFER_CHUNK for '" << name
-                  << "': rows [" << row_offset << ", " << row_offset + row_count
-                  << "), " << bytes.size() << " bytes received\n";
+                  << "': row_offset " << row_offset << ", row_count "
+                  << row_count << ", " << bytes.size() << " bytes received\n";
     }
 }
 

--- a/src/host/ipc/ipc_client.cpp
+++ b/src/host/ipc/ipc_client.cpp
@@ -28,6 +28,7 @@
 #include <chrono>
 #include <deque>
 #include <iostream>
+#include <new>
 #include <set>
 #include <stdexcept>
 #include <utility>
@@ -49,6 +50,13 @@ void IpcClient::poll() {
             dispatch(header);
         } catch (const std::runtime_error&) { // SocketTimeoutError, base catch
             return; // cross-shared-lib RTTI-safe; drop the partial message
+        } catch (const std::bad_alloc&) {
+            // A buffer's size comes from the peer. Sizes are capped before
+            // any allocation, but the cap is generous enough that the request
+            // can still fail on a loaded machine: drop the message rather
+            // than take the viewer down with it.
+            std::cerr << "[OID] out of memory decoding a message; dropped\n";
+            return;
         }
     }
 }
@@ -159,6 +167,12 @@ void IpcClient::handle_plot_buffer_contents() const {
         .read(stride)
         .read(type)
         .read(bytes);
+    if (!is_known_buffer_type(static_cast<int>(type))) {
+        std::cerr << "[OID] rejected PLOT_BUFFER_CONTENTS for '"
+                  << variable_name << "': unknown buffer type "
+                  << static_cast<int>(type) << "\n";
+        return;
+    }
     if (!geometry_fits_payload(
             width, height, channels, stride, type, bytes.size())) {
         std::cerr << "[OID] rejected PLOT_BUFFER_CONTENTS for '"
@@ -193,11 +207,37 @@ void IpcClient::handle_plot_buffer_begin() {
     params.type = type_int;
     decoder.read(params.total_byte_size);
     const std::string name = params.variable_name;
+    // Captured before the move so a refusal can say what it wanted. These
+    // mirror begin()'s rejection reasons one for one, so the message is never
+    // at odds with the decision.
+    const auto wire_type = static_cast<BufferType>(params.type);
+    const bool known_type = is_known_buffer_type(wire_type);
+    // padded_payload_size() reports nullopt for two different things, so the
+    // shape is checked separately to tell them apart in the message.
+    const bool renderable = params.width > 0 && params.height > 0 &&
+                            params.channels > 0 &&
+                            params.stride >= params.width;
+    const auto expected = padded_payload_size(
+        params.width, params.height, params.channels, params.stride, wire_type);
+    const auto received = params.total_byte_size;
     // Each rejected BEGIN is a distinct attempted transfer, so there is no
     // flood to collapse and nothing to remember between calls.
     if (!assembler_.begin(std::move(params))) {
-        std::cerr << "[OID] rejected PLOT_BUFFER_BEGIN for '" << name
-                  << "': invalid geometry\n";
+        std::cerr << "[OID] rejected PLOT_BUFFER_BEGIN for '" << name << "': ";
+        if (!known_type) {
+            std::cerr << "unknown buffer type " << type_int << "\n";
+        } else if (received > MAX_BUFFER_BYTES) {
+            std::cerr << received << " bytes exceeds the " << MAX_BUFFER_BYTES
+                      << " byte limit\n";
+        } else if (expected.has_value()) {
+            std::cerr << "geometry needs " << *expected << " bytes, got "
+                      << received << "\n";
+        } else if (renderable) {
+            std::cerr << "geometry is too large to size in bytes\n";
+        } else {
+            std::cerr << "geometry is not renderable (width, height and "
+                         "channels must be positive, and stride >= width)\n";
+        }
     }
 }
 

--- a/src/host/ipc/ipc_client.cpp
+++ b/src/host/ipc/ipc_client.cpp
@@ -34,6 +34,7 @@
 
 #include "host/ipc/buffer_decode.h"
 #include "host/settings/app_settings.h"
+#include "ipc/raw_data_decode.h"
 
 namespace oid::host {
 
@@ -158,6 +159,12 @@ void IpcClient::handle_plot_buffer_contents() const {
         .read(stride)
         .read(type)
         .read(bytes);
+    if (!geometry_fits_payload(
+            width, height, channels, stride, type, bytes.size())) {
+        std::cerr << "[OID] rejected PLOT_BUFFER_CONTENTS for '"
+                  << variable_name << "': payload too small for geometry\n";
+        return;
+    }
     model_.upsert(make_buffer_record({.variable_name = std::move(variable_name),
                                       .display_name = std::move(display_name),
                                       .pixel_layout = std::move(pixel_layout),
@@ -204,18 +211,18 @@ void IpcClient::handle_plot_buffer_chunk() {
         .read(row_offset)
         .read(row_count)
         .read(bytes);
-    if (!assembler_.chunk(name, row_offset, row_count, bytes)) {
-        // Already unusable: holding the allocation until PLOT_BUFFER_END
-        // would only waste memory. Gating the report on abort() having
-        // dropped something is what collapses the flood: the first bad chunk
-        // reports and drops, so every later chunk -- of that transfer, or of
-        // a name that never had a BEGIN -- finds nothing and stays silent.
-        if (assembler_.abort(name)) {
-            std::cerr << "[OID] rejected PLOT_BUFFER_CHUNK for '" << name
-                      << "': rows [" << row_offset << ", "
-                      << row_offset + row_count << "), " << bytes.size()
-                      << " bytes received\n";
-        }
+    if (assembler_.chunk(name, row_offset, row_count, bytes)) {
+        return;
+    }
+    // Already unusable: holding the allocation until PLOT_BUFFER_END would
+    // only waste memory. Gating the report on abort() having dropped
+    // something is what collapses the flood: the first bad chunk reports and
+    // drops, so every later chunk -- of that transfer, or of a name that
+    // never had a BEGIN -- finds nothing and stays silent.
+    if (assembler_.abort(name)) {
+        std::cerr << "[OID] rejected PLOT_BUFFER_CHUNK for '" << name
+                  << "': rows [" << row_offset << ", " << row_offset + row_count
+                  << "), " << bytes.size() << " bytes received\n";
     }
 }
 

--- a/src/host/ipc/ipc_client.cpp
+++ b/src/host/ipc/ipc_client.cpp
@@ -27,6 +27,7 @@
 
 #include <chrono>
 #include <deque>
+#include <iostream>
 #include <set>
 #include <stdexcept>
 #include <utility>
@@ -184,7 +185,13 @@ void IpcClient::handle_plot_buffer_begin() {
     decoder.read(type_int);
     params.type = type_int;
     decoder.read(params.total_byte_size);
-    assembler_.begin(std::move(params));
+    const std::string name = params.variable_name;
+    // Each rejected BEGIN is a distinct attempted transfer, so there is no
+    // flood to collapse and nothing to remember between calls.
+    if (!assembler_.begin(std::move(params))) {
+        std::cerr << "[OID] rejected PLOT_BUFFER_BEGIN for '" << name
+                  << "': invalid geometry\n";
+    }
 }
 
 void IpcClient::handle_plot_buffer_chunk() {
@@ -197,12 +204,27 @@ void IpcClient::handle_plot_buffer_chunk() {
         .read(row_offset)
         .read(row_count)
         .read(bytes);
-    (void)assembler_.chunk(name, row_offset, row_count, bytes);
+    if (!assembler_.chunk(name, row_offset, row_count, bytes)) {
+        // Already unusable: holding the allocation until PLOT_BUFFER_END
+        // would only waste memory. Gating the report on abort() having
+        // dropped something is what collapses the flood: the first bad chunk
+        // reports and drops, so every later chunk -- of that transfer, or of
+        // a name that never had a BEGIN -- finds nothing and stays silent.
+        if (assembler_.abort(name)) {
+            std::cerr << "[OID] rejected PLOT_BUFFER_CHUNK for '" << name
+                      << "': rows [" << row_offset << ", "
+                      << row_offset + row_count << "), " << bytes.size()
+                      << " bytes received\n";
+        }
+    }
 }
 
 void IpcClient::handle_plot_buffer_end() {
     std::string name;
     MessageDecoder{transport_}.read(name);
+    // Captured before end() (which erases the entry): an END for a name
+    // with nothing in flight is a stray, not a genuine incomplete transfer.
+    const bool was_in_progress = assembler_.has_in_progress(name);
     if (auto assembled = assembler_.end(name)) {
         model_.upsert(make_buffer_record(
             {.variable_name = std::move(assembled->variable_name),
@@ -215,6 +237,9 @@ void IpcClient::handle_plot_buffer_end() {
              .stride = assembled->stride,
              .type = static_cast<BufferType>(assembled->type),
              .bytes = std::move(assembled->bytes)}));
+    } else if (was_in_progress) {
+        std::cerr << "[OID] rejected PLOT_BUFFER_END for '" << name
+                  << "': incomplete transfer\n";
     }
 }
 

--- a/src/host/ipc/ipc_client.cpp
+++ b/src/host/ipc/ipc_client.cpp
@@ -173,6 +173,14 @@ void IpcClient::handle_plot_buffer_contents() const {
                   << static_cast<int>(type) << "\n";
         return;
     }
+    if (!within_display_limits(width, height, channels)) {
+        std::cerr << "[OID] rejected PLOT_BUFFER_CONTENTS for '"
+                  << variable_name
+                  << "': geometry exceeds the display limits (max dimension "
+                  << MAX_BUFFER_DIMENSION << ", max " << MAX_CHANNEL_COUNT
+                  << " channels)\n";
+        return;
+    }
     if (!geometry_fits_payload(
             width, height, channels, stride, type, bytes.size())) {
         std::cerr << "[OID] rejected PLOT_BUFFER_CONTENTS for '"
@@ -217,6 +225,8 @@ void IpcClient::handle_plot_buffer_begin() {
     const bool renderable = params.width > 0 && params.height > 0 &&
                             params.channels > 0 &&
                             params.stride >= params.width;
+    const bool displayable =
+        within_display_limits(params.width, params.height, params.channels);
     const auto expected = padded_payload_size(
         params.width, params.height, params.channels, params.stride, wire_type);
     const auto received = params.total_byte_size;
@@ -229,10 +239,17 @@ void IpcClient::handle_plot_buffer_begin() {
         } else if (received > MAX_BUFFER_BYTES) {
             std::cerr << received << " bytes exceeds the " << MAX_BUFFER_BYTES
                       << " byte limit\n";
+        } else if (!displayable) {
+            std::cerr << "geometry exceeds the display limits (max dimension "
+                      << MAX_BUFFER_DIMENSION << ", max " << MAX_CHANNEL_COUNT
+                      << " channels)\n";
         } else if (expected.has_value()) {
             std::cerr << "geometry needs " << *expected << " bytes, got "
                       << received << "\n";
         } else if (renderable) {
+            // Reachable only where size_t is 32 bits, i.e. the wasm build:
+            // with a 64-bit size_t the display limits above already bound the
+            // product some three orders of magnitude below overflow. Keep it.
             std::cerr << "geometry is too large to size in bytes\n";
         } else {
             std::cerr << "geometry is not renderable (width, height and "

--- a/src/ipc/buffer_assembler.cpp
+++ b/src/ipc/buffer_assembler.cpp
@@ -29,6 +29,8 @@
 #include <cstring>
 #include <utility>
 
+#include "raw_data_decode.h"
+
 namespace oid {
 
 bool BufferAssembler::begin(BeginParams params) {
@@ -36,20 +38,22 @@ bool BufferAssembler::begin(BeginParams params) {
     // this name, or its chunks would keep landing in the previous
     // allocation, under the previous geometry.
     auto name = params.variable_name;
-    // Validate while height is still `int`, before any unsigned cast can
-    // turn a negative value into a huge row count.
-    if (params.height <= 0) {
+    // Exact, not a lower bound: chunk() spaces rows by
+    // total_byte_size / height, so the payload must have a uniform row size.
+    // Requiring the padded size also makes the total divisible by height, so
+    // bytes-per-row is always meaningful.
+    const auto required =
+        padded_payload_size(params.width,
+                            params.height,
+                            params.channels,
+                            params.stride,
+                            static_cast<BufferType>(params.type));
+    if (!required || *required != params.total_byte_size) {
         in_progress_.erase(name);
         return false;
     }
     const auto height = static_cast<std::size_t>(params.height);
     const auto total = params.total_byte_size;
-    // The allocation must divide evenly into rows, else bytes-per-row is
-    // meaningless and a malformed transfer would otherwise be accepted.
-    if (total < height || total % height != 0) {
-        in_progress_.erase(name);
-        return false;
-    }
 
     InProgress entry{.params = std::move(params),
                      .bytes = std::vector<std::byte>(total, std::byte{}),

--- a/src/ipc/buffer_assembler.cpp
+++ b/src/ipc/buffer_assembler.cpp
@@ -25,16 +25,36 @@
 
 #include "buffer_assembler.h"
 
+#include <algorithm>
 #include <cstring>
 #include <utility>
 
 namespace oid {
 
 void BufferAssembler::begin(BeginParams params) {
+    // A rejected begin must also drop any transfer already in flight under
+    // this name, or its chunks would keep landing in the previous
+    // allocation, under the previous geometry.
+    auto name = params.variable_name;
+    // Validate while height is still `int`, before any unsigned cast can
+    // turn a negative value into a huge row count.
+    if (params.height <= 0) {
+        in_progress_.erase(name);
+        return;
+    }
+    const auto height = static_cast<std::size_t>(params.height);
     const auto total = params.total_byte_size;
-    auto& [entryParams, entryBytes] = in_progress_[params.variable_name];
-    entryParams = std::move(params);
-    entryBytes.assign(total, std::byte{});
+    // The allocation must divide evenly into rows, else bytes-per-row is
+    // meaningless and a malformed transfer would otherwise be accepted.
+    if (total < height || total % height != 0) {
+        in_progress_.erase(name);
+        return;
+    }
+
+    InProgress entry{.params = std::move(params),
+                     .bytes = std::vector<std::byte>(total, std::byte{}),
+                     .rows_received = std::vector<bool>(height, false)};
+    in_progress_.insert_or_assign(std::move(name), std::move(entry));
 }
 
 bool BufferAssembler::chunk(const std::string& name,
@@ -45,14 +65,27 @@ bool BufferAssembler::chunk(const std::string& name,
     if (it == in_progress_.end()) {
         return false;
     }
-    auto& [entryParams, entryBytes] = it->second;
-    const auto stride = static_cast<std::size_t>(entryParams.stride);
-    const auto offset = row_offset * stride;
-    if (const auto expected = row_count * stride;
+    auto& [entryParams, entryBytes, rowsReceived] = it->second;
+    const auto height = static_cast<std::size_t>(entryParams.height);
+
+    // Checked bound: row_offset > height rules out wraparound below.
+    if (row_offset > height || row_count > height - row_offset) {
+        return false;
+    }
+
+    // `stride` is row stride in elements, not bytes; derive real
+    // bytes-per-row from the allocation so multi-channel / multi-byte
+    // element buffers assemble correctly.
+    const auto bytes_per_row = entryBytes.size() / height;
+    const auto offset = row_offset * bytes_per_row;
+    if (const auto expected = row_count * bytes_per_row;
         bytes.size() != expected || offset + bytes.size() > entryBytes.size()) {
         return false;
     }
     std::memcpy(entryBytes.data() + offset, bytes.data(), bytes.size());
+    std::fill_n(rowsReceived.begin() + static_cast<std::ptrdiff_t>(row_offset),
+                row_count,
+                true);
     return true;
 }
 
@@ -61,7 +94,12 @@ std::optional<AssembledBuffer> BufferAssembler::end(const std::string& name) {
     if (it == in_progress_.end()) {
         return std::nullopt;
     }
-    auto& [params, bytes] = it->second;
+    auto& [params, bytes, rowsReceived] = it->second;
+    // Refuse a partial transfer rather than hand back a zero-filled buffer.
+    if (!std::ranges::all_of(rowsReceived, [](const bool r) { return r; })) {
+        in_progress_.erase(it);
+        return std::nullopt;
+    }
     AssembledBuffer out{.variable_name = std::move(params.variable_name),
                         .display_name = std::move(params.display_name),
                         .pixel_layout = std::move(params.pixel_layout),

--- a/src/ipc/buffer_assembler.cpp
+++ b/src/ipc/buffer_assembler.cpp
@@ -31,7 +31,7 @@
 
 namespace oid {
 
-void BufferAssembler::begin(BeginParams params) {
+bool BufferAssembler::begin(BeginParams params) {
     // A rejected begin must also drop any transfer already in flight under
     // this name, or its chunks would keep landing in the previous
     // allocation, under the previous geometry.
@@ -40,7 +40,7 @@ void BufferAssembler::begin(BeginParams params) {
     // turn a negative value into a huge row count.
     if (params.height <= 0) {
         in_progress_.erase(name);
-        return;
+        return false;
     }
     const auto height = static_cast<std::size_t>(params.height);
     const auto total = params.total_byte_size;
@@ -48,13 +48,14 @@ void BufferAssembler::begin(BeginParams params) {
     // meaningless and a malformed transfer would otherwise be accepted.
     if (total < height || total % height != 0) {
         in_progress_.erase(name);
-        return;
+        return false;
     }
 
     InProgress entry{.params = std::move(params),
                      .bytes = std::vector<std::byte>(total, std::byte{}),
                      .rows_received = std::vector<bool>(height, false)};
     in_progress_.insert_or_assign(std::move(name), std::move(entry));
+    return true;
 }
 
 bool BufferAssembler::chunk(const std::string& name,
@@ -112,6 +113,14 @@ std::optional<AssembledBuffer> BufferAssembler::end(const std::string& name) {
                         .bytes = std::move(bytes)};
     in_progress_.erase(it);
     return out;
+}
+
+bool BufferAssembler::abort(const std::string& name) {
+    return in_progress_.erase(name) != 0;
+}
+
+bool BufferAssembler::has_in_progress(const std::string& name) const {
+    return in_progress_.contains(name);
 }
 
 } // namespace oid

--- a/src/ipc/buffer_assembler.cpp
+++ b/src/ipc/buffer_assembler.cpp
@@ -38,17 +38,29 @@ bool BufferAssembler::begin(BeginParams params) {
     // this name, or its chunks would keep landing in the previous
     // allocation, under the previous geometry.
     auto name = params.variable_name;
+    // An unknown type would be taken as UNSIGNED_BYTE by type_size(), so the
+    // size arithmetic below would silently use the wrong element width.
+    if (!is_known_buffer_type(params.type)) {
+        in_progress_.erase(name);
+        return false;
+    }
+    // The declaration is untrusted and drives the allocation right below, so
+    // cap it before allocating rather than relying on the allocator to fail.
+    if (params.total_byte_size > MAX_BUFFER_BYTES) {
+        in_progress_.erase(name);
+        return false;
+    }
     // Exact, not a lower bound: chunk() spaces rows by
     // total_byte_size / height, so the payload must have a uniform row size.
     // Requiring the padded size also makes the total divisible by height, so
     // bytes-per-row is always meaningful.
-    const auto required =
-        padded_payload_size(params.width,
-                            params.height,
-                            params.channels,
-                            params.stride,
-                            static_cast<BufferType>(params.type));
-    if (!required || *required != params.total_byte_size) {
+    if (const auto required =
+            padded_payload_size(params.width,
+                                params.height,
+                                params.channels,
+                                params.stride,
+                                static_cast<BufferType>(params.type));
+        !required.has_value() || *required != params.total_byte_size) {
         in_progress_.erase(name);
         return false;
     }

--- a/src/ipc/buffer_assembler.cpp
+++ b/src/ipc/buffer_assembler.cpp
@@ -46,7 +46,7 @@ bool BufferAssembler::begin(BeginParams params) {
     }
     // The declaration is untrusted and drives the allocation right below, so
     // cap it before allocating rather than relying on the allocator to fail.
-    if (params.total_byte_size > MAX_BUFFER_BYTES) {
+    if (exceeds_max_buffer_bytes(params.total_byte_size)) {
         in_progress_.erase(name);
         return false;
     }

--- a/src/ipc/buffer_assembler.cpp
+++ b/src/ipc/buffer_assembler.cpp
@@ -50,6 +50,13 @@ bool BufferAssembler::begin(BeginParams params) {
         in_progress_.erase(name);
         return false;
     }
+    // The renderer would refuse this geometry anyway (Buffer::configure());
+    // catching it here means the transfer never gets allocated and assembled
+    // first.
+    if (!within_display_limits(params.width, params.height, params.channels)) {
+        in_progress_.erase(name);
+        return false;
+    }
     // Exact, not a lower bound: chunk() spaces rows by
     // total_byte_size / height, so the payload must have a uniform row size.
     // Requiring the padded size also makes the total divisible by height, so

--- a/src/ipc/buffer_assembler.h
+++ b/src/ipc/buffer_assembler.h
@@ -64,24 +64,29 @@ class BufferAssembler {
         std::size_t total_byte_size;
     };
 
-    // Start transfer for buffer `name`.
+    // Start transfer for buffer `name`. Returns void: invalid geometry
+    // (height <= 0, or total_byte_size not an exact multiple of height) is
+    // rejected by simply not starting the transfer, so chunk()/end() then
+    // fail closed for `name` as if begin() was never called.
     void begin(BeginParams params);
 
-    // Append row-strip chunk. Returns false if name unknown, size mismatch, or
-    // out of bounds.
+    // Append row-strip chunk. Returns false if name unknown, rows out of
+    // bounds, or size mismatch.
     [[nodiscard]] bool chunk(const std::string& name,
                              std::size_t row_offset,
                              std::size_t row_count,
                              std::span<const std::byte> bytes);
 
-    // Finish transfer, moving bytes out dropping entry. Returns
-    // nullopt if name unknown.
+    // Finish transfer, moving bytes out and dropping entry. Returns nullopt
+    // if name unknown or if any row was never received.
     [[nodiscard]] std::optional<AssembledBuffer> end(const std::string& name);
 
   private:
     struct InProgress {
         BeginParams params;
         std::vector<std::byte> bytes;
+        // Per-row arrival tracking so end() can refuse a partial transfer.
+        std::vector<bool> rows_received;
     };
     std::map<std::string, InProgress, std::less<>> in_progress_{};
 };

--- a/src/ipc/buffer_assembler.h
+++ b/src/ipc/buffer_assembler.h
@@ -64,10 +64,13 @@ class BufferAssembler {
         std::size_t total_byte_size;
     };
 
-    // Start transfer for buffer `name`. Returns false (without starting) if
-    // geometry is invalid (height <= 0, or total_byte_size not an exact
-    // multiple of height); chunk()/end() then fail closed for `name` as if
-    // begin() was never called. Returns true once the transfer has started.
+    // Start transfer for buffer `name`. Returns false (without starting)
+    // unless total_byte_size is exactly the fully padded size of the
+    // declared width/height/channels/stride/type -- stricter than
+    // geometry_fits_payload(), because row-strip chunks are spaced
+    // uniformly and so cannot tolerate a trimmed final row; chunk()/end()
+    // then fail closed for `name` as if begin() was never called. Returns
+    // true once the transfer has started.
     [[nodiscard]] bool begin(BeginParams params);
 
     // Append row-strip chunk. Returns false if name unknown, rows out of

--- a/src/ipc/buffer_assembler.h
+++ b/src/ipc/buffer_assembler.h
@@ -64,11 +64,11 @@ class BufferAssembler {
         std::size_t total_byte_size;
     };
 
-    // Start transfer for buffer `name`. Returns void: invalid geometry
-    // (height <= 0, or total_byte_size not an exact multiple of height) is
-    // rejected by simply not starting the transfer, so chunk()/end() then
-    // fail closed for `name` as if begin() was never called.
-    void begin(BeginParams params);
+    // Start transfer for buffer `name`. Returns false (without starting) if
+    // geometry is invalid (height <= 0, or total_byte_size not an exact
+    // multiple of height); chunk()/end() then fail closed for `name` as if
+    // begin() was never called. Returns true once the transfer has started.
+    [[nodiscard]] bool begin(BeginParams params);
 
     // Append row-strip chunk. Returns false if name unknown, rows out of
     // bounds, or size mismatch.
@@ -80,6 +80,12 @@ class BufferAssembler {
     // Finish transfer, moving bytes out and dropping entry. Returns nullopt
     // if name unknown or if any row was never received.
     [[nodiscard]] std::optional<AssembledBuffer> end(const std::string& name);
+
+    // Drop any in-progress transfer for `name`. Returns true if one existed.
+    bool abort(const std::string& name);
+
+    // True while a transfer for `name` is in flight (begun, not yet ended).
+    [[nodiscard]] bool has_in_progress(const std::string& name) const;
 
   private:
     struct InProgress {

--- a/src/ipc/message_exchange.h
+++ b/src/ipc/message_exchange.h
@@ -59,6 +59,11 @@ enum class MessageType {
     PLOT_BUFFER_END = 12
 };
 
+// Ceiling on a decoded string length. Names, pixel layouts and session JSON
+// are the only strings on this wire; the bound exists so a peer-supplied
+// length cannot drive an unbounded allocation, not to constrain real data.
+constexpr std::size_t MAX_STRING_BYTES = 16ULL * 1024ULL * 1024ULL;
+
 // C++20 concept to replace SFINAE for primitive type checking
 template <typename T>
 concept PrimitiveType =
@@ -92,6 +97,14 @@ class SocketTimeoutError final : public std::runtime_error {
     const std::source_location& loc = std::source_location::current()) {
     throw SocketTimeoutError{operation, loc};
 }
+
+// A message that cannot be decoded, as opposed to one that has not arrived
+// yet. Derives from std::runtime_error for the same cross-module RTTI reason
+// as SocketTimeoutError above: callers catch the base, never this type.
+class MessageDecodeError final : public std::runtime_error {
+  public:
+    using std::runtime_error::runtime_error;
+};
 
 struct MessageBlock {
     [[nodiscard]] virtual std::size_t size() const noexcept = 0;
@@ -241,6 +254,15 @@ class MessageDecoder {
             return size;
         }();
 
+        // The length comes from the peer and drives the allocation below.
+        // Refuse an impossible one rather than ask the allocator for it: a
+        // throw here has consumed only the length prefix, whereas a
+        // bad_alloc from resize() would leave the payload unread and every
+        // later message decoding from the wrong offset.
+        if (container_size > MAX_BUFFER_BYTES) {
+            throw MessageDecodeError{"declared payload exceeds the maximum "
+                                     "buffer size"};
+        }
         value.resize(container_size);
         read_impl(std::span{value.data(), container_size});
 
@@ -254,6 +276,12 @@ class MessageDecoder {
             return length;
         }();
 
+        // As above. Strings on this wire are names, pixel layouts and session
+        // JSON, none of which approach this bound.
+        if (symbol_length > MAX_STRING_BYTES) {
+            throw MessageDecodeError{"declared string exceeds the maximum "
+                                     "length"};
+        }
         value.resize(symbol_length);
         // std::string uses char* internally, convert to std::byte* for
         // read_impl

--- a/src/ipc/message_exchange.h
+++ b/src/ipc/message_exchange.h
@@ -259,9 +259,19 @@ class MessageDecoder {
         // throw here has consumed only the length prefix, whereas a
         // bad_alloc from resize() would leave the payload unread and every
         // later message decoding from the wrong offset.
-        if (container_size > MAX_BUFFER_BYTES) {
+        if (exceeds_max_buffer_bytes(container_size)) {
             throw MessageDecodeError{"declared payload exceeds the maximum "
                                      "buffer size"};
+        }
+        // Reachable only where size_t is 32 bits, i.e. the wasm build: there
+        // MAX_BUFFER_BYTES's 16 GiB ceiling can never be exceeded, so it
+        // cannot catch a length past what the container can represent;
+        // max_size() is the real limit there. resize() would otherwise throw
+        // std::length_error, which is not a std::runtime_error and would
+        // escape poll()'s catch. Keep this guard.
+        if (container_size > value.max_size()) {
+            throw MessageDecodeError{
+                "declared payload exceeds the container limit"};
         }
         value.resize(container_size);
         read_impl(std::span{value.data(), container_size});
@@ -281,6 +291,12 @@ class MessageDecoder {
         if (symbol_length > MAX_STRING_BYTES) {
             throw MessageDecodeError{"declared string exceeds the maximum "
                                      "length"};
+        }
+        // Reachable only where size_t is 32 bits, i.e. the wasm build: same
+        // reasoning as the vector overload above. Keep this guard.
+        if (symbol_length > value.max_size()) {
+            throw MessageDecodeError{
+                "declared string exceeds the container limit"};
         }
         value.resize(symbol_length);
         // std::string uses char* internally, convert to std::byte* for

--- a/src/ipc/raw_data_decode.cpp
+++ b/src/ipc/raw_data_decode.cpp
@@ -28,6 +28,7 @@
 #include <algorithm>
 
 #include <bit>
+#include <limits>
 
 namespace oid {
 
@@ -43,6 +44,49 @@ make_float_buffer_from_double(const std::vector<std::byte>& buff_double) {
     });
 
     return buff_float;
+}
+
+bool geometry_fits_payload(const int width,
+                           const int height,
+                           const int channels,
+                           const int stride,
+                           const BufferType type,
+                           const std::size_t byte_count) {
+    if (width <= 0 || height <= 0 || channels <= 0 || stride < width) {
+        return false;
+    }
+    const auto element_size =
+        static_cast<std::uint64_t>(channels) * type_size(type);
+    const auto pixels_needed = (static_cast<std::uint64_t>(height) - 1) *
+                                   static_cast<std::uint64_t>(stride) +
+                               static_cast<std::uint64_t>(width);
+    // Divided rather than multiplied: pixels_needed * element_size can
+    // overflow 64 bits for hostile geometry, the quotient cannot.
+    return static_cast<std::uint64_t>(byte_count) / element_size >=
+           pixels_needed;
+}
+
+std::optional<std::size_t> padded_payload_size(const int width,
+                                               const int height,
+                                               const int channels,
+                                               const int stride,
+                                               const BufferType type) {
+    if (width <= 0 || height <= 0 || channels <= 0 || stride < width) {
+        return std::nullopt;
+    }
+    // Each factor is checked before it is applied: hostile geometry can
+    // overflow this product, and a wrapped result would look plausible.
+    constexpr auto LIMIT = std::numeric_limits<std::size_t>::max();
+    auto size = static_cast<std::size_t>(stride);
+    for (const std::size_t factor : {static_cast<std::size_t>(height),
+                                     static_cast<std::size_t>(channels),
+                                     type_size(type)}) {
+        if (size > LIMIT / factor) {
+            return std::nullopt;
+        }
+        size *= factor;
+    }
+    return size;
 }
 
 } // namespace oid

--- a/src/ipc/raw_data_decode.cpp
+++ b/src/ipc/raw_data_decode.cpp
@@ -85,7 +85,7 @@ std::optional<std::size_t> padded_payload_size(const int width,
     }
     // Each factor is checked before it is applied: hostile geometry can
     // overflow this product, and a wrapped result would look plausible.
-    constexpr auto LIMIT = std::numeric_limits<std::size_t>::max();
+    constexpr auto LIMIT = (std::numeric_limits<std::size_t>::max)();
     auto size = static_cast<std::size_t>(stride);
     for (const std::size_t factor : {static_cast<std::size_t>(height),
                                      static_cast<std::size_t>(channels),

--- a/src/ipc/raw_data_decode.cpp
+++ b/src/ipc/raw_data_decode.cpp
@@ -52,6 +52,11 @@ bool geometry_fits_payload(const int width,
                            const int stride,
                            const BufferType type,
                            const std::size_t byte_count) {
+    // type_size() reports one byte for anything it does not recognise, which
+    // would silently measure the payload with the wrong element width.
+    if (!is_known_buffer_type(type)) {
+        return false;
+    }
     if (width <= 0 || height <= 0 || channels <= 0 || stride < width) {
         return false;
     }
@@ -71,6 +76,10 @@ std::optional<std::size_t> padded_payload_size(const int width,
                                                const int channels,
                                                const int stride,
                                                const BufferType type) {
+    // As above: an unrecognised type would be sized as one byte per element.
+    if (!is_known_buffer_type(type)) {
+        return std::nullopt;
+    }
     if (width <= 0 || height <= 0 || channels <= 0 || stride < width) {
         return std::nullopt;
     }

--- a/src/ipc/raw_data_decode.h
+++ b/src/ipc/raw_data_decode.h
@@ -43,6 +43,24 @@ enum class BufferType {
     FLOAT64 = 6
 };
 
+// Largest buffer, in bytes, that any path will accept. Bounds what an
+// untrusted wire declaration can make the viewer allocate, and is the same
+// ceiling Buffer::update() enforces before uploading a texture.
+constexpr std::uint64_t MAX_BUFFER_BYTES = 16ULL * 1024ULL * 1024ULL * 1024ULL;
+
+// True if `type` is a value this protocol defines. The wire carries a plain
+// int, and an unknown one would otherwise be silently taken as UNSIGNED_BYTE
+// by type_size()'s default while drawing no pixel label at all.
+[[nodiscard]] constexpr bool is_known_buffer_type(const BufferType type) {
+    using enum BufferType;
+    return type == UNSIGNED_BYTE || type == UNSIGNED_SHORT || type == SHORT ||
+           type == INT32 || type == FLOAT32 || type == FLOAT64;
+}
+
+[[nodiscard]] constexpr bool is_known_buffer_type(const int type) {
+    return is_known_buffer_type(static_cast<BufferType>(type));
+}
+
 std::vector<std::byte>
 make_float_buffer_from_double(const std::vector<std::byte>& buff_double);
 

--- a/src/ipc/raw_data_decode.h
+++ b/src/ipc/raw_data_decode.h
@@ -29,6 +29,7 @@
 #include <cstddef> // for std::size_t
 #include <cstdint> // for std::uint8_t
 
+#include <optional>
 #include <vector> // for std::vector
 
 namespace oid {
@@ -44,6 +45,26 @@ enum class BufferType {
 
 std::vector<std::byte>
 make_float_buffer_from_double(const std::vector<std::byte>& buff_double);
+
+// True if `byte_count` wire bytes can hold every pixel the declared geometry
+// addresses. The last row needs only `width` pixels, not the full `stride`,
+// so a producer that trims trailing row padding is still accepted. It is a
+// floor for one contiguous payload, which is what the single-shot path
+// needs, and it implies nothing about rows being uniformly sized.
+[[nodiscard]] bool geometry_fits_payload(int width,
+                                         int height,
+                                         int channels,
+                                         int stride,
+                                         BufferType type,
+                                         std::size_t byte_count);
+
+// Bytes a fully padded buffer of this geometry occupies, every row carrying
+// its whole stride. nullopt if the geometry is not renderable (non-positive
+// dimensions, or a stride narrower than the width) or if the size overflows.
+// Row-strip assembly needs this rather than the floor above, because it
+// addresses rows by a single fixed size.
+[[nodiscard]] std::optional<std::size_t> padded_payload_size(
+    int width, int height, int channels, int stride, BufferType type);
 
 [[nodiscard]] constexpr std::size_t type_size(const BufferType type) noexcept {
     using enum BufferType;

--- a/src/ipc/raw_data_decode.h
+++ b/src/ipc/raw_data_decode.h
@@ -48,6 +48,25 @@ enum class BufferType {
 // ceiling Buffer::update() enforces before uploading a texture.
 constexpr std::uint64_t MAX_BUFFER_BYTES = 16ULL * 1024ULL * 1024ULL * 1024ULL;
 
+// What the viewer can actually display. They live here, below the renderer,
+// so the wire layer can refuse a buffer it would otherwise allocate and then
+// have Buffer::configure() drop.
+constexpr int MIN_BUFFER_DIMENSION = 1;
+constexpr int MAX_BUFFER_DIMENSION = 131072; // 2^17, ~the 100k practical max
+constexpr int MIN_CHANNEL_COUNT = 1;
+constexpr int MAX_CHANNEL_COUNT = 4;
+
+// True if the geometry is one the renderer will accept. Deliberately separate
+// from the sizing helpers below: those answer whether a payload can be
+// measured, this answers whether the result is displayable, and the two
+// refusals want different diagnostics.
+[[nodiscard]] constexpr bool
+within_display_limits(const int width, const int height, const int channels) {
+    return width >= MIN_BUFFER_DIMENSION && width <= MAX_BUFFER_DIMENSION &&
+           height >= MIN_BUFFER_DIMENSION && height <= MAX_BUFFER_DIMENSION &&
+           channels >= MIN_CHANNEL_COUNT && channels <= MAX_CHANNEL_COUNT;
+}
+
 // True if `type` is a value this protocol defines. The wire carries a plain
 // int, and an unknown one would otherwise be silently taken as UNSIGNED_BYTE
 // by type_size()'s default while drawing no pixel label at all.

--- a/src/ipc/raw_data_decode.h
+++ b/src/ipc/raw_data_decode.h
@@ -29,6 +29,7 @@
 #include <cstddef> // for std::size_t
 #include <cstdint> // for std::uint8_t
 
+#include <limits>
 #include <optional>
 #include <vector> // for std::vector
 
@@ -47,6 +48,20 @@ enum class BufferType {
 // untrusted wire declaration can make the viewer allocate, and is the same
 // ceiling Buffer::update() enforces before uploading a texture.
 constexpr std::uint64_t MAX_BUFFER_BYTES = 16ULL * 1024ULL * 1024ULL * 1024ULL;
+
+// True if `byte_count` is past the ceiling above. Always false where size_t
+// cannot represent such a value -- the 32-bit wasm build -- because comparing
+// directly there is a tautology and a hard error under -Werror. That build is
+// bounded by the container's own max_size() instead.
+[[nodiscard]] constexpr bool
+exceeds_max_buffer_bytes(const std::size_t byte_count) {
+    if constexpr ((std::numeric_limits<std::size_t>::max)() >
+                  MAX_BUFFER_BYTES) {
+        return byte_count > MAX_BUFFER_BYTES;
+    } else {
+        return false;
+    }
+}
 
 // What the viewer can actually display. They live here, below the renderer,
 // so the wire layer can refuse a buffer it would otherwise allocate and then

--- a/src/visualization/components/buffer.cpp
+++ b/src/visualization/components/buffer.cpp
@@ -354,25 +354,24 @@ void Buffer::configure(const BufferParams& params) {
     // Validate dimensions
     if (!validate_dimension(params.buffer_width_i,
                             "width",
-                            BufferConstants::MIN_BUFFER_DIMENSION,
-                            BufferConstants::MAX_BUFFER_DIMENSION)) {
+                            MIN_BUFFER_DIMENSION,
+                            MAX_BUFFER_DIMENSION)) {
         return;
     }
 
     if (!validate_dimension(params.buffer_height_i,
                             "height",
-                            BufferConstants::MIN_BUFFER_DIMENSION,
-                            BufferConstants::MAX_BUFFER_DIMENSION)) {
+                            MIN_BUFFER_DIMENSION,
+                            MAX_BUFFER_DIMENSION)) {
         return;
     }
 
     // Validate channel count
-    if (params.channels < BufferConstants::MIN_CHANNELS ||
-        params.channels > BufferConstants::MAX_CHANNELS) {
+    if (params.channels < MIN_CHANNEL_COUNT ||
+        params.channels > MAX_CHANNEL_COUNT) {
         std::cerr << "[Error] Invalid channel count: " << params.channels
-                  << " (must be between " << BufferConstants::MIN_CHANNELS
-                  << " and " << BufferConstants::MAX_CHANNELS << ")"
-                  << std::endl;
+                  << " (must be between " << MIN_CHANNEL_COUNT << " and "
+                  << MAX_CHANNEL_COUNT << ")" << std::endl;
         return;
     }
 
@@ -397,10 +396,10 @@ void Buffer::configure(const BufferParams& params) {
     // on the 64-bit desktop build).
     if (const auto buffer_size =
             static_cast<std::uint64_t>(params.buffer.size());
-        buffer_size > BufferConstants::MAX_BUFFER_SIZE) {
+        buffer_size > MAX_BUFFER_BYTES) {
         std::cerr << "[Error] Buffer size too large: " << buffer_size
-                  << " bytes (maximum: " << BufferConstants::MAX_BUFFER_SIZE
-                  << " bytes)" << std::endl;
+                  << " bytes (maximum: " << MAX_BUFFER_BYTES << " bytes)"
+                  << std::endl;
         return;
     }
 

--- a/src/visualization/components/buffer.h
+++ b/src/visualization/components/buffer.h
@@ -42,14 +42,9 @@ namespace oid {
 namespace BufferConstants {
 constexpr int MAX_TEXTURE_SIZE = 2048;
 constexpr float ZOOM_BORDER_THRESHOLD = 40.0f;
-constexpr int MIN_BUFFER_DIMENSION = 1;
-constexpr int MAX_BUFFER_DIMENSION =
-    131072; // 2^17 = 128K (closest power of 2 to 100k)
-constexpr int MIN_CHANNELS = 1;
-constexpr int MAX_CHANNELS = 4;
-// Defined in ipc/raw_data_decode.h so the IPC layer can refuse an oversized
-// declaration before allocating, rather than the two limits drifting apart.
-constexpr std::uint64_t MAX_BUFFER_SIZE = MAX_BUFFER_BYTES;
+// The buffer dimension, channel and byte limits are not here: they live in
+// ipc/raw_data_decode.h, below this layer, so the wire code can refuse a
+// buffer this one would only reject later. Use them by their own names.
 } // namespace BufferConstants
 
 struct BufferParams {

--- a/src/visualization/components/buffer.h
+++ b/src/visualization/components/buffer.h
@@ -47,8 +47,9 @@ constexpr int MAX_BUFFER_DIMENSION =
     131072; // 2^17 = 128K (closest power of 2 to 100k)
 constexpr int MIN_CHANNELS = 1;
 constexpr int MAX_CHANNELS = 4;
-constexpr std::uint64_t MAX_BUFFER_SIZE =
-    16ULL * 1024ULL * 1024ULL * 1024ULL; // 16GB
+// Defined in ipc/raw_data_decode.h so the IPC layer can refuse an oversized
+// declaration before allocating, rather than the two limits drifting apart.
+constexpr std::uint64_t MAX_BUFFER_SIZE = MAX_BUFFER_BYTES;
 } // namespace BufferConstants
 
 struct BufferParams {

--- a/src/visualization/components/buffer_values.cpp
+++ b/src/visualization/components/buffer_values.cpp
@@ -129,8 +129,10 @@ void BufferValues::draw_pixel_values(const DrawPixelValuesParams& params) {
 
     for (int c = start_ch; c < end_ch; ++c) {
         constexpr auto label_length{30};
-        auto pix_label = std::string{};
-        pix_label.reserve(label_length);
+        // A plain char buffer, not a std::string: pix2str() writes through
+        // this pointer and terminates it by hand, which would be writing past
+        // a string's size() into merely reserved capacity.
+        std::array<char, label_length> pix_label{};
 
         // For single-channel mode, center the value; otherwise use original
         // calculation

--- a/testbench/.vscode/launch.json
+++ b/testbench/.vscode/launch.json
@@ -45,11 +45,12 @@
                 // The oid_breakpoint marker. Every fixture is constructed by
                 // this line, and breaking earlier catches half-built objects,
                 // which read as garbage dimensions rather than failing
-                // visibly. It is also the only nearby line that emits code:
-                // the (void) casts below it generate none, so a breakpoint
-                // set on one of those cannot bind and silently slides down to
-                // the closing return.
-                "breakpoint set --file realtypes.cpp --line 252"
+                // visibly. Matched by source pattern rather than by line
+                // number, which moves every time a fixture is added. The
+                // marker is also the only nearby line that emits code: the
+                // (void) casts below it generate none, so a breakpoint set on
+                // one cannot bind and silently slides to the closing return.
+                "breakpoint set --file realtypes.cpp --source-pattern-regexp \"oid_breakpoint = 0\""
             ]
         }
     ]

--- a/testbench/realtypes.cpp
+++ b/testbench/realtypes.cpp
@@ -12,6 +12,9 @@
  *     type NAME and reads members by name, so faithful local structs with the
  *     same member names and legacy constant values exercise those two entries
  *     exactly as the real types would.
+ *   - One deliberately oversized cv::Mat crosses the viewer's 8 MiB
+ *     per-message budget, so plotting it exercises the chunked transfer path
+ *     that every other fixture here is too small to reach.
  *
  * This target is built only when OpenCV and Eigen are found (see CMakeLists).
  * Set a breakpoint on the marked line in main(), run under a debugger with OID
@@ -69,6 +72,10 @@ namespace {
 constexpr int kW = 160;
 constexpr int kH = 120;
 
+// Dimensions of the oversized fixture; see make_mat_chunked_64f().
+constexpr int kBigW = 1024;
+constexpr int kBigH = 1025;
+
 // CvMat.type packs the depth (which doubles as the OID dtype code) in the low
 // 3 bits and (channels - 1) in the CV_CN_SHIFT (=3) field. CV_8U is OpenCV's
 // own macro (== 0) from <opencv2/core.hpp>.
@@ -100,12 +107,32 @@ cv::Mat make_mat_32fc1() {
     return m;
 }
 
+// Oversized single-channel float64: the only fixture here that is about the
+// transfer rather than a type entry. 1025 rows x 1024 float64 = 8,396,800
+// bytes, just past the viewer's 8 MiB per-message budget, so it crosses the
+// wire as a begin + one full 1024-row strip + a 1-row remainder instead of a
+// single message. float64 also makes bytes-per-row eight times the element
+// stride, which is where a transfer that measures strips in the wrong unit
+// goes wrong. Values ramp with the row, so a dropped tail reads as a flat
+// band rather than as plausible data.
+cv::Mat make_mat_chunked_64f() {
+    cv::Mat m(kBigH, kBigW, CV_64FC1);
+    for (int y = 0; y < m.rows; ++y) {
+        for (int x = 0; x < m.cols; ++x) {
+            m.at<double>(y, x) =
+                static_cast<double>(y) + static_cast<double>(x) / kBigW;
+        }
+    }
+    return m;
+}
+
 } // namespace
 
 int main() {
     // --- OpenCV cv::Mat (real library) ---
     cv::Mat mat_8uc3 = make_mat_8uc3();
     cv::Mat mat_32fc1 = make_mat_32fc1();
+    cv::Mat mat_chunked_64f = make_mat_chunked_64f();
 
     // --- CvMat (legacy struct), single-channel 8-bit ---
     std::vector<unsigned char> cvmat_backing(static_cast<std::size_t>(kW) * kH);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -135,6 +135,7 @@ target_link_libraries(test_buffer_assembler
 
 target_sources(test_buffer_assembler PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/ipc/buffer_assembler.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ipc/raw_data_decode.cpp
 )
 
 add_test(NAME BufferAssemblerTests COMMAND test_buffer_assembler)

--- a/tests/host/ipc/ipc_client_test.cpp
+++ b/tests/host/ipc/ipc_client_test.cpp
@@ -32,6 +32,7 @@
 #include <cstring>
 #include <deque>
 #include <iostream>
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 #include <string_view>
@@ -635,8 +636,133 @@ TEST(IpcClient, BeginRejectsFloorAcceptedGeometryThatIsNotFullyPadded) {
     // 128-byte chunk and leave the model empty. The diagnostic is what
     // discriminates -- it names BEGIN only when begin() did the refusing,
     // and CHUNK otherwise.
-    EXPECT_NE(cap.out.str().find("rejected PLOT_BUFFER_BEGIN"),
-              std::string::npos);
+    const std::string logged = cap.out.str();
+    EXPECT_NE(logged.find("rejected PLOT_BUFFER_BEGIN"), std::string::npos);
+    // Naming both sizes is what makes this failure self-diagnosing for a
+    // producer that computes the total from the trimmed lower bound.
+    EXPECT_NE(logged.find("needs 144 bytes"), std::string::npos);
+    EXPECT_NE(logged.find("got 128"), std::string::npos);
+}
+
+// An unknown type would fall through type_size()'s default and be measured
+// as one byte per element, so the size arithmetic would use the wrong
+// element width without anything noticing.
+TEST(IpcClient, BeginRejectsUnknownBufferType) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    // 1 is deliberately absent from BufferType; the enum skips it.
+    constexpr int unknown_type = 1;
+    MessageComposer c;
+    c.push(MessageType::PLOT_BUFFER_BEGIN)
+        .push(std::string("v"))
+        .push(std::string("disp"))
+        .push(std::string("rgb"))
+        .push(false)
+        .push(4)
+        .push(2)
+        .push(1)
+        .push(4)
+        .push(unknown_type)
+        .push(std::size_t{8});
+    t.feed(frame(c));
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    EXPECT_EQ(model.size(), 0u);
+    // 8 bytes is exactly the padded size at one byte per element, so only
+    // the type check can be doing the refusing here.
+    EXPECT_NE(cap.out.str().find("unknown buffer type 1"), std::string::npos);
+}
+
+TEST(IpcClient, PlotBufferContentsRejectsUnknownBufferType) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    const std::vector bytes(8, std::byte{5});
+    MessageComposer c;
+    c.push(MessageType::PLOT_BUFFER_CONTENTS)
+        .push(std::string("v"))
+        .push(std::string("disp"))
+        .push(std::string("rgb"))
+        .push(false)
+        .push(4)
+        .push(2)
+        .push(1)
+        .push(4)
+        .push(1) // absent from BufferType
+        .push(std::span<const std::byte>(bytes));
+    t.feed(frame(c));
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    EXPECT_EQ(model.size(), 0u);
+    EXPECT_NE(cap.out.str().find("unknown buffer type 1"), std::string::npos);
+}
+
+// The declared size drives an allocation, so it is capped before allocating
+// rather than left for the allocator to refuse. Nothing is allocated here:
+// the BEGIN only carries the number.
+TEST(IpcClient, BeginRejectsDeclarationAboveTheByteLimit) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    // stride 2^20 x height 2^15 x 1 channel x 1 byte = 32 GiB, which is
+    // exactly its own padded size -- so the cap, not the geometry, refuses.
+    constexpr int stride = 1 << 20;
+    constexpr int height = 1 << 15;
+    constexpr std::size_t declared =
+        static_cast<std::size_t>(stride) * static_cast<std::size_t>(height);
+    ASSERT_GT(declared, MAX_BUFFER_BYTES);
+    t.feed(begin_frame_ex(
+        "v", stride, height, 1, stride, BufferType::UNSIGNED_BYTE, declared));
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    EXPECT_EQ(model.size(), 0u);
+    EXPECT_NE(cap.out.str().find("exceeds the"), std::string::npos);
+}
+
+// padded_payload_size() reports nullopt both for a shape that makes no sense
+// and for one whose byte count will not fit, and those need different
+// messages: this geometry is entirely well-formed, just too big to measure.
+TEST(IpcClient, BeginDistinguishesAnOversizedGeometryFromAnInvalidOne) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    constexpr int huge = std::numeric_limits<int>::max();
+    t.feed(begin_frame_ex(
+        "v", huge, huge, 4, huge, BufferType::FLOAT64, std::size_t{8}));
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    EXPECT_EQ(model.size(), 0u);
+    const std::string logged = cap.out.str();
+    EXPECT_NE(logged.find("too large to size"), std::string::npos);
+    EXPECT_EQ(logged.find("not renderable"), std::string::npos);
+}
+
+// The other rejection reason: a shape that has no size at all, rather than
+// one whose size disagrees with the payload.
+TEST(IpcClient, BeginReportsUnrenderableGeometryDistinctly) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    // stride < width: no padded size exists, so there is no byte count to
+    // quote back.
+    t.feed(begin_frame_ex("v", 8, 2, 1, 4, BufferType::UNSIGNED_BYTE, 16));
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    EXPECT_EQ(model.size(), 0u);
+    const std::string logged = cap.out.str();
+    EXPECT_NE(logged.find("not renderable"), std::string::npos);
+    EXPECT_EQ(logged.find("needs"), std::string::npos);
 }
 
 TEST(IpcClient, BeginRejectsPayloadOneByteAboveOrBelowPaddedSize) {

--- a/tests/host/ipc/ipc_client_test.cpp
+++ b/tests/host/ipc/ipc_client_test.cpp
@@ -189,6 +189,32 @@ static std::vector<std::byte> begin_frame(const std::string& name,
     return frame(c);
 }
 
+// Like begin_frame, but exposes channels, stride and type: the
+// geometry-vs-payload checks need shapes begin_frame's fixed
+// channels=1/stride=width can't reach.
+static std::vector<std::byte>
+begin_frame_ex(const std::string& name,
+               const int width,
+               const int height,
+               const int channels,
+               const int stride,
+               const BufferType type,
+               const std::size_t total_byte_size) {
+    MessageComposer c;
+    c.push(MessageType::PLOT_BUFFER_BEGIN)
+        .push(name)
+        .push(std::string("disp"))
+        .push(std::string("rgb"))
+        .push(false)
+        .push(width)
+        .push(height)
+        .push(channels)
+        .push(stride)
+        .push(static_cast<int>(type))
+        .push(total_byte_size);
+    return frame(c);
+}
+
 static std::vector<std::byte>
 chunk_frame(const std::string& name,
             const std::size_t row_offset,
@@ -211,10 +237,10 @@ static std::vector<std::byte> end_frame(const std::string& name) {
 
 // Counts non-overlapping occurrences of `needle` in `haystack`; used instead
 // of find() != npos so tests assert an exact log count, not just presence.
-static std::size_t count_occurrences(const std::string& haystack,
-                                     const std::string& needle) {
+static std::size_t count_occurrences(const std::string_view haystack,
+                                     const std::string_view needle) {
     std::size_t count = 0;
-    for (std::size_t pos = haystack.find(needle); pos != std::string::npos;
+    for (std::size_t pos = haystack.find(needle); pos != std::string_view::npos;
          pos = haystack.find(needle, pos + needle.size())) {
         ++count;
     }
@@ -225,6 +251,8 @@ TEST(IpcClient, PlotBufferContentsUpsertsModel) {
     FakeTransport t;
     host::IpcBufferModel model;
     MessageComposer c;
+    // 2x2 rgb8, unpadded: stride counts PIXELS per row, so it equals width
+    // here, and the payload is channels * stride * height = 12 bytes.
     std::vector bytes(12, std::byte{5});
     c.push(MessageType::PLOT_BUFFER_CONTENTS)
         .push(std::string("v"))
@@ -234,7 +262,7 @@ TEST(IpcClient, PlotBufferContentsUpsertsModel) {
         .push(2)
         .push(2)
         .push(3)
-        .push(6)
+        .push(2)
         .push(BufferType::UNSIGNED_BYTE)
         .push(std::span<const std::byte>(bytes));
     t.feed(frame(c));
@@ -244,8 +272,76 @@ TEST(IpcClient, PlotBufferContentsUpsertsModel) {
 
     ASSERT_EQ(model.size(), 1u);
     EXPECT_EQ(model.at(0).variable_name, "v");
-    EXPECT_EQ(model.at(0).step, 6);
+    EXPECT_EQ(model.at(0).step, 2);
     EXPECT_EQ(model.at(0).bytes.size(), 12u);
+}
+
+// The single-shot sibling of the chunked-path fix: PLOT_BUFFER_CONTENTS
+// carries its whole payload in one message, with no BufferAssembler::begin()
+// to reject it, so handle_plot_buffer_contents() must apply the same check
+// itself.
+TEST(IpcClient, PlotBufferContentsRejectsPayloadTooSmallForGeometry) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    MessageComposer c;
+    // width=4, height=2, channels=1, stride=100000, FLOAT32 needs 100004
+    // pixels x 4 bytes; 2 bytes is nowhere close.
+    const std::vector bytes(2, std::byte{5});
+    c.push(MessageType::PLOT_BUFFER_CONTENTS)
+        .push(std::string("v"))
+        .push(std::string("disp"))
+        .push(std::string("rgb"))
+        .push(false)
+        .push(4)
+        .push(2)
+        .push(1)
+        .push(100000)
+        .push(BufferType::FLOAT32)
+        .push(std::span<const std::byte>(bytes));
+    t.feed(frame(c));
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    EXPECT_EQ(model.size(), 0u);
+    const std::string logged = cap.out.str();
+    EXPECT_NE(logged.find("rejected PLOT_BUFFER_CONTENTS"), std::string::npos);
+    EXPECT_NE(logged.find("'v'"), std::string::npos);
+    EXPECT_NE(logged.find("payload too small for geometry"), std::string::npos);
+}
+
+// The other half of the deliberate asymmetry: this is the exact geometry
+// LastRowOmittingTrailingStridePaddingIsRejectedOnChunkedPath refuses, and
+// the single-shot path takes it. Nothing here assembles row strips, so a
+// non-uniform final row is harmless and the floor is all that is required.
+TEST(IpcClient, PlotBufferContentsAcceptsLastRowOmittingStridePadding) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    MessageComposer c;
+    // width=3, height=2, channels=1, stride=5 (pixels/row): floor is
+    // (height-1)*stride+width = 8 bytes, fully padded would be 10.
+    const std::vector bytes(8, std::byte{5});
+    c.push(MessageType::PLOT_BUFFER_CONTENTS)
+        .push(std::string("v"))
+        .push(std::string("disp"))
+        .push(std::string("rgb"))
+        .push(false)
+        .push(3)
+        .push(2)
+        .push(1)
+        .push(5)
+        .push(BufferType::UNSIGNED_BYTE)
+        .push(std::span<const std::byte>(bytes));
+    t.feed(frame(c));
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    ASSERT_EQ(model.size(), 1u);
+    EXPECT_EQ(model.at(0).bytes.size(), 8u);
+    EXPECT_TRUE(cap.out.str().empty());
 }
 
 TEST(IpcClient, SetAvailableSymbolsPopulatesList) {
@@ -372,6 +468,8 @@ TEST(IpcClient, RequestPlotSends) {
 TEST(IpcClient, ChunkedRoundTripReassemblesBuffer) {
     FakeTransport t;
     host::IpcBufferModel model;
+    // 4x2 rgb8, unpadded: stride counts PIXELS per row, so it equals width
+    // here, and the payload is channels * stride * height = 24 bytes.
     std::vector bytes(24, std::byte{9});
 
     {
@@ -385,7 +483,7 @@ TEST(IpcClient, ChunkedRoundTripReassemblesBuffer) {
             .push(4)
             .push(2)
             .push(3)
-            .push(12)
+            .push(4)
             .push(static_cast<int>(BufferType::UNSIGNED_BYTE))
             .push(total);
         t.feed(frame(c));
@@ -414,6 +512,178 @@ TEST(IpcClient, ChunkedRoundTripReassemblesBuffer) {
     for (auto b : model.at(0).bytes) {
         EXPECT_EQ(b, std::byte{9});
     }
+}
+
+// The reported failure mode: a huge stride paired with a tiny, but
+// height-divisible, total_byte_size sails through the old height-only/
+// divisibility checks. begin() must now refuse it outright, so the buffer
+// never reaches the model even if well-formed chunks and an END follow.
+TEST(IpcClient, BeginRejectsGeometryTooLargeForPayload) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    // width=4, height=2, channels=1, stride=100000, FLOAT32: needs
+    // (height-1)*stride+width = 100004 pixels, but total_byte_size=2 covers
+    // zero (2 / type_size(FLOAT32) == 0).
+    t.feed(begin_frame_ex("v", 4, 2, 1, 100000, BufferType::FLOAT32, 2));
+    const std::vector bytes(2, std::byte{9}); // 1 byte/row, height-divisible
+    t.feed(chunk_frame("v", 0, 2, bytes));
+    t.feed(end_frame("v"));
+
+    host::IpcClient client(t, model);
+    {
+        CerrCapture cap; // silence the expected diagnostic
+        client.poll();
+    }
+
+    EXPECT_EQ(model.size(), 0u);
+}
+
+// begin() must reject non-positive width/channels and stride < width: none
+// of these are checked by the pre-existing height/divisibility validation,
+// so a peer could otherwise declare a shape the payload cannot back.
+TEST(IpcClient, BeginRejectsNonPositiveWidthChannelsAndStrideBelowWidth) {
+    // width <= 0.
+    {
+        FakeTransport t;
+        host::IpcBufferModel model;
+        t.feed(begin_frame_ex("v", 0, 2, 1, 1, BufferType::UNSIGNED_BYTE, 2));
+        host::IpcClient client(t, model);
+        CerrCapture cap;
+        client.poll();
+        EXPECT_NE(cap.out.str().find("rejected PLOT_BUFFER_BEGIN"),
+                  std::string::npos);
+    }
+    // channels <= 0.
+    {
+        FakeTransport t;
+        host::IpcBufferModel model;
+        t.feed(begin_frame_ex("v", 4, 2, 0, 4, BufferType::UNSIGNED_BYTE, 8));
+        host::IpcClient client(t, model);
+        CerrCapture cap;
+        client.poll();
+        EXPECT_NE(cap.out.str().find("rejected PLOT_BUFFER_BEGIN"),
+                  std::string::npos);
+    }
+    // stride < width.
+    {
+        FakeTransport t;
+        host::IpcBufferModel model;
+        t.feed(begin_frame_ex("v", 4, 2, 1, 2, BufferType::UNSIGNED_BYTE, 8));
+        host::IpcClient client(t, model);
+        CerrCapture cap;
+        client.poll();
+        EXPECT_NE(cap.out.str().find("rejected PLOT_BUFFER_BEGIN"),
+                  std::string::npos);
+    }
+}
+
+// A producer that trims the trailing stride padding off only the last row is
+// rejected on the chunked path: chunk() spaces every strip by
+// total_byte_size / height, so a non-uniform final row has nowhere to go.
+// (The single-shot path still accepts this shape via geometry_fits_payload,
+// unaffected by this test.) This exercises stride > width so the fully
+// padded size (stride*height = 10) differs from the trimmed lower bound
+// ((height-1)*stride+width = 8) that used to be let through.
+TEST(IpcClient, LastRowOmittingTrailingStridePaddingIsRejectedOnChunkedPath) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    // width=3, height=2, channels=1, stride=5 (pixels/row): trimmed lower
+    // bound is 8 bytes, the exact padded size begin() now requires is 10.
+    constexpr std::size_t trimmed_total = 8;
+    t.feed(begin_frame_ex(
+        "v", 3, 2, 1, 5, BufferType::UNSIGNED_BYTE, trimmed_total));
+    const std::vector bytes(trimmed_total, std::byte{7});
+    t.feed(chunk_frame("v", 0, 2, bytes));
+    t.feed(end_frame("v"));
+
+    host::IpcClient client(t, model);
+    {
+        CerrCapture cap; // silence the expected diagnostic
+        client.poll();
+    }
+
+    EXPECT_EQ(model.size(), 0u);
+}
+
+// Pins the exact contradiction the design review found: a geometry that
+// geometry_fits_payload() (the single-shot floor) accepts outright is still
+// refused on the chunked path, because chunk() needs every row spaced by a
+// single uniform size and this payload only has one if the trimmed last row
+// is ignored.
+TEST(IpcClient, BeginRejectsFloorAcceptedGeometryThatIsNotFullyPadded) {
+    // width=4, height=3, channels=2, stride=6, FLOAT32: floor =
+    // ((3-1)*6+4)*2*4 = 128 bytes; the fully padded size begin() now
+    // requires is stride*height*channels*type_size = 6*3*2*4 = 144.
+    constexpr std::size_t floor_total = 128;
+    ASSERT_TRUE(
+        geometry_fits_payload(4, 3, 2, 6, BufferType::FLOAT32, floor_total));
+
+    FakeTransport t;
+    host::IpcBufferModel model;
+    t.feed(begin_frame_ex("v", 4, 3, 2, 6, BufferType::FLOAT32, floor_total));
+    const std::vector bytes(floor_total, std::byte{5});
+    t.feed(chunk_frame("v", 0, 3, bytes));
+    t.feed(end_frame("v"));
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    EXPECT_EQ(model.size(), 0u);
+    // The empty model alone proves nothing here: 128 / 3 truncates to 42
+    // bytes per row, so even a wrongly accepted BEGIN would refuse the
+    // 128-byte chunk and leave the model empty. The diagnostic is what
+    // discriminates -- it names BEGIN only when begin() did the refusing,
+    // and CHUNK otherwise.
+    EXPECT_NE(cap.out.str().find("rejected PLOT_BUFFER_BEGIN"),
+              std::string::npos);
+}
+
+TEST(IpcClient, BeginRejectsPayloadOneByteAboveOrBelowPaddedSize) {
+    // width=4, height=1, channels=2, stride=6, FLOAT32: padded size is
+    // stride*height*channels*type_size = 6*1*2*4 = 48. height=1 is
+    // deliberate: with height>1 an off-by-one payload is already caught by
+    // the divisibility the exact size implies, so only height=1 leaves the
+    // exact comparison itself as the thing under test.
+    for (const std::size_t total : {std::size_t{47}, std::size_t{49}}) {
+        FakeTransport t;
+        host::IpcBufferModel model;
+        t.feed(begin_frame_ex("v", 4, 1, 2, 6, BufferType::FLOAT32, total));
+        // Chunk sized exactly as the old code would have computed
+        // bytes-per-row (total / height), followed by END: a full,
+        // internally-consistent round trip, so a wrongly-accepted begin()
+        // would actually complete the transfer instead of silently stalling
+        // on a missing END.
+        const std::vector bytes(total, std::byte{9});
+        t.feed(chunk_frame("v", 0, 1, bytes));
+        t.feed(end_frame("v"));
+
+        host::IpcClient client(t, model);
+        CerrCapture cap; // silence the expected diagnostic
+        client.poll();
+
+        EXPECT_EQ(model.size(), 0u);
+    }
+}
+
+TEST(IpcClient, BeginAcceptsExactlyPaddedSizeAndRoundTripsIntoModel) {
+    // Same geometry as the contradiction test above, but with the fully
+    // padded size (144) rather than the floor (128).
+    constexpr int height = 3;
+    constexpr std::size_t total = 144;
+    FakeTransport t;
+    host::IpcBufferModel model;
+    t.feed(begin_frame_ex("v", 4, height, 2, 6, BufferType::FLOAT32, total));
+    const std::vector bytes(total, std::byte{3});
+    t.feed(chunk_frame("v", 0, static_cast<std::size_t>(height), bytes));
+    t.feed(end_frame("v"));
+
+    host::IpcClient client(t, model);
+    client.poll();
+
+    ASSERT_EQ(model.size(), 1u);
+    EXPECT_EQ(model.at(0).variable_name, "v");
+    EXPECT_EQ(model.at(0).bytes.size(), total);
 }
 
 TEST(IpcClient, RejectedChunkAbortsTransferSoAWellFormedRetryCannotResumeIt) {

--- a/tests/host/ipc/ipc_client_test.cpp
+++ b/tests/host/ipc/ipc_client_test.cpp
@@ -138,6 +138,24 @@ struct ThrowingTransport final : ITransport {
     }
 };
 
+// Transport whose receive() throws std::length_error, standing in for a
+// peer-supplied size overrunning a container elsewhere in the receive path
+// (e.g. BufferAssembler::begin()'s vector construction on a 32-bit size_t)
+// that this fake cannot reach directly.
+struct LengthErrorTransport final : ITransport {
+    void send(std::span<const std::byte>) override {
+        // Nothing to record: only the receive side is under test here.
+    }
+
+    [[noreturn]] std::size_t receive(std::span<std::byte>) override {
+        throw std::length_error("simulated container overrun");
+    }
+
+    bool has_data() const override {
+        return true;
+    }
+};
+
 // Redirects std::cerr into a buffer for the test's duration, restoring the
 // original streambuf on destruction (production code logs via std::cerr
 // directly, so this is the only hook available to observe it).
@@ -842,7 +860,7 @@ TEST(IpcClient, BeginAcceptsGeometryExactlyAtDisplayLimits) {
 TEST(IpcClient, BeginRejectsHugeGeometryWithTheDisplayLimitsDiagnostic) {
     FakeTransport t;
     host::IpcBufferModel model;
-    constexpr int huge = std::numeric_limits<int>::max();
+    constexpr int huge = (std::numeric_limits<int>::max)();
     t.feed(begin_frame_ex(
         "v", huge, huge, 4, huge, BufferType::FLOAT64, std::size_t{8}));
 
@@ -1025,6 +1043,39 @@ TEST(IpcClient, RepeatedChunkFailuresForOneTransferReportOnlyOnce) {
     EXPECT_NE(logged.find("'v'"), std::string::npos);
 }
 
+TEST(IpcClient, RejectedChunkLogsRowOffsetAndRowCountWithoutWrappedEndpoint) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    t.feed(begin_frame("v", 4, 2, 8));
+
+    // row_offset + row_count overflows std::size_t and wraps to 0: a
+    // naively-computed endpoint would print an end row smaller than the
+    // start row, which is what this test guards against. row_count is
+    // chosen so its digits never appear inside row_offset's, so a substring
+    // search for it is unambiguous.
+    constexpr auto row_offset = (std::numeric_limits<std::size_t>::max)() - 999;
+    constexpr std::size_t row_count = 1000;
+    const std::vector bytes(5, std::byte{1});
+    t.feed(chunk_frame("v", row_offset, row_count, bytes));
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    const std::string logged = cap.out.str();
+    EXPECT_NE(logged.find("rejected PLOT_BUFFER_CHUNK for 'v'"),
+              std::string::npos);
+    EXPECT_NE(logged.find(std::to_string(row_offset)), std::string::npos);
+    // row_count is never printed by the old "rows [start, end)" phrasing
+    // (only the wrapped sum is), so this alone fails against that code.
+    EXPECT_NE(logged.find(std::to_string(row_count)), std::string::npos);
+    EXPECT_NE(logged.find(std::to_string(bytes.size()) + " bytes received"),
+              std::string::npos);
+    // The old phrasing would print ", 0)" here (row_offset + row_count
+    // wraps to 0); that text must be gone.
+    EXPECT_EQ(logged.find(", 0)"), std::string::npos);
+}
+
 TEST(IpcClient, StrayChunksForNeverBegunNamesAreSilent) {
     FakeTransport t;
     host::IpcBufferModel model;
@@ -1147,6 +1198,24 @@ TEST(IpcClient, PollDoesNotThrowOnTruncatedMessage) {
     EXPECT_NO_THROW(client.poll());
 
     EXPECT_EQ(model.size(), 0u); // partial message dropped, not half-applied
+}
+
+// MessageDecoder's own size guards keep it from throwing std::length_error,
+// but other peer-size-driven allocations reachable from dispatch() (e.g.
+// BufferAssembler::begin()'s vector construction, on a 32-bit size_t) are not
+// guarded that way, and poll() backstops those. The throw is driven straight
+// from the transport so the test does not depend on any of them being
+// reachable on this host.
+TEST(IpcClient, PollCatchesLengthErrorBackstopWithoutCrashing) {
+    LengthErrorTransport t;
+    host::IpcBufferModel model;
+
+    host::IpcClient client(t, model);
+    CerrCapture cap; // silence the expected diagnostic in test output
+    EXPECT_NO_THROW(client.poll());
+
+    EXPECT_EQ(model.size(), 0u);
+    EXPECT_NE(cap.out.str().find("dropped"), std::string::npos);
 }
 
 TEST(IpcClient, RestoresAvailableUnexpiredBuffersOnSetAvailableSymbols) {

--- a/tests/host/ipc/ipc_client_test.cpp
+++ b/tests/host/ipc/ipc_client_test.cpp
@@ -726,10 +726,120 @@ TEST(IpcClient, BeginRejectsDeclarationAboveTheByteLimit) {
     EXPECT_NE(cap.out.str().find("exceeds the"), std::string::npos);
 }
 
-// padded_payload_size() reports nullopt both for a shape that makes no sense
-// and for one whose byte count will not fit, and those need different
-// messages: this geometry is entirely well-formed, just too big to measure.
-TEST(IpcClient, BeginDistinguishesAnOversizedGeometryFromAnInvalidOne) {
+// The design review's motivating example: this geometry is otherwise
+// completely valid -- padded_payload_size(1, 131073, 1, 1, UNSIGNED_BYTE) is
+// exactly 131073, matching total_byte_size -- so only the new display-limits
+// check can be refusing it. Before this fix, begin() would have allocated,
+// assembled, and handed it to the model, for Buffer::configure() to drop.
+TEST(IpcClient, BeginRejectsGeometryOutsideDisplayLimits) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    // height = MAX_BUFFER_DIMENSION + 1.
+    t.feed(begin_frame_ex(
+        "v", 1, 131073, 1, 1, BufferType::UNSIGNED_BYTE, std::size_t{131073}));
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    EXPECT_EQ(model.size(), 0u);
+    const std::string logged = cap.out.str();
+    EXPECT_NE(logged.find("rejected PLOT_BUFFER_BEGIN"), std::string::npos);
+    EXPECT_NE(logged.find("display limits"), std::string::npos);
+}
+
+// Same check, the other geometry axis: channels one past MAX_CHANNEL_COUNT,
+// on the chunked path. The payload backs this shape exactly (4*2*5*1 = 40
+// bytes), so again only the display-limits check can be refusing it.
+TEST(IpcClient, BeginRejectsChannelsAboveDisplayLimit) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    t.feed(begin_frame_ex(
+        "v", 4, 2, 5, 4, BufferType::UNSIGNED_BYTE, std::size_t{40}));
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    EXPECT_EQ(model.size(), 0u);
+    const std::string logged = cap.out.str();
+    EXPECT_NE(logged.find("rejected PLOT_BUFFER_BEGIN"), std::string::npos);
+    EXPECT_NE(logged.find("display limits"), std::string::npos);
+}
+
+// The single-shot sibling of BeginRejectsGeometryOutsideDisplayLimits: same
+// geometry, but via PLOT_BUFFER_CONTENTS, which has no BufferAssembler::begin
+// to reject it, so handle_plot_buffer_contents() must apply the same check
+// itself.
+TEST(IpcClient, PlotBufferContentsRejectsGeometryOutsideDisplayLimits) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    const std::vector bytes(131073, std::byte{5});
+    MessageComposer c;
+    c.push(MessageType::PLOT_BUFFER_CONTENTS)
+        .push(std::string("v"))
+        .push(std::string("disp"))
+        .push(std::string("rgb"))
+        .push(false)
+        .push(1)
+        .push(131073) // height = MAX_BUFFER_DIMENSION + 1
+        .push(1)
+        .push(1)
+        .push(BufferType::UNSIGNED_BYTE)
+        .push(std::span<const std::byte>(bytes));
+    t.feed(frame(c));
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    EXPECT_EQ(model.size(), 0u);
+    const std::string logged = cap.out.str();
+    EXPECT_NE(logged.find("rejected PLOT_BUFFER_CONTENTS"), std::string::npos);
+    EXPECT_NE(logged.find("display limits"), std::string::npos);
+}
+
+// The boundary itself must not be off by one: height == MAX_BUFFER_DIMENSION
+// and channels == MAX_CHANNEL_COUNT together are still accepted and round
+// trip into the model. (This passes even before the fix -- it pins the
+// boundary, it is not a regression test for the new check.)
+TEST(IpcClient, BeginAcceptsGeometryExactlyAtDisplayLimits) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    constexpr int width = 1;
+    constexpr int stride = 1;
+    constexpr int height = 131072; // MAX_BUFFER_DIMENSION
+    constexpr int channels = 4;    // MAX_CHANNEL_COUNT
+    // UNSIGNED_BYTE keeps this well under MAX_BUFFER_BYTES despite the
+    // maximal height and channel count: 1 * 131072 * 4 * 1 = 512 KiB.
+    constexpr std::size_t total =
+        static_cast<std::size_t>(width) * height * channels;
+    t.feed(begin_frame_ex("v",
+                          width,
+                          height,
+                          channels,
+                          stride,
+                          BufferType::UNSIGNED_BYTE,
+                          total));
+    const std::vector bytes(total, std::byte{3});
+    t.feed(chunk_frame("v", 0, static_cast<std::size_t>(height), bytes));
+    t.feed(end_frame("v"));
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    ASSERT_EQ(model.size(), 1u);
+    EXPECT_EQ(model.at(0).bytes.size(), total);
+    EXPECT_TRUE(cap.out.str().empty());
+}
+
+// Before the display-limits check existed, this geometry reached
+// padded_payload_size(), overflowed there, and was reported as "too large to
+// size in bytes". The display-limits check now runs first (width and height
+// are each far past MAX_BUFFER_DIMENSION) and refuses it earlier with a more
+// specific reason, so the overflow branch is never reached for this input.
+TEST(IpcClient, BeginRejectsHugeGeometryWithTheDisplayLimitsDiagnostic) {
     FakeTransport t;
     host::IpcBufferModel model;
     constexpr int huge = std::numeric_limits<int>::max();
@@ -742,7 +852,8 @@ TEST(IpcClient, BeginDistinguishesAnOversizedGeometryFromAnInvalidOne) {
 
     EXPECT_EQ(model.size(), 0u);
     const std::string logged = cap.out.str();
-    EXPECT_NE(logged.find("too large to size"), std::string::npos);
+    EXPECT_NE(logged.find("display limits"), std::string::npos);
+    EXPECT_EQ(logged.find("too large to size"), std::string::npos);
     EXPECT_EQ(logged.find("not renderable"), std::string::npos);
 }
 

--- a/tests/host/ipc/ipc_client_test.cpp
+++ b/tests/host/ipc/ipc_client_test.cpp
@@ -31,6 +31,8 @@
 #include <array>
 #include <cstring>
 #include <deque>
+#include <iostream>
+#include <sstream>
 #include <stdexcept>
 #include <string_view>
 
@@ -135,6 +137,17 @@ struct ThrowingTransport final : ITransport {
     }
 };
 
+// Redirects std::cerr into a buffer for the test's duration, restoring the
+// original streambuf on destruction (production code logs via std::cerr
+// directly, so this is the only hook available to observe it).
+struct CerrCapture {
+    std::ostringstream out;
+    std::streambuf* saved = std::cerr.rdbuf(out.rdbuf());
+    ~CerrCapture() {
+        std::cerr.rdbuf(saved);
+    }
+};
+
 // Captures the bytes a MessageComposer would send, without a real socket.
 static std::vector<std::byte> frame(const MessageComposer& c) {
     struct Cap final : ITransport {
@@ -152,6 +165,60 @@ static std::vector<std::byte> frame(const MessageComposer& c) {
     Cap cap;
     c.send(cap);
     return cap.b;
+}
+
+// Builds a PLOT_BUFFER_BEGIN frame for `name`: single-channel, row-major
+// geometry (channels=1, stride=width) so callers only need to pick width,
+// height and the total payload size.
+static std::vector<std::byte> begin_frame(const std::string& name,
+                                          const int width,
+                                          const int height,
+                                          const std::size_t total_byte_size) {
+    MessageComposer c;
+    c.push(MessageType::PLOT_BUFFER_BEGIN)
+        .push(name)
+        .push(std::string("disp"))
+        .push(std::string("rgb"))
+        .push(false)
+        .push(width)
+        .push(height)
+        .push(1)
+        .push(width)
+        .push(static_cast<int>(BufferType::UNSIGNED_BYTE))
+        .push(total_byte_size);
+    return frame(c);
+}
+
+static std::vector<std::byte>
+chunk_frame(const std::string& name,
+            const std::size_t row_offset,
+            const std::size_t row_count,
+            const std::span<const std::byte> bytes) {
+    MessageComposer c;
+    c.push(MessageType::PLOT_BUFFER_CHUNK)
+        .push(name)
+        .push(row_offset)
+        .push(row_count)
+        .push(bytes);
+    return frame(c);
+}
+
+static std::vector<std::byte> end_frame(const std::string& name) {
+    MessageComposer c;
+    c.push(MessageType::PLOT_BUFFER_END).push(name);
+    return frame(c);
+}
+
+// Counts non-overlapping occurrences of `needle` in `haystack`; used instead
+// of find() != npos so tests assert an exact log count, not just presence.
+static std::size_t count_occurrences(const std::string& haystack,
+                                     const std::string& needle) {
+    std::size_t count = 0;
+    for (std::size_t pos = haystack.find(needle); pos != std::string::npos;
+         pos = haystack.find(needle, pos + needle.size())) {
+        ++count;
+    }
+    return count;
 }
 
 TEST(IpcClient, PlotBufferContentsUpsertsModel) {
@@ -346,6 +413,201 @@ TEST(IpcClient, ChunkedRoundTripReassemblesBuffer) {
     ASSERT_EQ(model.at(0).bytes.size(), 24u);
     for (auto b : model.at(0).bytes) {
         EXPECT_EQ(b, std::byte{9});
+    }
+}
+
+TEST(IpcClient, RejectedChunkAbortsTransferSoAWellFormedRetryCannotResumeIt) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    std::vector bytes(8, std::byte{1}); // 2 rows x 4 bytes/row
+
+    {
+        MessageComposer c;
+        c.push(MessageType::PLOT_BUFFER_BEGIN)
+            .push(std::string("v"))
+            .push(std::string("disp"))
+            .push(std::string("rgb"))
+            .push(false)
+            .push(4)
+            .push(2)
+            .push(1)
+            .push(4)
+            .push(static_cast<int>(BufferType::UNSIGNED_BYTE))
+            .push(bytes.size());
+        t.feed(frame(c));
+    }
+    {
+        // row_offset 5 is out of range for height 2: chunk() rejects it,
+        // which must abort the transfer outright.
+        MessageComposer c;
+        c.push(MessageType::PLOT_BUFFER_CHUNK)
+            .push(std::string("v"))
+            .push(std::size_t{5})
+            .push(std::size_t{1})
+            .push(std::span<const std::byte>(bytes));
+        t.feed(frame(c));
+    }
+    {
+        // A well-formed chunk covering every row, sent right after: without
+        // abort() this alone would complete the transfer, masking the
+        // earlier rejection instead of surfacing it.
+        MessageComposer c;
+        c.push(MessageType::PLOT_BUFFER_CHUNK)
+            .push(std::string("v"))
+            .push(std::size_t{0})
+            .push(std::size_t{2})
+            .push(std::span<const std::byte>(bytes));
+        t.feed(frame(c));
+    }
+    {
+        MessageComposer c;
+        c.push(MessageType::PLOT_BUFFER_END).push(std::string("v"));
+        t.feed(frame(c));
+    }
+
+    host::IpcClient client(t, model);
+    {
+        CerrCapture cap; // silence the expected diagnostic in test output
+        client.poll();
+    }
+
+    // Aborted transfer: even the later well-formed retry can't resume it.
+    EXPECT_EQ(model.size(), 0u);
+}
+
+TEST(IpcClient, RepeatedChunkFailuresForOneTransferReportOnlyOnce) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    std::vector bytes(8, std::byte{1});
+
+    {
+        MessageComposer c;
+        c.push(MessageType::PLOT_BUFFER_BEGIN)
+            .push(std::string("v"))
+            .push(std::string("disp"))
+            .push(std::string("rgb"))
+            .push(false)
+            .push(4)
+            .push(2)
+            .push(1)
+            .push(4)
+            .push(static_cast<int>(BufferType::UNSIGNED_BYTE))
+            .push(bytes.size());
+        t.feed(frame(c));
+    }
+    // First chunk aborts the transfer; every one after fails too (unknown
+    // name) -- a naive implementation would log all of these.
+    constexpr int kBadChunks = 200;
+    for (int i = 0; i < kBadChunks; ++i) {
+        MessageComposer c;
+        c.push(MessageType::PLOT_BUFFER_CHUNK)
+            .push(std::string("v"))
+            .push(std::size_t{5})
+            .push(std::size_t{1})
+            .push(std::span<const std::byte>(bytes));
+        t.feed(frame(c));
+    }
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    const std::string logged = cap.out.str();
+    EXPECT_EQ(std::ranges::count(logged, '\n'), 1);
+    EXPECT_NE(logged.find("PLOT_BUFFER_CHUNK"), std::string::npos);
+    EXPECT_NE(logged.find("'v'"), std::string::npos);
+}
+
+TEST(IpcClient, StrayChunksForNeverBegunNamesAreSilent) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    const std::vector bytes(4, std::byte{1});
+    t.feed(chunk_frame("a", 0, 1, bytes));
+    t.feed(chunk_frame("b", 0, 1, bytes));
+    t.feed(chunk_frame("c", 0, 1, bytes));
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    EXPECT_TRUE(cap.out.str().empty());
+}
+
+TEST(IpcClient, LaterTransferForSameNameStillReportsAfterEarlierRefusal) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+
+    // First attempt: invalid geometry refuses the BEGIN outright.
+    t.feed(begin_frame("v", 4, 0, 0)); // height <= 0 -> rejected
+
+    // Second attempt: a fresh, valid transfer under the same name that is
+    // then refused too (wrong-sized chunk). The old code tracked "already
+    // reported" per name with no bound on how long that lasts, so a second,
+    // unrelated failure for "v" could go unreported forever; it must not.
+    t.feed(begin_frame("v", 4, 2, 8));
+    const std::vector wrong_size_bytes(3, std::byte{1});
+    t.feed(chunk_frame("v", 0, 1, wrong_size_bytes));
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    const std::string logged = cap.out.str();
+    EXPECT_NE(logged.find("rejected PLOT_BUFFER_BEGIN"), std::string::npos);
+    EXPECT_NE(logged.find("rejected PLOT_BUFFER_CHUNK"), std::string::npos);
+}
+
+// Sharper version of the above: no intervening successful begin() at all, so
+// the only way a second BEGIN failure for "v" can be reported is if rejected
+// BEGINs are never gated by "already reported" in the first place. This is
+// the precise regression test for the suppression half of the bug: the old
+// per-name "already reported" set was cleared only by a successful begin()
+// or by end() running for that name, so a peer that only ever sends invalid
+// BEGINs for "v" got exactly one diagnostic, forever, no matter how many
+// distinct malformed attempts followed.
+TEST(IpcClient, RepeatedInvalidBeginsForSameNameEachReport) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    t.feed(begin_frame("v", 4, 0, 0)); // height <= 0 -> rejected
+    t.feed(begin_frame("v", 4, 0, 0)); // rejected again, unrelated attempt
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    EXPECT_EQ(count_occurrences(cap.out.str(), "rejected PLOT_BUFFER_BEGIN"),
+              2u);
+}
+
+TEST(IpcClient, StrayEndIsSilentButRealIncompleteTransferStillLogs) {
+    // A PLOT_BUFFER_END for a name with no transfer in flight is a stray
+    // (e.g. the tail of an already-reported refusal) and must be silent.
+    {
+        FakeTransport t;
+        host::IpcBufferModel model;
+        t.feed(end_frame("v"));
+
+        host::IpcClient client(t, model);
+        CerrCapture cap;
+        client.poll();
+
+        EXPECT_TRUE(cap.out.str().empty());
+    }
+    // A valid BEGIN whose rows are never fully covered before END is a
+    // genuine incomplete transfer and must still be reported.
+    {
+        FakeTransport t;
+        host::IpcBufferModel model;
+        t.feed(begin_frame("v", 4, 2, 8));
+        const std::vector bytes(4, std::byte{9});
+        t.feed(chunk_frame("v", 0, 1, bytes)); // only row 0 of 2 covered
+        t.feed(end_frame("v"));
+
+        host::IpcClient client(t, model);
+        CerrCapture cap;
+        client.poll();
+
+        EXPECT_NE(cap.out.str().find("incomplete transfer"), std::string::npos);
     }
 }
 

--- a/tests/test_buffer_assembler.cpp
+++ b/tests/test_buffer_assembler.cpp
@@ -117,6 +117,163 @@ TEST(BufferAssemblerTests, RejectsChunkAndEndForUnknownBuffer) {
     EXPECT_FALSE(a.end("missing").has_value());
 }
 
+// Regression test: `stride` is row stride in elements, not bytes. For a
+// multi-byte element the geometry must come from the payload (total bytes /
+// height), or rows silently go missing while size checks still pass.
+TEST(BufferAssemblerTests, AssemblesMultiByteElementBufferFromPayloadGeometry) {
+    constexpr int width = 4;
+    constexpr int height = 6;
+    constexpr int stride = width; // elements per row, deliberately != bytes/row
+    constexpr std::size_t bytes_per_row = width * sizeof(double);
+    constexpr std::size_t total = bytes_per_row * height;
+    BufferAssembler a;
+    a.begin(make_begin("buf", width, height, stride, total));
+
+    const auto full = iota_bytes(total);
+
+    // Row-strip sizes chosen so a stride-in-elements assembler (4 bytes/row)
+    // would reject these chunks outright (wrong expected size).
+    ASSERT_TRUE(
+        a.chunk("buf", 0, 2, std::span{full.data(), 2 * bytes_per_row}));
+    ASSERT_TRUE(
+        a.chunk("buf",
+                2,
+                4,
+                std::span{full.data() + 2 * bytes_per_row, 4 * bytes_per_row}));
+
+    const auto result = a.end("buf");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->bytes, full);
+}
+
+TEST(BufferAssemblerTests, RejectsWrongSizedChunkForMultiByteElementBuffer) {
+    constexpr int width = 4;
+    constexpr int height = 6;
+    constexpr int stride = width;
+    constexpr std::size_t bytes_per_row = width * sizeof(double);
+    constexpr std::size_t total = bytes_per_row * height;
+    BufferAssembler a;
+    a.begin(make_begin("buf", width, height, stride, total));
+    // One byte short of a single row.
+    const auto strip = iota_bytes(bytes_per_row - 1);
+    EXPECT_FALSE(a.chunk("buf", 0, 1, std::span{strip.data(), strip.size()}));
+}
+
+TEST(BufferAssemblerTests, RejectsNegativeHeight) {
+    constexpr int stride = 8;
+    constexpr int height = -4;
+    constexpr std::size_t total = 32;
+    BufferAssembler a;
+    a.begin(make_begin("buf", 8, height, stride, total));
+    const auto strip = iota_bytes(8);
+    // begin() must not have started a transfer for "buf".
+    EXPECT_FALSE(a.chunk("buf", 0, 1, std::span{strip.data(), strip.size()}));
+    EXPECT_FALSE(a.end("buf").has_value());
+}
+
+TEST(BufferAssemblerTests, RejectsHeightExceedingTotalByteSize) {
+    constexpr int stride = 8;
+    constexpr int height = 100;
+    constexpr std::size_t total = 32; // far fewer bytes than height rows
+    BufferAssembler a;
+    a.begin(make_begin("buf", 8, height, stride, total));
+    const auto strip = iota_bytes(8);
+    EXPECT_FALSE(a.chunk("buf", 0, 1, std::span{strip.data(), strip.size()}));
+    EXPECT_FALSE(a.end("buf").has_value());
+}
+
+TEST(BufferAssemblerTests, RejectsTotalByteSizeNotDivisibleByHeight) {
+    constexpr int stride = 8;
+    constexpr int height = 5;
+    constexpr std::size_t total = 33; // 33 % 5 != 0
+    BufferAssembler a;
+    a.begin(make_begin("buf", 8, height, stride, total));
+    const auto strip = iota_bytes(8);
+    EXPECT_FALSE(a.chunk("buf", 0, 1, std::span{strip.data(), strip.size()}));
+    EXPECT_FALSE(a.end("buf").has_value());
+}
+
+TEST(BufferAssemblerTests, EmptyChunkDoesNotCountAsCoverage) {
+    constexpr int stride = 4;
+    constexpr int height = 2;
+    constexpr std::size_t total = stride * height;
+    BufferAssembler a;
+    a.begin(make_begin("buf", 4, height, stride, total));
+    // A zero-row, zero-byte chunk is a harmless no-op, but must not be
+    // mistaken for a completed transfer.
+    EXPECT_TRUE(a.chunk("buf", 0, 0, std::span<const std::byte>{}));
+    EXPECT_FALSE(a.end("buf").has_value());
+}
+
+TEST(BufferAssemblerTests, RejectsRowRangeExceedingHeight) {
+    constexpr int stride = 8;
+    constexpr int height = 4;
+    constexpr std::size_t total = stride * height;
+    BufferAssembler a;
+    a.begin(make_begin("buf", 8, height, stride, total));
+    const auto strip = iota_bytes(2 * stride);
+    // rows [3,5) - row 4 does not exist for height=4.
+    EXPECT_FALSE(a.chunk("buf", 3, 2, std::span{strip.data(), strip.size()}));
+}
+
+TEST(BufferAssemblerTests, RejectsRowOffsetThatWouldWrapByteMathAroundSizeT) {
+    constexpr int stride = 8;
+    constexpr int height = 4;
+    constexpr std::size_t total = stride * height; // bytes_per_row == 8
+    BufferAssembler a;
+    a.begin(make_begin("buf", 8, height, stride, total));
+    const auto strip = iota_bytes(2 * stride);
+    // row_offset * bytes_per_row == 2^61 * 8 == 2^64, which wraps to 0 in
+    // size_t arithmetic; an unchecked implementation would compute a
+    // deceptively in-bounds offset for a row far past `height`.
+    constexpr std::size_t wrapping_offset = std::size_t{1} << 61;
+    EXPECT_FALSE(a.chunk(
+        "buf", wrapping_offset, 2, std::span{strip.data(), strip.size()}));
+}
+
+TEST(BufferAssemblerTests, EndFailsWhenAStripIsMissing) {
+    constexpr int stride = 8;
+    constexpr int height = 4;
+    constexpr std::size_t total = stride * height;
+    BufferAssembler a;
+    a.begin(make_begin("buf", 8, height, stride, total));
+    const auto full = iota_bytes(total);
+    // Only rows [0,2) ever arrive; rows [2,4) are missing.
+    ASSERT_TRUE(
+        a.chunk("buf",
+                0,
+                2,
+                std::span{full.data(), 2 * static_cast<std::size_t>(stride)}));
+    EXPECT_FALSE(a.end("buf").has_value());
+}
+
+TEST(BufferAssemblerTests, AssemblesCorrectlyWhenChunksArriveOutOfOrder) {
+    constexpr int stride = 8;
+    constexpr int height = 4;
+    constexpr std::size_t total = stride * height;
+    BufferAssembler a;
+    a.begin(make_begin("buf", 8, height, stride, total));
+    const auto full = iota_bytes(total);
+
+    // Second half arrives first.
+    ASSERT_TRUE(
+        a.chunk("buf",
+                2,
+                2,
+                std::span{full.data() + 2 * static_cast<std::size_t>(stride),
+                          2 * static_cast<std::size_t>(stride)}));
+    // Then the first half.
+    ASSERT_TRUE(
+        a.chunk("buf",
+                0,
+                2,
+                std::span{full.data(), 2 * static_cast<std::size_t>(stride)}));
+
+    const auto result = a.end("buf");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->bytes, full);
+}
+
 TEST(BufferAssemblerTests, InterleavedBuffersDoNotCorruptEachOther) {
     constexpr int stride = 4;
     constexpr int height = 1;
@@ -137,4 +294,21 @@ TEST(BufferAssemblerTests, InterleavedBuffersDoNotCorruptEachOther) {
     ASSERT_TRUE(result_b.has_value());
     EXPECT_EQ(result_a->bytes[0], std::byte{1});
     EXPECT_EQ(result_b->bytes[0], std::byte{5});
+}
+
+TEST(BufferAssemblerTests, RejectedBeginDropsATransferAlreadyInFlight) {
+    // A rejected begin must leave nothing behind: otherwise the earlier
+    // transfer stays live under the same name and keeps accepting chunks
+    // against its own geometry, which is not the geometry being sent.
+    constexpr int stride = 4;
+    constexpr std::size_t total = 8;
+    BufferAssembler a;
+    a.begin(make_begin("x", 4, 2, stride, total));
+
+    a.begin(make_begin("x", 4, -1, stride, total));
+
+    const std::vector row{
+        std::byte{1}, std::byte{2}, std::byte{3}, std::byte{4}};
+    EXPECT_FALSE(a.chunk("x", 0, 1, std::span{row.data(), row.size()}));
+    EXPECT_FALSE(a.end("x").has_value());
 }

--- a/tests/test_buffer_assembler.cpp
+++ b/tests/test_buffer_assembler.cpp
@@ -24,6 +24,7 @@
  */
 
 #include "ipc/buffer_assembler.h"
+#include "ipc/raw_data_decode.h"
 
 #include <gtest/gtest.h>
 
@@ -31,11 +32,13 @@ using namespace oid;
 
 namespace {
 
-BufferAssembler::BeginParams make_begin(const std::string& name,
-                                        const int width,
-                                        const int height,
-                                        const int stride,
-                                        const std::size_t total) {
+BufferAssembler::BeginParams
+make_begin(const std::string& name,
+           const int width,
+           const int height,
+           const int stride,
+           const std::size_t total,
+           const BufferType type = BufferType::UNSIGNED_BYTE) {
     return BufferAssembler::BeginParams{.variable_name = name,
                                         .display_name = name,
                                         .pixel_layout = "rgba",
@@ -44,7 +47,7 @@ BufferAssembler::BeginParams make_begin(const std::string& name,
                                         .height = height,
                                         .channels = 1,
                                         .stride = stride,
-                                        .type = 0,
+                                        .type = static_cast<int>(type),
                                         .total_byte_size = total};
 }
 
@@ -119,7 +122,10 @@ TEST(BufferAssemblerTests, RejectsChunkAndEndForUnknownBuffer) {
 
 // Regression test: `stride` is row stride in elements, not bytes. For a
 // multi-byte element the geometry must come from the payload (total bytes /
-// height), or rows silently go missing while size checks still pass.
+// height), or rows silently go missing while size checks still pass. Type is
+// FLOAT64 (not the helper's UNSIGNED_BYTE default) so `total` -- sized for
+// 8-byte doubles -- is the geometry's exact padded size, as begin() now
+// requires.
 TEST(BufferAssemblerTests, AssemblesMultiByteElementBufferFromPayloadGeometry) {
     constexpr int width = 4;
     constexpr int height = 6;
@@ -127,7 +133,8 @@ TEST(BufferAssemblerTests, AssemblesMultiByteElementBufferFromPayloadGeometry) {
     constexpr std::size_t bytes_per_row = width * sizeof(double);
     constexpr std::size_t total = bytes_per_row * height;
     BufferAssembler a;
-    ASSERT_TRUE(a.begin(make_begin("buf", width, height, stride, total)));
+    ASSERT_TRUE(a.begin(
+        make_begin("buf", width, height, stride, total, BufferType::FLOAT64)));
 
     const auto full = iota_bytes(total);
 
@@ -153,7 +160,8 @@ TEST(BufferAssemblerTests, RejectsWrongSizedChunkForMultiByteElementBuffer) {
     constexpr std::size_t bytes_per_row = width * sizeof(double);
     constexpr std::size_t total = bytes_per_row * height;
     BufferAssembler a;
-    ASSERT_TRUE(a.begin(make_begin("buf", width, height, stride, total)));
+    ASSERT_TRUE(a.begin(
+        make_begin("buf", width, height, stride, total, BufferType::FLOAT64)));
     // One byte short of a single row.
     const auto strip = iota_bytes(bytes_per_row - 1);
     EXPECT_FALSE(a.chunk("buf", 0, 1, std::span{strip.data(), strip.size()}));

--- a/tests/test_buffer_assembler.cpp
+++ b/tests/test_buffer_assembler.cpp
@@ -63,7 +63,7 @@ TEST(BufferAssemblerTests, ReassemblesRowStripsIntoContiguousBuffer) {
     constexpr int height = 4;
     constexpr std::size_t total = stride * height;
     BufferAssembler a;
-    a.begin(make_begin("buf", 8, height, stride, total));
+    ASSERT_TRUE(a.begin(make_begin("buf", 8, height, stride, total)));
 
     const auto full = iota_bytes(total);
 
@@ -93,7 +93,7 @@ TEST(BufferAssemblerTests, RejectsChunkBeyondImageHeight) {
     constexpr int height = 2;
     constexpr std::size_t total = stride * height;
     BufferAssembler a;
-    a.begin(make_begin("buf", 8, height, stride, total));
+    ASSERT_TRUE(a.begin(make_begin("buf", 8, height, stride, total)));
     const auto strip = iota_bytes(2 * stride);
     // rows [1,3) do not fit in 2-row buffer.
     EXPECT_FALSE(a.chunk("buf", 1, 2, std::span{strip.data(), strip.size()}));
@@ -104,7 +104,7 @@ TEST(BufferAssemblerTests, RejectsWrongSizedChunk) {
     constexpr int height = 2;
     constexpr std::size_t total = stride * height;
     BufferAssembler a;
-    a.begin(make_begin("buf", 8, height, stride, total));
+    ASSERT_TRUE(a.begin(make_begin("buf", 8, height, stride, total)));
     const auto strip = iota_bytes(stride + 1); // not multiple stride
     EXPECT_FALSE(a.chunk("buf", 0, 1, std::span{strip.data(), strip.size()}));
 }
@@ -127,7 +127,7 @@ TEST(BufferAssemblerTests, AssemblesMultiByteElementBufferFromPayloadGeometry) {
     constexpr std::size_t bytes_per_row = width * sizeof(double);
     constexpr std::size_t total = bytes_per_row * height;
     BufferAssembler a;
-    a.begin(make_begin("buf", width, height, stride, total));
+    ASSERT_TRUE(a.begin(make_begin("buf", width, height, stride, total)));
 
     const auto full = iota_bytes(total);
 
@@ -153,7 +153,7 @@ TEST(BufferAssemblerTests, RejectsWrongSizedChunkForMultiByteElementBuffer) {
     constexpr std::size_t bytes_per_row = width * sizeof(double);
     constexpr std::size_t total = bytes_per_row * height;
     BufferAssembler a;
-    a.begin(make_begin("buf", width, height, stride, total));
+    ASSERT_TRUE(a.begin(make_begin("buf", width, height, stride, total)));
     // One byte short of a single row.
     const auto strip = iota_bytes(bytes_per_row - 1);
     EXPECT_FALSE(a.chunk("buf", 0, 1, std::span{strip.data(), strip.size()}));
@@ -164,9 +164,9 @@ TEST(BufferAssemblerTests, RejectsNegativeHeight) {
     constexpr int height = -4;
     constexpr std::size_t total = 32;
     BufferAssembler a;
-    a.begin(make_begin("buf", 8, height, stride, total));
+    // begin() itself must report the rejection, not just leave "buf" unstarted.
+    EXPECT_FALSE(a.begin(make_begin("buf", 8, height, stride, total)));
     const auto strip = iota_bytes(8);
-    // begin() must not have started a transfer for "buf".
     EXPECT_FALSE(a.chunk("buf", 0, 1, std::span{strip.data(), strip.size()}));
     EXPECT_FALSE(a.end("buf").has_value());
 }
@@ -176,7 +176,7 @@ TEST(BufferAssemblerTests, RejectsHeightExceedingTotalByteSize) {
     constexpr int height = 100;
     constexpr std::size_t total = 32; // far fewer bytes than height rows
     BufferAssembler a;
-    a.begin(make_begin("buf", 8, height, stride, total));
+    EXPECT_FALSE(a.begin(make_begin("buf", 8, height, stride, total)));
     const auto strip = iota_bytes(8);
     EXPECT_FALSE(a.chunk("buf", 0, 1, std::span{strip.data(), strip.size()}));
     EXPECT_FALSE(a.end("buf").has_value());
@@ -187,7 +187,7 @@ TEST(BufferAssemblerTests, RejectsTotalByteSizeNotDivisibleByHeight) {
     constexpr int height = 5;
     constexpr std::size_t total = 33; // 33 % 5 != 0
     BufferAssembler a;
-    a.begin(make_begin("buf", 8, height, stride, total));
+    EXPECT_FALSE(a.begin(make_begin("buf", 8, height, stride, total)));
     const auto strip = iota_bytes(8);
     EXPECT_FALSE(a.chunk("buf", 0, 1, std::span{strip.data(), strip.size()}));
     EXPECT_FALSE(a.end("buf").has_value());
@@ -198,7 +198,7 @@ TEST(BufferAssemblerTests, EmptyChunkDoesNotCountAsCoverage) {
     constexpr int height = 2;
     constexpr std::size_t total = stride * height;
     BufferAssembler a;
-    a.begin(make_begin("buf", 4, height, stride, total));
+    ASSERT_TRUE(a.begin(make_begin("buf", 4, height, stride, total)));
     // A zero-row, zero-byte chunk is a harmless no-op, but must not be
     // mistaken for a completed transfer.
     EXPECT_TRUE(a.chunk("buf", 0, 0, std::span<const std::byte>{}));
@@ -210,7 +210,7 @@ TEST(BufferAssemblerTests, RejectsRowRangeExceedingHeight) {
     constexpr int height = 4;
     constexpr std::size_t total = stride * height;
     BufferAssembler a;
-    a.begin(make_begin("buf", 8, height, stride, total));
+    ASSERT_TRUE(a.begin(make_begin("buf", 8, height, stride, total)));
     const auto strip = iota_bytes(2 * stride);
     // rows [3,5) - row 4 does not exist for height=4.
     EXPECT_FALSE(a.chunk("buf", 3, 2, std::span{strip.data(), strip.size()}));
@@ -221,7 +221,7 @@ TEST(BufferAssemblerTests, RejectsRowOffsetThatWouldWrapByteMathAroundSizeT) {
     constexpr int height = 4;
     constexpr std::size_t total = stride * height; // bytes_per_row == 8
     BufferAssembler a;
-    a.begin(make_begin("buf", 8, height, stride, total));
+    ASSERT_TRUE(a.begin(make_begin("buf", 8, height, stride, total)));
     const auto strip = iota_bytes(2 * stride);
     // row_offset * bytes_per_row == 2^61 * 8 == 2^64, which wraps to 0 in
     // size_t arithmetic; an unchecked implementation would compute a
@@ -236,7 +236,7 @@ TEST(BufferAssemblerTests, EndFailsWhenAStripIsMissing) {
     constexpr int height = 4;
     constexpr std::size_t total = stride * height;
     BufferAssembler a;
-    a.begin(make_begin("buf", 8, height, stride, total));
+    ASSERT_TRUE(a.begin(make_begin("buf", 8, height, stride, total)));
     const auto full = iota_bytes(total);
     // Only rows [0,2) ever arrive; rows [2,4) are missing.
     ASSERT_TRUE(
@@ -252,7 +252,7 @@ TEST(BufferAssemblerTests, AssemblesCorrectlyWhenChunksArriveOutOfOrder) {
     constexpr int height = 4;
     constexpr std::size_t total = stride * height;
     BufferAssembler a;
-    a.begin(make_begin("buf", 8, height, stride, total));
+    ASSERT_TRUE(a.begin(make_begin("buf", 8, height, stride, total)));
     const auto full = iota_bytes(total);
 
     // Second half arrives first.
@@ -279,8 +279,8 @@ TEST(BufferAssemblerTests, InterleavedBuffersDoNotCorruptEachOther) {
     constexpr int height = 1;
     constexpr std::size_t total = stride * height;
     BufferAssembler a;
-    a.begin(make_begin("a", 4, height, stride, total));
-    a.begin(make_begin("b", 4, height, stride, total));
+    ASSERT_TRUE(a.begin(make_begin("a", 4, height, stride, total)));
+    ASSERT_TRUE(a.begin(make_begin("b", 4, height, stride, total)));
     const std::vector da{
         std::byte{1}, std::byte{2}, std::byte{3}, std::byte{4}};
     const std::vector db{
@@ -303,12 +303,34 @@ TEST(BufferAssemblerTests, RejectedBeginDropsATransferAlreadyInFlight) {
     constexpr int stride = 4;
     constexpr std::size_t total = 8;
     BufferAssembler a;
-    a.begin(make_begin("x", 4, 2, stride, total));
+    ASSERT_TRUE(a.begin(make_begin("x", 4, 2, stride, total)));
 
-    a.begin(make_begin("x", 4, -1, stride, total));
+    EXPECT_FALSE(a.begin(make_begin("x", 4, -1, stride, total)));
 
     const std::vector row{
         std::byte{1}, std::byte{2}, std::byte{3}, std::byte{4}};
     EXPECT_FALSE(a.chunk("x", 0, 1, std::span{row.data(), row.size()}));
     EXPECT_FALSE(a.end("x").has_value());
+}
+
+TEST(BufferAssemblerTests, AbortDropsAnInProgressTransfer) {
+    constexpr int stride = 4;
+    constexpr int height = 2;
+    constexpr std::size_t total = stride * height;
+    BufferAssembler a;
+    ASSERT_TRUE(a.begin(make_begin("buf", 4, height, stride, total)));
+    const auto strip = iota_bytes(stride);
+    ASSERT_TRUE(a.chunk("buf", 0, 1, std::span{strip.data(), strip.size()}));
+
+    a.abort("buf");
+
+    // Later chunks and end() fail closed, as if "buf" was never begun.
+    EXPECT_FALSE(a.chunk("buf", 1, 1, std::span{strip.data(), strip.size()}));
+    EXPECT_FALSE(a.end("buf").has_value());
+}
+
+TEST(BufferAssemblerTests, AbortOnUnknownNameIsHarmless) {
+    BufferAssembler a;
+    EXPECT_NO_FATAL_FAILURE(a.abort("missing"));
+    EXPECT_FALSE(a.end("missing").has_value());
 }

--- a/tests/test_message_exchange.cpp
+++ b/tests/test_message_exchange.cpp
@@ -30,6 +30,7 @@
 #include <gtest/gtest.h>
 #include <optional>
 #include <span>
+#include <stdexcept>
 #include <string_view>
 #include <thread>
 #include <vector>
@@ -300,6 +301,35 @@ TEST_F(MessageExchangeTest, MessageDecoderReadVector) {
 
     EXPECT_EQ(result.size(), test_vector.size());
     EXPECT_EQ(std::memcmp(result.data(), test_vector.data(), result.size()), 0);
+}
+
+// A peer-supplied length drives the resize, so an impossible one must be
+// refused rather than handed to the allocator: a bad_alloc there would leave
+// the payload unread and every later message decoding from the wrong offset.
+TEST_F(MessageExchangeTest, MessageDecoderRejectsOversizedVectorLength) {
+    ConnectSockets();
+
+    const auto absurd = static_cast<std::size_t>(MAX_BUFFER_BYTES) + 1;
+    std::array<char, sizeof(std::size_t)> buffer{};
+    std::memcpy(buffer.data(), &absurd, sizeof(std::size_t));
+    client_transport_->send(as_bytes_span(buffer));
+
+    MessageDecoder decoder(*server_transport_);
+    std::vector<std::byte> result;
+    EXPECT_THROW(decoder.read(result), MessageDecodeError);
+}
+
+TEST_F(MessageExchangeTest, MessageDecoderRejectsOversizedStringLength) {
+    ConnectSockets();
+
+    const auto absurd = MAX_STRING_BYTES + 1;
+    std::array<char, sizeof(std::size_t)> buffer{};
+    std::memcpy(buffer.data(), &absurd, sizeof(std::size_t));
+    client_transport_->send(as_bytes_span(buffer));
+
+    MessageDecoder decoder(*server_transport_);
+    std::string result;
+    EXPECT_THROW(decoder.read(result), MessageDecodeError);
 }
 
 TEST_F(MessageExchangeTest, MessageDecoderReadStringContainer) {

--- a/tests/test_raw_data_decode.cpp
+++ b/tests/test_raw_data_decode.cpp
@@ -25,6 +25,7 @@
 
 #include <cstring>
 #include <gtest/gtest.h>
+#include <limits>
 #include <numbers>
 #include <vector>
 
@@ -114,4 +115,144 @@ TEST(RawDataDecodeTest, MakeFloatBufferFromDouble_NegativeValue) {
 
 TEST(RawDataDecodeTest, MakeFloatBufferFromDouble_Zero) {
     TestSingleDoubleValue(0.0);
+}
+
+TEST(RawDataDecodeTest, GeometryFitsPayloadAcceptsExactLowerBound) {
+    // width=4, height=3, channels=2, stride=6 (pixels/row), FLOAT32:
+    // pixels_needed = (height-1)*stride + width = 2*6+4 = 16 pixels,
+    // i.e. 16 * channels(2) * type_size(FLOAT32=4) = 128 bytes.
+    EXPECT_TRUE(geometry_fits_payload(4, 3, 2, 6, BufferType::FLOAT32, 128));
+}
+
+TEST(RawDataDecodeTest, GeometryFitsPayloadRejectsOneByteShortOfLowerBound) {
+    EXPECT_FALSE(geometry_fits_payload(4, 3, 2, 6, BufferType::FLOAT32, 127));
+}
+
+TEST(RawDataDecodeTest, GeometryFitsPayloadAcceptsTrimmedLastRowStridePadding) {
+    // stride(6) > width(4): a fully stride-padded buffer would need
+    // stride*height*channels*type_size = 6*3*2*4 = 144 bytes. The lower
+    // bound (128, from the exact-bound test above) must still be accepted
+    // -- that's what lets a producer omit trailing padding on the last row.
+    EXPECT_TRUE(geometry_fits_payload(4, 3, 2, 6, BufferType::FLOAT32, 128));
+}
+
+TEST(RawDataDecodeTest, GeometryFitsPayloadRejectsNonPositiveWidth) {
+    EXPECT_FALSE(
+        geometry_fits_payload(0, 2, 1, 2, BufferType::UNSIGNED_BYTE, 1000));
+    EXPECT_FALSE(
+        geometry_fits_payload(-1, 2, 1, 2, BufferType::UNSIGNED_BYTE, 1000));
+}
+
+TEST(RawDataDecodeTest, GeometryFitsPayloadRejectsNonPositiveHeight) {
+    EXPECT_FALSE(
+        geometry_fits_payload(2, 0, 1, 2, BufferType::UNSIGNED_BYTE, 1000));
+    EXPECT_FALSE(
+        geometry_fits_payload(2, -1, 1, 2, BufferType::UNSIGNED_BYTE, 1000));
+}
+
+TEST(RawDataDecodeTest, GeometryFitsPayloadRejectsNonPositiveChannels) {
+    EXPECT_FALSE(
+        geometry_fits_payload(2, 2, 0, 2, BufferType::UNSIGNED_BYTE, 1000));
+    EXPECT_FALSE(
+        geometry_fits_payload(2, 2, -1, 2, BufferType::UNSIGNED_BYTE, 1000));
+}
+
+TEST(RawDataDecodeTest, GeometryFitsPayloadRejectsStrideBelowWidth) {
+    EXPECT_FALSE(
+        geometry_fits_payload(4, 2, 1, 3, BufferType::UNSIGNED_BYTE, 1000));
+}
+
+TEST(RawDataDecodeTest, GeometryFitsPayloadAcceptsStrideEqualToWidth) {
+    // stride == width is the tightest legal packing (no row padding at all).
+    EXPECT_TRUE(
+        geometry_fits_payload(4, 2, 1, 4, BufferType::UNSIGNED_BYTE, 8));
+}
+
+TEST(RawDataDecodeTest, GeometryFitsPayloadUsesWireByteCountForFloat64) {
+    // FLOAT64 wire elements are 8 bytes; make_buffer_record() later halves
+    // this to float32, but the check must validate the wire size against
+    // type_size(FLOAT64), not the post-narrowing size, so it agrees with
+    // what the renderer (which reads the narrowed buffer as float32) needs.
+    EXPECT_TRUE(geometry_fits_payload(2, 2, 1, 2, BufferType::FLOAT64, 32));
+    EXPECT_FALSE(geometry_fits_payload(2, 2, 1, 2, BufferType::FLOAT64, 31));
+}
+
+TEST(RawDataDecodeTest, GeometryFitsPayloadDoesNotOverflowOnHostileGeometry) {
+    // pixels_needed * element_size overflows 64 bits if computed by direct
+    // multiplication; the division-based check must still correctly reject
+    // a payload nowhere near large enough, rather than wrapping around to a
+    // deceptively small (and thus falsely satisfied) requirement.
+    constexpr int width = 1000000;
+    constexpr int height = 1000000;
+    constexpr int stride = 1000000000;
+    constexpr int channels = 1000000000;
+    EXPECT_FALSE(geometry_fits_payload(
+        width, height, channels, stride, BufferType::FLOAT64, 0));
+    EXPECT_FALSE(geometry_fits_payload(
+        width, height, channels, stride, BufferType::FLOAT64, 1000000));
+}
+
+TEST(RawDataDecodeTest,
+     PaddedPayloadSizeReturnsExactByteCountForKnownGeometry) {
+    // width=4, height=3, channels=2, stride=6, FLOAT32:
+    // stride*height*channels*type_size = 6*3*2*4 = 144 bytes.
+    const auto size = padded_payload_size(4, 3, 2, 6, BufferType::FLOAT32);
+    ASSERT_TRUE(size.has_value());
+    EXPECT_EQ(*size, 144u);
+}
+
+TEST(RawDataDecodeTest, PaddedPayloadSizeRejectsNonPositiveWidth) {
+    EXPECT_FALSE(
+        padded_payload_size(0, 2, 1, 2, BufferType::UNSIGNED_BYTE).has_value());
+    EXPECT_FALSE(padded_payload_size(-1, 2, 1, 2, BufferType::UNSIGNED_BYTE)
+                     .has_value());
+}
+
+TEST(RawDataDecodeTest, PaddedPayloadSizeRejectsNonPositiveHeight) {
+    EXPECT_FALSE(
+        padded_payload_size(2, 0, 1, 2, BufferType::UNSIGNED_BYTE).has_value());
+    EXPECT_FALSE(padded_payload_size(2, -1, 1, 2, BufferType::UNSIGNED_BYTE)
+                     .has_value());
+}
+
+TEST(RawDataDecodeTest, PaddedPayloadSizeRejectsNonPositiveChannels) {
+    EXPECT_FALSE(
+        padded_payload_size(2, 2, 0, 2, BufferType::UNSIGNED_BYTE).has_value());
+    EXPECT_FALSE(padded_payload_size(2, 2, -1, 2, BufferType::UNSIGNED_BYTE)
+                     .has_value());
+}
+
+TEST(RawDataDecodeTest, PaddedPayloadSizeRejectsStrideBelowWidth) {
+    EXPECT_FALSE(
+        padded_payload_size(4, 2, 1, 3, BufferType::UNSIGNED_BYTE).has_value());
+}
+
+TEST(RawDataDecodeTest, PaddedPayloadSizeDoesNotOverflowOnHostileGeometry) {
+    // stride*height*channels*type_size overflows 64 bits if computed by
+    // direct multiplication; each factor must be checked before it is
+    // applied, rather than wrapping around to a deceptively small value.
+    constexpr int width = 1000000;
+    constexpr int height = 1000000;
+    constexpr int stride = 1000000000;
+    constexpr int channels = 1000000000;
+    EXPECT_FALSE(padded_payload_size(
+                     width, height, channels, stride, BufferType::FLOAT64)
+                     .has_value());
+}
+
+TEST(RawDataDecodeTest, PaddedPayloadSizeChecksTheFinalFactorToo) {
+    // The case above trips the guard on `channels`, leaving the last factor
+    // unexercised. Here stride*height*channels fits comfortably and only
+    // multiplying by sizeof(double) overflows, so a regression that applied
+    // the element size unchecked would return a wrapped size instead of
+    // nullopt.
+    constexpr int max_int = std::numeric_limits<int>::max();
+    EXPECT_FALSE(
+        padded_payload_size(1, max_int, 1, max_int, BufferType::FLOAT64)
+            .has_value());
+    // Same geometry at one byte per element is representable, so the
+    // rejection above is the overflow guard and not the geometry itself.
+    EXPECT_TRUE(
+        padded_payload_size(1, max_int, 1, max_int, BufferType::UNSIGNED_BYTE)
+            .has_value());
 }

--- a/tests/test_raw_data_decode.cpp
+++ b/tests/test_raw_data_decode.cpp
@@ -268,7 +268,7 @@ TEST(RawDataDecodeTest, PaddedPayloadSizeChecksTheFinalFactorToo) {
     // multiplying by sizeof(double) overflows, so a regression that applied
     // the element size unchecked would return a wrapped size instead of
     // nullopt.
-    constexpr int max_int = std::numeric_limits<int>::max();
+    constexpr int max_int = (std::numeric_limits<int>::max)();
     EXPECT_FALSE(
         padded_payload_size(1, max_int, 1, max_int, BufferType::FLOAT64)
             .has_value());

--- a/tests/test_raw_data_decode.cpp
+++ b/tests/test_raw_data_decode.cpp
@@ -192,6 +192,28 @@ TEST(RawDataDecodeTest, GeometryFitsPayloadDoesNotOverflowOnHostileGeometry) {
         width, height, channels, stride, BufferType::FLOAT64, 1000000));
 }
 
+TEST(RawDataDecodeTest, WithinDisplayLimitsAcceptsBoundaryValues) {
+    EXPECT_TRUE(within_display_limits(
+        MIN_BUFFER_DIMENSION, MIN_BUFFER_DIMENSION, MIN_CHANNEL_COUNT));
+    EXPECT_TRUE(within_display_limits(
+        MAX_BUFFER_DIMENSION, MAX_BUFFER_DIMENSION, MAX_CHANNEL_COUNT));
+}
+
+TEST(RawDataDecodeTest, WithinDisplayLimitsRejectsOnePastEachBound) {
+    EXPECT_FALSE(within_display_limits(
+        MIN_BUFFER_DIMENSION - 1, MIN_BUFFER_DIMENSION, MIN_CHANNEL_COUNT));
+    EXPECT_FALSE(within_display_limits(
+        MIN_BUFFER_DIMENSION, MIN_BUFFER_DIMENSION - 1, MIN_CHANNEL_COUNT));
+    EXPECT_FALSE(within_display_limits(
+        MIN_BUFFER_DIMENSION, MIN_BUFFER_DIMENSION, MIN_CHANNEL_COUNT - 1));
+    EXPECT_FALSE(within_display_limits(
+        MAX_BUFFER_DIMENSION + 1, MAX_BUFFER_DIMENSION, MAX_CHANNEL_COUNT));
+    EXPECT_FALSE(within_display_limits(
+        MAX_BUFFER_DIMENSION, MAX_BUFFER_DIMENSION + 1, MAX_CHANNEL_COUNT));
+    EXPECT_FALSE(within_display_limits(
+        MAX_BUFFER_DIMENSION, MAX_BUFFER_DIMENSION, MAX_CHANNEL_COUNT + 1));
+}
+
 TEST(RawDataDecodeTest,
      PaddedPayloadSizeReturnsExactByteCountForKnownGeometry) {
     // width=4, height=3, channels=2, stride=6, FLOAT32:


### PR DESCRIPTION
## What was wrong

Buffers over 8 MiB are sent to the viewer in pieces. The pieces were measured in the wrong unit, so any buffer with more than one channel, or with elements wider than a byte, arrived incomplete — a 1024×1025 `float64` buffer delivered an eighth of itself.

Nothing reported it. The rows that never arrived rendered as zeros, which looks like data rather than like a failure. Buffers of `double` cross that threshold at ordinary image sizes, so this was easy to hit.

Looking at the surrounding code turned up more of the same shape: a transfer could also be accepted while incomplete, or while describing a picture its bytes could not fill. Some of those shapes sent the viewer reading past the end of the buffer while drawing pixel values.

## What changed

Large buffers transfer correctly.

Beyond that, a transfer is refused when it is malformed, incomplete, or describes a shape its data cannot back — including a buffer type the protocol doesn't define, a size larger than the viewer accepts, and dimensions beyond what it can display. Each refusal writes its reason to stderr, naming the byte counts where they disagree, instead of drawing a plausible-looking wrong image or failing silently.

## Worth knowing

A split transfer must now carry every row at its full stride. A sender that trims the padding from the final row will be refused rather than displayed. Single-message transfers are unaffected — they only need enough bytes to cover the picture.

## Fixture

`testbench/realtypes.cpp` gains `mat_chunked_64f`, at 8,396,800 bytes the first fixture that crosses the 8 MiB budget, so the split-transfer path can be exercised end to end. It has been plotted live and reassembles exactly: the values ramp with the row, so a dropped tail would show as a flat band rather than as plausible data.
