### PR TITLE
test: add a fixture sitting exactly on the per-message budget

### DIFF
--- a/testbench/.vscode/launch.json
+++ b/testbench/.vscode/launch.json
@@ -12,7 +12,8 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "(CodeLLDB) Launch testbench (no build)",
+            "name": "(CodeLLDB) Launch testbench",
+            "preLaunchTask": "build testbench",
             "type": "lldb",
             "request": "launch",
             "program": "${workspaceFolder}/build/testbench",
@@ -29,10 +30,10 @@
             // The real-library fixture: one live instance of every built-in
             // buffer type (cv::Mat, CvMat, IplImage, and five Eigen variants)
             // against the actual OpenCV and Eigen headers, for plotting by
-            // hand. Build it first -- it is a separate target, and CMake only
-            // offers it when both libraries are found:
-            //     cmake --build build --target testbench_realtypes
-            "name": "(CodeLLDB) Launch realtypes fixture (no build)",
+            // hand. The pre-launch task builds it; CMake only offers the
+            // target when both libraries are found.
+            "name": "(CodeLLDB) Launch realtypes fixture",
+            "preLaunchTask": "build realtypes fixture",
             "type": "lldb",
             "request": "launch",
             "program": "${workspaceFolder}/build/testbench_realtypes",

--- a/testbench/.vscode/tasks.json
+++ b/testbench/.vscode/tasks.json
@@ -1,0 +1,34 @@
+{
+    // Pre-launch builds for the debug configs in launch.json. Both configure
+    // first: `cmake -B build` is a cheap no-op once the cache exists, and it
+    // means F5 works from a fresh checkout instead of failing on a missing
+    // build directory.
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build realtypes fixture",
+            "type": "shell",
+            "command": "cmake -S . -B build && cmake --build build --target testbench_realtypes",
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": "$gcc",
+            "group": "build",
+            "detail": "Configure if needed, then build testbench_realtypes. CMake only offers this target when OpenCV and Eigen are both found."
+        },
+        {
+            "label": "build testbench",
+            "type": "shell",
+            "command": "cmake -S . -B build && cmake --build build --target testbench",
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": "$gcc",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "detail": "Configure if needed, then build the dependency-free testbench."
+        }
+    ]
+}

--- a/testbench/realtypes.cpp
+++ b/testbench/realtypes.cpp
@@ -12,9 +12,10 @@
  *     type NAME and reads members by name, so faithful local structs with the
  *     same member names and legacy constant values exercise those two entries
  *     exactly as the real types would.
- *   - One deliberately oversized cv::Mat crosses the viewer's 8 MiB
- *     per-message budget, so plotting it exercises the chunked transfer path
- *     that every other fixture here is too small to reach.
+ *   - Two deliberately large cv::Mats sit either side of the viewer's 8 MiB
+ *     per-message budget: one just over it, to exercise the chunked transfer
+ *     path every other fixture here is too small to reach, and one exactly on
+ *     it, which must still cross as a single message.
  *
  * This target is built only when OpenCV and Eigen are found (see CMakeLists).
  * Set a breakpoint on the marked line in main(), run under a debugger with OID
@@ -126,6 +127,23 @@ cv::Mat make_mat_chunked_64f() {
     return m;
 }
 
+// The other side of the same boundary: 1024 rows x 1024 float64 is 8,388,608
+// bytes, which is the per-message budget exactly. The sender's test is
+// "payload <= budget", so this must still cross as a single message while the
+// fixture above, one row larger, must not. It is also an exact multiple of the
+// page size the extension reads memory in, so nothing here is a remainder --
+// the case where an off-by-one leaves a page unread or requests an empty one.
+cv::Mat make_mat_budget_edge_64f() {
+    cv::Mat m(kBigW, kBigW, CV_64FC1);
+    for (int y = 0; y < m.rows; ++y) {
+        for (int x = 0; x < m.cols; ++x) {
+            m.at<double>(y, x) =
+                static_cast<double>(x) + static_cast<double>(y) / kBigW;
+        }
+    }
+    return m;
+}
+
 } // namespace
 
 int main() {
@@ -133,6 +151,7 @@ int main() {
     cv::Mat mat_8uc3 = make_mat_8uc3();
     cv::Mat mat_32fc1 = make_mat_32fc1();
     cv::Mat mat_chunked_64f = make_mat_chunked_64f();
+    cv::Mat mat_budget_edge_64f = make_mat_budget_edge_64f();
 
     // --- CvMat (legacy struct), single-channel 8-bit ---
     std::vector<unsigned char> cvmat_backing(static_cast<std::size_t>(kW) * kH);


### PR DESCRIPTION
## Why

Buffers over 8 MiB are sent to the viewer in pieces; at or below that they cross as a single message. `mat_chunked_64f` sits one row over the threshold and proves the split path works, but nothing sat *on* it.

The test is "split when the payload exceeds the budget", so a buffer of exactly 8,388,608 bytes must still cross whole. An off-by-one there would quietly start splitting every 8 MiB buffer, with no fixture to notice.

## What

`mat_budget_edge_64f` — 1024×1024 float64, exactly 8,388,608 bytes. Together with the existing fixture one row larger, the pair brackets the boundary from both sides. Its values ramp along the other axis, so the two are easy to tell apart on screen.

It is also an exact multiple of the page size the VS Code extension reads memory in, so it covers reads that end on a page boundary rather than part-way through one.

## Also

The testbench debug configs now build their target before launching, instead of a comment asking the reader to run CMake by hand — which made it easy to debug a stale binary after editing a fixture. Both configure first, so they work from a fresh checkout.
