### PR TITLE
feat: catch mistakes in a custom types file instead of failing silently

### DIFF
--- a/doc/declarative-types.md
+++ b/doc/declarative-types.md
@@ -47,6 +47,19 @@ Entries are matched in precedence order and the **first match wins**:
 So a workspace entry overrides everything, and the built-ins come last. Loading
 happens once per debug session; edits take effect the next session.
 
+### Validation while you edit
+
+Point your file at the schema and any JSON-aware editor will check it as you
+type — a wrong `version`, a missing required field, a misspelled key:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/OpenImageDebugger/OpenImageDebugger/main/resources/schemas/oid-types-v1.json",
+  "version": 1,
+  "types": []
+}
+```
+
 ## File shape
 
 ```json
@@ -61,10 +74,11 @@ happens once per debug session; edits take effect the next session.
 - `version` — required; the v1 loader accepts exactly `1` and skips any other
   file with a warning.
 - `types` — array of entries; array order is precedence order within the file.
-- Unknown keys at the document and entry level are ignored (forward
-  compatibility). Keys inside a value-node object (`if`/`then`/`else`,
-  `first_valid`, `expr`/`map`) are not — an unrecognized one is rejected as
-  a typo.
+- Unknown keys at the document level are tolerated (forward compatibility),
+  so a file written for a future OID still loads. An unknown key inside an
+  entry is not tolerated — see "Error handling" below. Keys inside a
+  value-node object (`if`/`then`/`else`, `first_valid`, `expr`/`map`) are
+  rejected too, as a typo.
 
 ## Entry fields
 
@@ -81,6 +95,7 @@ happens once per debug session; edits take effect the next session.
 | `display_name` | `"{name} ({type})"` | template string; placeholders `{name}` (variable name), `{type}` (type string), `{targ:…}`; not debugger-evaluated |
 | `language` | `"cpp"` | expression dialect; entries a backend can't evaluate are skipped |
 | `name` | the `match` pattern | identifier used in error messages and the conformance tool |
+| `description` | none — absent when unset | free text about the entry; never evaluated, never displayed. JSON has no comments, so this is where an expression gets explained |
 
 ## Value grammar
 
@@ -146,6 +161,12 @@ the entry, while the rest of the file still loads. At plot time, an evaluation
 failure (bad expression, exhausted `first_valid`, invalid/unmapped dtype, null
 pointer) is reported with the entry name, the field, and the **substituted**
 expression text.
+
+An entry carrying a key that is not in the field list above is **skipped**,
+with a warning naming the offending key. This is deliberate: a misspelled
+field name is not applied, so the entry would otherwise run with a default
+silently substituted for the value its author intended. Use `description` for
+notes — JSON has no comment syntax.
 
 ## Migrating a Python inspector
 

--- a/resources/oidmcp/tests/e2e/check_session.py
+++ b/resources/oidmcp/tests/e2e/check_session.py
@@ -57,8 +57,62 @@ def check_debugger() -> int:
         print('FAIL: unexpected values')
         return 1
 
+    status = check_custom_type(client, symbols)
     client.close()
+    if status:
+        return status
     print('PASS')
+    return 0
+
+
+def check_custom_type(client, symbols) -> int:
+    """
+    Resolve the fixture's RgbFrame, which no builtin entry matches.
+
+    Reaching it at all proves the engine loaded custom_types.json from
+    OID_TYPES_PATH; reading the right pixels out of it proves the JSON's
+    field expressions were evaluated against the real debugger rather than
+    guessed. row_stride carries the weight here: the fixture pads every row
+    to 60 bytes (20 pixels) against a 16-pixel width, so a stride the engine
+    computed as the width would still return a correct row 0 and garbage
+    afterwards.
+    """
+    if 'frame' not in symbols:
+        print('FAIL: frame not observable -- custom_types.json did not load')
+        return 1
+
+    meta, raw = client.get_buffer('frame')
+    print(f'custom type meta: {meta}')
+    if int(meta['row_stride']) != 20:
+        print(f"FAIL: row_stride {meta['row_stride']}, expected 20 pixels "
+              '(60 bytes / 3 channels / 1 byte)')
+        return 1
+
+    arr = decode_buffer(meta, raw)
+    print(f'custom buffer: shape={arr.shape} dtype={arr.dtype}')
+    if arr.shape != (8, 16, 3) or arr.dtype != np.uint8:
+        print('FAIL: unexpected shape or dtype for the custom type')
+        return 1
+
+    rows, cols = np.mgrid[0:8, 0:16]
+    expected = np.stack([(cols * 16) & 0xff,
+                         (rows * 32) & 0xff,
+                         ((rows + cols) * 8) & 0xff],
+                        axis=-1).astype(np.uint8)
+    if not np.array_equal(arr, expected):
+        # The last row is the one a wrong stride corrupts, so name it.
+        print('FAIL: custom buffer pixels differ; '
+              f'row 0 ok={np.array_equal(arr[0], expected[0])} '
+              f'row 7 ok={np.array_equal(arr[7], expected[7])}')
+        return 1
+
+    # Padding must never reach the caller: 0xff anywhere means whole rows
+    # were taken from the gaps rather than de-strided past them.
+    if (arr == 0xff).all(axis=2).any():
+        print('FAIL: saturated pixel found -- padding leaked into the buffer')
+        return 1
+
+    print('custom type: PASS')
     return 0
 
 

