### PR TITLE
fix(viewer): refuse a buffer too small for the geometry it declares

### DIFF
--- a/src/visualization/buffer_span_fits.h
+++ b/src/visualization/buffer_span_fits.h
@@ -1,0 +1,98 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef VISUALIZATION_BUFFER_SPAN_FITS_H_
+#define VISUALIZATION_BUFFER_SPAN_FITS_H_
+
+#include <cstddef>
+
+#include "ipc/raw_data_decode.h"
+
+// Deliberately free of GL and canvas headers so the rule can be unit tested
+// without a GL context.
+
+namespace oid {
+
+// Bytes one element occupies *as the renderer reads it*, which is not always
+// what type_size() reports. make_buffer_record() narrows a FLOAT64 payload to
+// float32 while leaving the record's type tagged FLOAT64, and both the texture
+// upload and the pixel-value overlay then read it back as float. Sizing a
+// FLOAT64 record at type_size()'s eight bytes would reject every valid one.
+[[nodiscard]] constexpr std::size_t
+display_element_size(const BufferType type) noexcept {
+    using enum BufferType;
+    switch (type) {
+    case SHORT:
+        [[fallthrough]];
+    case UNSIGNED_SHORT:
+        return sizeof(short);
+    case INT32:
+        [[fallthrough]];
+    case FLOAT32:
+        [[fallthrough]];
+    case FLOAT64:
+        return sizeof(float);
+    case UNSIGNED_BYTE:
+        [[fallthrough]];
+    default:
+        return sizeof(unsigned char);
+    }
+}
+
+// True if `byte_count` bytes can hold every pixel this geometry addresses.
+//
+// Drawing indexes the buffer as (y * step + x) * channels + c, so the last
+// element it can touch is at ((height - 1) * step + width) * channels - 1.
+// Nothing on the drawing path bounds that against the span it was given, so a
+// buffer describing more pixels than it carries reads past the end of its
+// allocation. The wire layer refuses such a buffer on the way in, but a buffer
+// can also arrive from a file, and this is the layer that every source shares.
+//
+// The last row needs only `width` pixels rather than the full `step`, so a
+// producer that trims trailing row padding is still accepted.
+[[nodiscard]] constexpr bool buffer_span_fits(const int width,
+                                              const int height,
+                                              const int channels,
+                                              const int step,
+                                              const std::size_t element_size,
+                                              const std::size_t byte_count) {
+    if (width <= 0 || height <= 0 || channels <= 0 || step < width ||
+        element_size == 0) {
+        return false;
+    }
+    const auto elements_per_pixel = static_cast<std::size_t>(channels);
+    // Divided rather than multiplied: the equivalent product overflows for
+    // hostile geometry, the quotient cannot.
+    const auto affordable_pixels =
+        byte_count / (elements_per_pixel * element_size);
+    const auto addressed_pixels = (static_cast<std::size_t>(height) - 1) *
+                                      static_cast<std::size_t>(step) +
+                                  static_cast<std::size_t>(width);
+    return affordable_pixels >= addressed_pixels;
+}
+
+} // namespace oid
+
+#endif // VISUALIZATION_BUFFER_SPAN_FITS_H_

--- a/src/visualization/buffer_span_fits.h
+++ b/src/visualization/buffer_span_fits.h
@@ -27,6 +27,7 @@
 #define VISUALIZATION_BUFFER_SPAN_FITS_H_
 
 #include <cstddef>
+#include <cstdint>
 
 #include "ipc/raw_data_decode.h"
 
@@ -82,14 +83,18 @@ display_element_size(const BufferType type) noexcept {
         element_size == 0) {
         return false;
     }