--- a/resources/oidmcp/tests/e2e/custom_types.json
+++ b/resources/oidmcp/tests/e2e/custom_types.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenImageDebugger/OpenImageDebugger/main/resources/schemas/oid-types-v1.json",
+  "version": 1,
+  "types": [
+    {
+      "name": "RgbFrame",
+      "match": "^(?:const\\s+)?RgbFrame(?:\\s*[*&])?$",
+      "pointer": "{sym}.pixels",
+      "width": "{sym}.cols",
+      "height": "{sym}.rows",
+      "channels": "{sym}.channel_count",
+      "dtype": "uint8",
+      "row_stride": "{sym}.stride_bytes / {channels} / {elemsize}",
+      "pixel_layout": "rgba"
+    }
+  ]
+}

--- a/resources/oidmcp/tests/e2e/fixture.cpp
+++ b/resources/oidmcp/tests/e2e/fixture.cpp
@@ -1,11 +1,49 @@
 #include <Eigen/Dense>
+#include <array>
+
+// A plain struct no builtin entry matches, so the only thing that can resolve
+// it is the user-supplied custom_types.json this test points OID_TYPES_PATH
+// at. Rows are deliberately padded -- stride_bytes exceeds cols *
+// channel_count -- because a row_stride the engine got wrong still reads row 0
+// correctly and only corrupts the rows after it.
+struct RgbFrame {
+    unsigned char* pixels;
+    int cols;
+    int rows;
+    int channel_count;
+    int stride_bytes;
+};
 
 int main() {
+    constexpr int COLS = 16;
+    constexpr int ROWS = 8;
+    constexpr int CHANNELS = 3;
+    constexpr int STRIDE_BYTES = 60; // 48 bytes of pixels, 12 of padding
+
     Eigen::MatrixXf gradient(8, 16);
     for (int row = 0; row < gradient.rows(); ++row) {
         for (int col = 0; col < gradient.cols(); ++col) {
             gradient(row, col) = static_cast<float>(col) / 15.0f;
         }
     }
-    return static_cast<int>(gradient(0, 15)); // BREAK
+
+    // Local rather than global: the resolver only needs an address that is
+    // live at the breakpoint, and the buffer has to stay writable.
+    std::array<unsigned char, ROWS * STRIDE_BYTES> frame_storage{};
+
+    // Padding is filled first and left saturated, so a stride error surfaces
+    // as 0xff rather than as plausible-looking neighbouring pixels.
+    frame_storage.fill(0xff);
+    for (int row = 0; row < ROWS; ++row) {
+        for (int col = 0; col < COLS; ++col) {
+            unsigned char* pixel =
+                frame_storage.data() + row * STRIDE_BYTES + col * CHANNELS;
+            pixel[0] = static_cast<unsigned char>(col * 16);
+            pixel[1] = static_cast<unsigned char>(row * 32);
+            pixel[2] = static_cast<unsigned char>((row + col) * 8);
+        }
+    }
+    RgbFrame frame{frame_storage.data(), COLS, ROWS, CHANNELS, STRIDE_BYTES};
+
+    return static_cast<int>(gradient(0, 15)) + frame.pixels[0]; // BREAK
 }

--- a/resources/oidmcp/tests/e2e/run_e2e_lldb.sh
+++ b/resources/oidmcp/tests/e2e/run_e2e_lldb.sh
@@ -39,6 +39,11 @@ EOF
 
 export OID_AGENT=1
 export OID_AGENT_DIR="$WORK/agent"
+# Custom-type leg: RgbFrame in the fixture matches no builtin entry, so if the
+# checker resolves it, the only thing that can have resolved it is this file.
+# Set here rather than in the lldb command file because the engine reads it
+# from the environment of the debugger's own interpreter.
+export OID_TYPES_PATH="$HERE/custom_types.json"
 
 # `command script import oid.py` runs its main(), which builds the
 # LldbBridge; that bridge runs queue_request() callbacks on its own

--- a/resources/oidmcp/tests/test_declarative_conformance.py
+++ b/resources/oidmcp/tests/test_declarative_conformance.py
@@ -463,6 +463,14 @@ SCHEMA_REJECTED_FIXTURES = {
     'map_value_non_node_dict':
         _minimal_entry(height={'expr': '{sym}.h',
                                'map': {'8': {'bogus': 1}}}),
+    'entry_unknown_key':
+        _minimal_entry(widht='{sym}.w'),
+    'entry_unknown_key_alongside_valid':
+        _minimal_entry(channels='{sym}.c', bogus=1),
+    'description_not_a_string':
+        _minimal_entry(description=5),
+    'description_is_none':
+        _minimal_entry(description=None),
 }
 
 
@@ -568,3 +576,27 @@ def test_version_one_accepted_by_both(tmp_path):
 
     schema = json.loads(EDITOR_SCHEMA.read_text(encoding='utf-8'))
     jsonschema.validate(document, schema)  # does not raise
+
+
+# --- Unknown entry keys ---------------------------------------------------
+#
+# A typo'd field name used to load silently: the loader ignored the unknown
+# key and the entry ran with a default in place of the field the author
+# meant to set. Both sides now reject it, which keeps the bidirectional
+# contract intact -- tightening only the schema would make a loader-accepted
+# entry schema-invalid.
+
+def test_description_is_a_known_key_on_both_sides():
+    entry = _minimal_entry(description='why the mask is 4088')
+    assert declarative._validate_entry(entry) == []
+
+    schema = json.loads(EDITOR_SCHEMA.read_text(encoding='utf-8'))
+    jsonschema.validate({'version': 1, 'types': [entry]}, schema)
+
+
+def test_known_entry_keys_matches_the_schema_exactly():
+    # The two lists are maintained by hand in different files and different
+    # languages; if they drift, one side accepts what the other rejects.
+    schema = json.loads(EDITOR_SCHEMA.read_text(encoding='utf-8'))
+    schema_keys = set(schema['definitions']['entry']['properties'])
+    assert declarative.KNOWN_ENTRY_KEYS == schema_keys

--- a/resources/oidmcp/tests/test_declarative_discovery.py
+++ b/resources/oidmcp/tests/test_declarative_discovery.py
@@ -187,12 +187,29 @@ def test_entry_recursion_error_skips_entry_rest_of_file_loads(tmp_path,
                if record.levelno == logging.WARNING)
 
 
-def test_unknown_fields_are_ignored(tmp_path):
-    entry = dict(VALID_DOC['types'][0], frobnicate=True)
-    document = {'version': 1, 'types': [entry], 'future_key': {}}
+def test_unknown_document_level_fields_are_ignored(tmp_path):
+    # A document-level key this loader does not recognize (e.g. a future
+    # format addition) must not stop the file from loading. Entry-level
+    # unknown keys are a different matter -- see
+    # test_unknown_entry_key_warns_and_skips_entry below.
+    document = dict(VALID_DOC, future_key={})
     types_file = tmp_path / 'types.json'
     write_doc(types_file, document)
     assert len(declarative._load_types_file(str(types_file))) == 1
+
+
+def test_unknown_entry_key_warns_and_skips_entry(tmp_path, caplog):
+    # A misspelled field name used to load silently, running with a default
+    # in place of the value its author meant to set. The entry is now
+    # skipped with a warning naming the key.
+    caplog.set_level(logging.DEBUG, logger='oidscripts.logger')
+    entry = dict(VALID_DOC['types'][0], frobnicate=True)
+    document = {'version': 1, 'types': [entry]}
+    types_file = tmp_path / 'types.json'
+    write_doc(types_file, document)
+    assert declarative._load_types_file(str(types_file)) == []
+    assert any('frobnicate' in record.message for record in caplog.records
+               if record.levelno == logging.WARNING)
 
 
 def test_env_var_lists_files_in_order(tmp_path, monkeypatch):