-    const auto elements_per_pixel = static_cast<std::size_t>(channels);
-    // Divided rather than multiplied: the equivalent product overflows for
-    // hostile geometry, the quotient cannot.
+    // Widened to 64 bits deliberately, not left as size_t: on the 32-bit wasm
+    // build (height - 1) * step wraps for large-but-legal ints, which would
+    // make an undersized buffer look like it fits and defeat the whole check.
+    // Every input is an int or a size_t, so at 64 bits nothing here can
+    // overflow: the largest product is below 2^62.
+    const auto bytes_per_pixel = static_cast<std::uint64_t>(channels) *
+                                 static_cast<std::uint64_t>(element_size);
     const auto affordable_pixels =
-        byte_count / (elements_per_pixel * element_size);
-    const auto addressed_pixels = (static_cast<std::size_t>(height) - 1) *
-                                      static_cast<std::size_t>(step) +
-                                  static_cast<std::size_t>(width);
+        static_cast<std::uint64_t>(byte_count) / bytes_per_pixel;
+    const auto addressed_pixels = (static_cast<std::uint64_t>(height) - 1) *
+                                      static_cast<std::uint64_t>(step) +
+                                  static_cast<std::uint64_t>(width);
     return affordable_pixels >= addressed_pixels;
 }
 

--- a/src/visualization/components/buffer.cpp
+++ b/src/visualization/components/buffer.cpp
@@ -37,6 +37,7 @@
 #include "camera.h"
 #include "math/linear_algebra.h"
 #include "platform/gl_dialect.h"
+#include "visualization/buffer_span_fits.h"
 #include "visualization/game_object.h"
 #include "visualization/shader_pixel_layout.h"
 #include "visualization/shaders/oid_shaders.h"