--- a/resources/oidscripts/oidtypes/declarative.py
+++ b/resources/oidscripts/oidtypes/declarative.py
@@ -62,6 +62,16 @@ DTYPE_ELEMSIZE = {
 }
 
 REQUIRED_FIELDS = ('match', 'pointer', 'width', 'height', 'dtype')
+# Every key an entry may carry. Kept in lockstep with the `entry` definition
+# in resources/schemas/oid-types-v1.json: an editor validating against that
+# schema and this loader have to agree on what a valid entry looks like, in
+# both directions. `description` is free text, ignored at load time -- JSON
+# has no comments, so it is the only place to explain an expression.
+KNOWN_ENTRY_KEYS = frozenset({
+    'name', 'description', 'match', 'language', 'pointer', 'width',
+    'height', 'channels', 'dtype', 'row_stride', 'pixel_layout',
+    'transpose', 'display_name',
+})
 FIELD_DEFAULTS = {
     'channels': 1,
     'row_stride': '{width}',
@@ -702,6 +712,21 @@ def _validate_display_name(entry):
     return errors
 
 
+def _validate_description(entry):
+    """
+    description is free text with no default: unlike display_name it is
+    optional, so a missing key stays valid and only a present-but-wrong-type
+    value is rejected. isinstance(True, str) is False, so a bool is rejected
+    naturally along with every other non-string JSON shape (int, list,
+    object, null).
+    """
+    if 'description' not in entry:
+        return []
+    if not isinstance(entry['description'], str):
+        return ['description must be a string']
+    return []
+
+
 def _validate_entry(entry):
     """
     Load-time structural validation of one entry. Returns a list of
@@ -717,10 +742,16 @@ def _validate_entry(entry):
     for field in REQUIRED_FIELDS:
         if field not in entry:
             errors.append(f'missing required field "{field}"')
+    unknown = sorted(set(entry) - KNOWN_ENTRY_KEYS)
+    if unknown:
+        errors.append(
+            'unknown key(s) %s; a misspelled field is ignored rather than '
+            'applied, so the entry is skipped' % unknown)
     errors.extend(_validate_match(entry))
     for field in RESOLUTION_ORDER:
         errors.extend(_validate_field(entry, field))
     errors.extend(_validate_display_name(entry))
+    errors.extend(_validate_description(entry))
     return errors
 
 

--- a/resources/schemas/oid-types-v1.json
+++ b/resources/schemas/oid-types-v1.json
@@ -19,9 +19,14 @@
   "definitions": {
     "entry": {
       "type": "object",
+      "additionalProperties": false,
       "required": ["match", "pointer", "width", "height", "dtype"],
       "properties": {
         "name": { "type": "string" },
+        "description": {
+          "type": "string",
+          "description": "Free-text note about this entry. Ignored at load time."
+        },
         "match": { "type": "string" },
         "language": { "type": "string" },
         "pointer": { "$ref": "#/definitions/pointerValueNode" },

--- a/testbench/.oid/types.json
+++ b/testbench/.oid/types.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenImageDebugger/OpenImageDebugger/main/resources/schemas/oid-types-v1.json",
+  "version": 1,
+  "types": [
+    {
+      "name": "PackedGray8",
+      "description": "Five required fields only; everything else defaults.",
+      "match": "^(?:const\\s+)?PackedGray8(?:\\s*[*&])?$",
+      "pointer": "{sym}.data",
+      "width": "{sym}.w",
+      "height": "{sym}.h",
+      "dtype": "uint8"
+    },
+    {
+      "name": "PaddedBgr8",
+      "description": "stride_bytes is in bytes, so it divides down to pixels.",
+      "match": "^(?:const\\s+)?PaddedBgr8(?:\\s*[*&])?$",
+      "pointer": "{sym}.data",
+      "width": "{sym}.w",
+      "height": "{sym}.h",
+      "channels": "{sym}.channels",
+      "dtype": "uint8",
+      "row_stride": "{sym}.stride_bytes / {channels} / {elemsize}",
+      "pixel_layout": "bgra"
+    },
+    {
+      "name": "PackedRgba8",
+      "description": "channels as a literal rather than a field read.",
+      "match": "^(?:const\\s+)?PackedRgba8(?:\\s*[*&])?$",
+      "pointer": "{sym}.data",
+      "width": "{sym}.w",
+      "height": "{sym}.h",
+      "channels": 4,
+      "dtype": "uint8",
+      "pixel_layout": "rgba"
+    },
+    {
+      "name": "DepthF64",
+      "description": "Double precision, single channel.",
+      "match": "^(?:const\\s+)?DepthF64(?:\\s*[*&])?$",
+      "pointer": "{sym}.samples",
+      "width": "{sym}.w",
+      "height": "{sym}.h",
+      "dtype": "float64"
+    }
+  ]
+}

--- a/testbench/realtypes.cpp
+++ b/testbench/realtypes.cpp
@@ -16,6 +16,8 @@
  *     per-message budget: one just over it, to exercise the chunked transfer
  *     path every other fixture here is too small to reach, and one exactly on
  *     it, which must still cross as a single message.
+ *   - Four structs no built-in entry matches, described only by
+ *     testbench/.oid/types.json -- the user-supplied side of the format.
  *
  * This target is built only when OpenCV and Eigen are found (see CMakeLists).
  * Set a breakpoint on the marked line in main(), run under a debugger with OID
@@ -57,6 +59,41 @@ struct CvMat {
 // bit 31; the declarative entry recovers the value with `depth & 0xffffffff`.
 constexpr int IPL_DEPTH_8U = 8;
 constexpr int IPL_DEPTH_16S = static_cast<int>(0x80000010u);
+
+// --- Custom types ----------------------------------------------------------
+// Described only by testbench/.oid/types.json. Global scope for the same
+// reason as the two structs above.
+
+// Five required fields only: channels, row_stride and pixel_layout default.
+struct PackedGray8 {
+    unsigned char* data;
+    int w;
+    int h;
+};
+
+// stride_bytes is in bytes, so the entry divides it down to pixels. Declares
+// bgra, so the blue and red ramps swap if the layout is ignored.
+struct PaddedBgr8 {
+    unsigned char* data;
+    int w;
+    int h;
+    int channels;
+    int stride_bytes;
+};
+
+// Packed with alpha; its entry states channels as a literal 4.
+struct PackedRgba8 {
+    unsigned char* data;
+    int w;
+    int h;
+};
+
+// Double precision, single channel.
+struct DepthF64 {
+    double* samples;
+    int w;
+    int h;
+};
 
 // Reads: .imageData, .width, .height, .nChannels, .depth, .widthStep.
 struct IplImage {
@@ -289,6 +326,69 @@ int main() {
                Eigen::OuterStride<>>
         eig_map_strided(stride_backing.data(), 6, 8, Eigen::OuterStride<>(12));
 
+    // --- Custom types (testbench/.oid/types.json) ---
+    // If these plot, the user-supplied types file was found and evaluated.
+    // If not, the Debug Console names the file or the offending key.
+    constexpr int kCustomW = 64;
+    constexpr int kCustomH = 48;
+
+    // Horizontal ramp.
+    std::vector<unsigned char> gray_backing(static_cast<std::size_t>(kCustomW) *
+                                            kCustomH);
+    for (int y = 0; y < kCustomH; ++y) {
+        for (int x = 0; x < kCustomW; ++x) {
+            gray_backing[static_cast<std::size_t>(y) * kCustomW + x] =
+                static_cast<unsigned char>(x * 4);
+        }
+    }
+    PackedGray8 custom_gray{gray_backing.data(), kCustomW, kCustomH};
+
+    // 192 bytes of pixels per row, padded to 204 (68 whole pixels). Padding
+    // is saturated, so a wrong stride shows as a white band.
+    constexpr int kBgrStrideBytes = 204;
+    std::vector<unsigned char> bgr_backing(
+        static_cast<std::size_t>(kBgrStrideBytes) * kCustomH, 0xff);
+    for (int y = 0; y < kCustomH; ++y) {
+        for (int x = 0; x < kCustomW; ++x) {
+            unsigned char* px = bgr_backing.data() +
+                                static_cast<std::size_t>(y) * kBgrStrideBytes +
+                                x * 3;
+            px[0] = static_cast<unsigned char>(x * 4);       // B
+            px[1] = static_cast<unsigned char>(y * 5);       // G
+            px[2] = static_cast<unsigned char>(255 - x * 4); // R
+        }
+    }
+    PaddedBgr8 custom_bgr{
+        bgr_backing.data(), kCustomW, kCustomH, 3, kBgrStrideBytes};
+
+    // Red rises left to right, green top to bottom.
+    std::vector<unsigned char> rgba_backing(static_cast<std::size_t>(kCustomW) *
+                                            kCustomH * 4);
+    for (int y = 0; y < kCustomH; ++y) {
+        for (int x = 0; x < kCustomW; ++x) {
+            unsigned char* px =
+                rgba_backing.data() +
+                (static_cast<std::size_t>(y) * kCustomW + x) * 4;
+            px[0] = static_cast<unsigned char>(x * 4); // R
+            px[1] = static_cast<unsigned char>(y * 5); // G
+            px[2] = 128;                               // B
+            px[3] = 255;                               // A
+        }
+    }
+    PackedRgba8 custom_rgba{rgba_backing.data(), kCustomW, kCustomH};
+
+    // Metres, ramped so the min/max readout is worth reading.
+    std::vector<double> depth_backing(static_cast<std::size_t>(kCustomW) *
+                                      kCustomH);
+    for (int y = 0; y < kCustomH; ++y) {
+        for (int x = 0; x < kCustomW; ++x) {
+            depth_backing[static_cast<std::size_t>(y) * kCustomW + x] =
+                0.5 + static_cast<double>(x) / 100.0 +
+                static_cast<double>(y) / 1000.0;
+        }
+    }
+    DepthF64 custom_depth{depth_backing.data(), kCustomW, kCustomH};
+
     std::cout << "Fixtures live: mat_8uc3 " << mat_8uc3.cols << "x"
               << mat_8uc3.rows << ", eig_dyn " << eig_dyn.rows() << "x"
               << eig_dyn.cols() << ". Break on the next line and plot each.\n";
@@ -305,6 +405,10 @@ int main() {
     (void)eig_rowmajor;
     (void)eig_map;
     (void)eig_map_strided;
+    (void)custom_gray;
+    (void)custom_bgr;
+    (void)custom_rgba;
+    (void)custom_depth;
 
     return 0;
 }


### PR DESCRIPTION
You can teach OID to display your own image type by describing it in a JSON
file — no Python. Until now, getting that file slightly wrong told you nothing:
the buffer just never appeared, with no error and nothing to go on.

## What changes for users

**A misspelled field is now reported.** Writing `widht` instead of `width` used
to load fine — OID ignored the unknown key and drew the buffer with a default
in place of the value you meant to set, so you got a wrong picture or no
picture, and no clue why. That entry is now skipped with a message naming the
key you got wrong:

```
[OpenImageDebugger] WARNING: Skipping types entry 'MyImage': unknown key(s) ['widht']
```

**Your editor can check the file as you type.** The published schema is now
strict enough to be useful: point your types file at it and a wrong version, a
missing required field or a misspelled key is flagged before you ever start a
debug session.

```json
{
  "$schema": "https://raw.githubusercontent.com/OpenImageDebugger/OpenImageDebugger/main/resources/schemas/oid-types-v1.json",
  "version": 1,
  "types": [ ... ]
}
```

**You can annotate an entry.** A new optional `description` field gives you
somewhere to record why an entry does what it does — JSON has no comments, and
these entries can carry bit masks and regular expressions that are unreadable
six months later:

```json
{
  "description": "OpenCV packs depth in the low 3 bits of flags",
  "match": "^cv::Mat$",
  ...
}
```

A types file written for a newer OID still loads: an unrecognised key at the
top level of the document is tolerated, so only entry fields are strict.

## What this does not change

Nothing about how you write or place a types file, and no existing valid file
stops working. If an entry of yours carries a stray key today, it was already
not doing what you intended — now it says so.

## Confidence

A custom type is now covered end to end: a fixture struct that matches none of
the built-in types, described only by a user-style types file, resolved through
a real debug session and checked pixel by pixel. Its rows are padded so the
row-stride arithmetic has to be right — a wrong stride still produces a correct
first row and corrupts everything after it, which a lighter check would miss.

Verified against a live debugger, not only in unit tests.