@@ -399,6 +400,28 @@ void Buffer::configure(const BufferParams& params) {
         buffer_size > MAX_BUFFER_BYTES) {
         std::cerr << "[Error] Buffer size too large: " << buffer_size
                   << " bytes (maximum: " << MAX_BUFFER_BYTES << " bytes)"
+                  << std::endl;
+        return;
+    }
+
+    // The ceiling above bounds how much memory a buffer may claim; this bounds
+    // how little. Drawing indexes as (y * step + x) * channels and nothing on
+    // that path checks the span, so a buffer describing more pixels than it
+    // carries reads off the end. The wire layer refuses such a buffer on the
+    // way in, but one can also arrive from a file, and this is the layer they
+    // share.
+    if (const auto element_size = display_element_size(params.type);
+        !buffer_span_fits(params.buffer_width_i,
+                          params.buffer_height_i,
+                          params.channels,
+                          params.step,
+                          element_size,
+                          params.buffer.size())) {
+        std::cerr << "[Error] Buffer too small for its geometry: "
+                  << params.buffer.size() << " bytes cannot hold "
+                  << params.buffer_width_i << "x" << params.buffer_height_i
+                  << "x" << params.channels << " at step " << params.step
+                  << " and " << element_size << " bytes per element"
                   << std::endl;
         return;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -682,6 +682,25 @@ if(OID_BUILD_IMGUI_FRONTEND)
 
     add_test(NAME ShaderPixelLayoutTests COMMAND shader_pixel_layout_test)
 
+    # Whether a buffer's bytes can hold every pixel its geometry addresses,
+    # and how wide an element is once the renderer has it. Same shape as the
+    # rule above: header-only, no GL context needed.
+    add_executable(buffer_span_fits_test
+        visualization/buffer_span_fits_test.cpp
+    )
+
+    target_include_directories(buffer_span_fits_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    )
+
+    target_link_libraries(buffer_span_fits_test
+        PRIVATE
+        GTest::gtest_main
+        GTest::gtest
+    )
+
+    add_test(NAME BufferSpanFitsTests COMMAND buffer_span_fits_test)
+
     # Test stb_glyph_atlas() out of host/text/stb_glyph_atlas.cpp: bakes
     # oid::GLYPH_TEXT from the embedded Roboto-Regular font (stb_truetype)
     # through the same finalize_strip_atlas() pipeline glyph_atlas_test above

--- a/tests/visualization/buffer_span_fits_test.cpp
+++ b/tests/visualization/buffer_span_fits_test.cpp
@@ -23,6 +23,7 @@
  * IN THE SOFTWARE.
  */
 
+#include <cstdint>
 #include <limits>
 
 #include <gtest/gtest.h>
@@ -81,6 +82,22 @@ TEST(BufferSpanFits, RejectsTheHugeStepUnderRead) {
 TEST(BufferSpanFits, DoesNotOverflowOnHostileGeometry) {
     constexpr int huge = (std::numeric_limits<int>::max)();
     EXPECT_FALSE(buffer_span_fits(huge, huge, 4, huge, sizeof(float), 1024));
+}
+
+// Guards the 32-bit build specifically. (height - 1) * step here is exactly
+// 2^32, which wraps to zero in a 32-bit size_t and would make these four bytes
+// look sufficient for the whole geometry. The arithmetic is done in 64 bits so
+// the real requirement survives; this assertion is trivially true on a 64-bit
+// host and is the only thing standing behind wasm, where it is not.
+TEST(BufferSpanFits, DoesNotWrapWhereSizeTIsThirtyTwoBits) {
+    constexpr int step = 65536;
+    constexpr int height = 65537; // (height - 1) * step == 2^32
+    EXPECT_FALSE(buffer_span_fits(4, height, 1, step, 1, 4));
+    // The same geometry with genuinely sufficient bytes is still accepted, so
+    // the rejection above is the bound and not a blanket refusal.
+    constexpr std::uint64_t needed =
+        (static_cast<std::uint64_t>(height) - 1) * step + 4;
+    EXPECT_TRUE(buffer_span_fits(4, height, 1, step, 1, needed));
 }
 
 // A float64 buffer sized as the renderer sees it (four bytes per element) is

--- a/tests/visualization/buffer_span_fits_test.cpp
+++ b/tests/visualization/buffer_span_fits_test.cpp
@@ -1,0 +1,107 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "visualization/buffer_span_fits.h"
+
+using namespace oid;
+
+// A FLOAT64 record carries float32 bytes by the time it reaches the renderer:
+// make_buffer_record() narrows it and leaves the type tag alone. Sizing it at
+// type_size()'s eight bytes would reject every valid float64 buffer.
+TEST(DisplayElementSize, Float64IsFourBytesOnceNarrowed) {
+    EXPECT_EQ(display_element_size(BufferType::FLOAT64), sizeof(float));
+    EXPECT_EQ(display_element_size(BufferType::FLOAT32), sizeof(float));
+    EXPECT_EQ(display_element_size(BufferType::INT32), sizeof(float));
+    EXPECT_EQ(display_element_size(BufferType::SHORT), sizeof(short));
+    EXPECT_EQ(display_element_size(BufferType::UNSIGNED_SHORT), sizeof(short));
+    EXPECT_EQ(display_element_size(BufferType::UNSIGNED_BYTE), 1u);
+}
+
+TEST(BufferSpanFits, AcceptsAnExactlySizedPackedBuffer) {
+    // 4x2 rgb8, no padding: 4*2*3 = 24 bytes.
+    EXPECT_TRUE(buffer_span_fits(4, 2, 3, 4, 1, 24));
+}
+
+TEST(BufferSpanFits, RejectsOneByteShort) {
+    EXPECT_FALSE(buffer_span_fits(4, 2, 3, 4, 1, 23));
+}
+
+// The bound the renderer actually needs: the final row is only indexed out to
+// `width`, so trailing row padding on it need not be present.
+TEST(BufferSpanFits, AcceptsATrimmedFinalRow) {
+    // width 3, step 5, height 2, 1 channel: last addressed pixel is
+    // (1*5 + 3) = 8 pixels, so 8 bytes suffice even though a fully padded
+    // buffer would be 10.
+    EXPECT_TRUE(buffer_span_fits(3, 2, 1, 5, 1, 8));
+    EXPECT_FALSE(buffer_span_fits(3, 2, 1, 5, 1, 7));
+}
+
+TEST(BufferSpanFits, RejectsNonsenseGeometry) {
+    EXPECT_FALSE(buffer_span_fits(0, 2, 1, 4, 1, 1024));
+    EXPECT_FALSE(buffer_span_fits(4, 0, 1, 4, 1, 1024));
+    EXPECT_FALSE(buffer_span_fits(4, 2, 0, 4, 1, 1024));
+    EXPECT_FALSE(buffer_span_fits(4, 2, 1, 3, 1, 1024)); // step < width
+    EXPECT_FALSE(buffer_span_fits(4, 2, 1, 4, 0, 1024)); // zero element size
+}
+
+// The out-of-bounds read this guard exists to stop: a buffer claiming a huge
+// step but carrying only a row's worth of bytes.
+TEST(BufferSpanFits, RejectsTheHugeStepUnderRead) {
+    EXPECT_FALSE(buffer_span_fits(4, 2, 1, 100000, sizeof(float), 16));
+}
+
+// Hostile geometry whose byte requirement overflows a 64-bit product must be
+// refused rather than wrapping to a small number and being accepted.
+TEST(BufferSpanFits, DoesNotOverflowOnHostileGeometry) {
+    constexpr int huge = (std::numeric_limits<int>::max)();
+    EXPECT_FALSE(buffer_span_fits(huge, huge, 4, huge, sizeof(float), 1024));
+}
+
+// A float64 buffer sized as the renderer sees it (four bytes per element) is
+// accepted; sizing it at eight would have refused it.
+TEST(BufferSpanFits, AcceptsAFloat64BufferAtItsNarrowedSize) {
+    constexpr int width = 1024;
+    constexpr int height = 1025;
+    constexpr auto elem = display_element_size(BufferType::FLOAT64);
+    EXPECT_EQ(elem, 4u);
+    EXPECT_TRUE(
+        buffer_span_fits(width,
+                         height,
+                         1,
+                         width,
+                         elem,
+                         static_cast<std::size_t>(width) * height * elem));
+    EXPECT_FALSE(
+        buffer_span_fits(width,
+                         height,
+                         1,
+                         width,
+                         elem,
+                         static_cast<std::size_t>(width) * height * elem - 1));
+}


### PR DESCRIPTION
## Why

Drawing a buffer indexes it as `(y * step + x) * channels`, and nothing on that path checks the result against the memory it was given. A buffer that describes more pixels than it carries therefore reads past the end of its allocation while drawing pixel values.

`configure()` already refused a buffer that claims *too much* memory. This bounds the other side: too little for the picture it describes.

## Where the check belongs

At the render layer, because that is the one every source funnels through — messages from the debugger, and buffers loaded from a file. Placing it here means a new source cannot bypass it.

To be clear about what it is worth today: the message paths already validate geometry against the payload, and the `.npy` loader already refuses a file whose data section disagrees with its declared dimensions. **No producer shipping today can reach this guard.** It is defence in depth, not a fix for a reachable hole.

## Two details that are easy to get wrong

**An element is not always the size its type says.** A float64 buffer is narrowed to float32 on the way in while keeping its float64 tag, and the renderer reads it back as float. Sizing one at eight bytes per element would reject every valid float64 buffer by a factor of two.

**The final row needs only `width` pixels**, not the full row stride, so a buffer that trims its trailing padding is still accepted. The comparison divides rather than multiplies, because the equivalent product overflows for hostile geometry.

## Testing

The rule is a header free of GL types, so it is unit tested directly: exact fits, one byte short, trimmed final rows, nonsense geometry, overflow, and the float64 sizing. All 13 fixtures in `testbench/realtypes.cpp` were also plotted in a live debug session — none is refused, including the strided Eigen map whose final row is trimmed.
