### PR TITLE
feat(resolver): serve the JSON resolver under gdb

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -48,6 +48,8 @@ jobs:
       # The oid-mcp test suite is pure Python (it drives the endpoint through
       # in-process fakes), so it needs no debugger or OID build. uv resolves
       # the runtime + dev deps from resources/oidmcp/pyproject.toml.
+      # (test_gdb_live.py skips itself here unless the runner image happens
+      # to ship gdb; the gdb-live job below runs it unconditionally.)
       - name: Run oid-mcp test suite
         shell: bash
         working-directory: resources/oidmcp
@@ -55,3 +57,38 @@ jobs:
           export PATH="$HOME/.local/bin:$PATH"
           uv sync --frozen --no-build --no-install-project
           .venv/bin/python -m pytest -v
+
+  gdb-live:
+    name: Python tests (gdb, ${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-24.04, ubuntu-26.04]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install gdb and g++
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends gdb g++
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.28"
+
+      # The rest of the suite proves the resolver against in-process fakes;
+      # this lane proves the same two entry points inside gdb's embedded
+      # Python — block iteration, parse_and_eval field reads, and the
+      # user-types latch — against the checked-in testbench types.json.
+      - name: Run the gdb resolver test
+        shell: bash
+        working-directory: resources/oidmcp
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          uv sync --frozen --no-build --no-install-project
+          .venv/bin/python -m pytest -v -ra tests/test_gdb_live.py

--- a/doc/declarative-types.md
+++ b/doc/declarative-types.md
@@ -97,6 +97,11 @@ type: a missing required field, a misspelled key, most invalid values.
 | `name` | the `match` pattern | identifier used in error messages and the conformance tool |
 | `description` | none — absent when unset | free text about the entry; never evaluated, never displayed. JSON has no comments, so this is where an expression gets explained |
 
+Write template arguments with `,\s*` rather than a literal comma-space:
+debug-info readers disagree on the spacing (`Foo<unsigned char, 3>` vs
+`Foo<unsigned char,3>`), and a regex that encodes one spelling silently never
+matches under the other. `{targ:N}` extraction is unaffected either way.
+
 ## Value grammar
 
 A field value is a **scalar** or one of **three object nodes**.

--- a/resources/oidmcp/tests/test_declarative_engine.py
+++ b/resources/oidmcp/tests/test_declarative_engine.py
@@ -5,8 +5,12 @@ node resolution and entry validation. No debugger involved — a recording
 fake bridge stands in for expression evaluation.
 """
 
+import json
+import os
+
 import pytest
 
+from oidscripts import oidtypes
 from oidscripts import symbols
 from oidscripts.debuggers.template_args import TemplateTypeName
 from oidscripts.oidtypes import declarative
@@ -842,3 +846,34 @@ def test_first_valid_min_returns_leaf_result_for_valid_value():
     assert declarative._resolve_first_valid(
         resolution, candidates,
         declarative._leaf_dtype) == symbols.OID_TYPES_FLOAT32
+
+
+def test_match_tolerates_both_template_comma_spellings():
+    # Debug-info readers disagree on template-argument spacing: some spell
+    # Tile<unsigned char, 3>, others Tile<unsigned char,3>. An entry written
+    # with ',\s*' must match both.
+    entry = {
+        'name': 'TileU8x3',
+        'match': r'^(?:const\s+)?Tile<unsigned char,\s*3>(?:\s*[*&])?$',
+        'pointer': '{sym}.data',
+        'width': '{sym}.w',
+        'height': '{sym}.h',
+        'dtype': 'uint8',
+    }
+    inspector = declarative.DeclarativeInspector(entry, 'test')
+    for spelling in ('Tile<unsigned char, 3>', 'Tile<unsigned char,3>'):
+        symbol = FakeSymbol(TemplateTypeName(spelling))
+        assert inspector.is_symbol_observable(symbol, 'tile'), spelling
+
+
+def test_builtin_matchers_never_encode_a_comma_space():
+    # A literal ', ' in a builtin match regex silently unmatches readers
+    # that drop the space. Builtins must stay comma-agnostic.
+    path = os.path.join(os.path.dirname(oidtypes.__file__),
+                        'builtin_types.json')
+    with open(path, 'r', encoding='utf-8') as fh:
+        doc = json.load(fh)
+    for entry in doc['types']:
+        assert ', ' not in entry['match'], (
+            "builtin '%s' encodes a literal comma-space in its match regex"
+            % entry['name'])

--- a/resources/oidmcp/tests/test_gdb_live.py
+++ b/resources/oidmcp/tests/test_gdb_live.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+
+"""End-to-end: the JSON resolver inside gdb itself, not the sys.modules fakes.
+
+Every other test in this suite drives the resolver through fake debugger
+modules; this one proves the same entry points against gdb's embedded
+Python — block iteration, parse_and_eval field reads, and the user-types
+latch — using the repo's own testbench/.oid/types.json as the user-type file
+so that artifact is exercised too.
+
+Skipped wherever gdb or g++ is missing (macOS ships neither); the dedicated
+CI job installs both so the test always runs there.
+"""
+
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+GDB = shutil.which('gdb')
+GXX = shutil.which('g++')
+
+# darwin is excluded even when a gdb binary exists (homebrew ships one):
+# without the codesigning ritual macOS gdb cannot control an inferior, so
+# the run fails on the environment, not the code. The CI lane is Linux.
+pytestmark = pytest.mark.skipif(
+    sys.platform == 'darwin' or GDB is None or GXX is None,
+    reason='needs a Linux host with gdb and g++ (see the gdb-live CI lane)')
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+RESOURCES = REPO_ROOT / 'resources'
+TYPES_JSON = REPO_ROOT / 'testbench' / '.oid' / 'types.json'
+
+# Mirrors testbench/realtypes.cpp's PackedGray8 (data/w/h), which the
+# checked-in types.json matches; kept minimal so the lane needs only g++.
+# Holder exists for the two member paths: a struct-typed local expands to
+# qualified members (`holder.member_gray`), and inside a method the members
+# of `this` surface BARE (`member_gray`), matching lldbbridge's naming.
+FIXTURE_CPP = """\
+struct PackedGray8 {
+    unsigned char* data;
+    int w;
+    int h;
+};
+
+struct Holder {
+    PackedGray8 member_gray;
+    int tag;
+
+    void probe() {
+        volatile int oid_method_breakpoint = 0;
+        (void)oid_method_breakpoint;
+    }
+};
+
+int main() {
+    unsigned char backing[6] = {10, 20, 30, 40, 50, 60};
+    PackedGray8 custom_gray{backing, 3, 2};
+    Holder holder{{backing, 3, 2}, 7};
+    volatile int oid_breakpoint = 0;
+    (void)oid_breakpoint;
+    (void)custom_gray;
+    holder.probe();
+    return 0;
+}
+"""
+
+PROBE_PRELUDE = """\
+import json
+import sys
+
+sys.path.insert(0, {resources!r})
+
+from oidscripts import oid_resolve
+
+SENTINEL = '|OIDEND'
+
+
+def payload(raw):
+    assert raw.endswith(SENTINEL), raw
+    return json.loads(raw[:-len(SENTINEL)])
+"""
+
+PROBE_MAIN_PY = PROBE_PRELUDE + """\
+
+
+page = payload(oid_resolve.list_observable(0))
+print('OIDPROBE list ' + json.dumps(page))
+meta = payload(oid_resolve.resolve('custom_gray'))
+print('OIDPROBE resolve ' + json.dumps(meta))
+"""
+
+# Runs at the Holder::probe() stop: list_observable must surface the
+# member of `this` under its bare name, and that exact name must resolve.
+PROBE_METHOD_PY = PROBE_PRELUDE + """\
+
+
+page = payload(oid_resolve.list_observable(0))
+print('OIDPROBE list2 ' + json.dumps(page))
+meta = payload(oid_resolve.resolve('member_gray'))
+print('OIDPROBE resolve2 ' + json.dumps(meta))
+"""
+
+
+def _probe_lines(stdout):
+    out = {}
+    for line in stdout.splitlines():
+        if line.startswith('OIDPROBE '):
+            _, kind, doc = line.split(' ', 2)
+            out[kind] = json.loads(doc)
+    return out
+
+
+def test_resolver_answers_under_gdb(tmp_path):
+    source = tmp_path / 'fixture.cpp'
+    source.write_text(FIXTURE_CPP)
+    binary = tmp_path / 'fixture'
+    subprocess.run(
+        [GXX, '-g', '-O0', '-o', str(binary), str(source)],
+        check=True, capture_output=True, text=True)
+
+    probe_main = tmp_path / 'probe_main.py'
+    probe_main.write_text(PROBE_MAIN_PY.format(resources=str(RESOURCES)))
+    probe_method = tmp_path / 'probe_method.py'
+    probe_method.write_text(PROBE_METHOD_PY.format(resources=str(RESOURCES)))
+
+    lines = FIXTURE_CPP.splitlines()
+    bp_main = lines.index('    volatile int oid_breakpoint = 0;') + 1
+    bp_method = lines.index(
+        '        volatile int oid_method_breakpoint = 0;') + 1
+
+    env = dict(os.environ)
+    env['OID_TYPES_PATH'] = str(TYPES_JSON)
+    proc = subprocess.run(
+        # The probes ride as -x argv elements (executed in order with -ex),
+        # never spliced into a 'source ...' command line: gdb takes source's
+        # rest-of-line verbatim, so a tmp path with spaces would mis-parse.
+        [GDB, '-batch', '-nx',
+         '-ex', 'set confirm off',
+         '-ex', 'break fixture.cpp:%d' % bp_main,
+         '-ex', 'break fixture.cpp:%d' % bp_method,
+         '-ex', 'run',
+         '-x', str(probe_main),
+         '-ex', 'continue',
+         '-x', str(probe_method),
+         str(binary)],
+        capture_output=True, text=True, timeout=120,
+        cwd=str(tmp_path), env=env)
+
+    transcript = 'stdout:\n%s\nstderr:\n%s' % (proc.stdout, proc.stderr)
+    probes = _probe_lines(proc.stdout)
+    assert 'list' in probes, transcript
+    assert 'resolve' in probes, transcript
+    assert 'list2' in probes, transcript
+    assert 'resolve2' in probes, transcript
+
+    page = probes['list']
+    assert 'error' not in page, transcript
+    names = [item['name'] for item in page['items']]
+    assert 'custom_gray' in names, transcript
+    # A struct-typed local that is not itself observable expands into its
+    # observable members under qualified names.
+    assert 'holder.member_gray' in names, transcript
+    assert 'holder' not in names, transcript
+    # The observable filter must hold under gdb too: a raw byte array
+    # and a scalar local match no type entry and stay out of the page.
+    assert 'backing' not in names, transcript
+    assert 'oid_breakpoint' not in names, transcript
+
+    meta = probes['resolve']
+    assert 'error' not in meta, transcript
+    assert meta['width'] == 3, transcript
+    assert meta['height'] == 2, transcript
+    assert meta['channels'] == 1, transcript
+    assert meta['byte_count'] == 6, transcript
+    assert meta['pointer'] > 0, transcript
+
+    # Inside Holder::probe(): members of `this` surface bare, exactly as
+    # lldbbridge names them, and the listed name resolves as-is.
+    page2 = probes['list2']
+    assert 'error' not in page2, transcript
+    names2 = [item['name'] for item in page2['items']]
+    assert 'member_gray' in names2, transcript
+    assert 'this.member_gray' not in names2, transcript
+    assert 'this' not in names2, transcript
+
+    meta2 = probes['resolve2']
+    assert 'error' not in meta2, transcript
+    assert meta2['width'] == 3, transcript
+    assert meta2['height'] == 2, transcript
+    assert meta2['byte_count'] == 6, transcript
+    assert meta2['pointer'] > 0, transcript

--- a/resources/oidmcp/tests/test_oid_resolve_host.py
+++ b/resources/oidmcp/tests/test_oid_resolve_host.py
@@ -21,17 +21,14 @@ def test_current_host_without_a_debugger_raises_a_named_error(monkeypatch):
     assert 'no supported debugger' in str(excinfo.value).lower()
 
 
-def test_current_host_with_gdb_present_names_gdb_not_no_debugger(monkeypatch):
-    # gdb is a real, supported backend elsewhere in this repo
-    # (debuggers/gdbbridge.py); this entry point just doesn't serve it
-    # yet. The error must say that, not claim no debugger is available.
-    monkeypatch.delitem(sys.modules, 'lldb', raising=False)
-    monkeypatch.setitem(sys.modules, 'gdb', types.ModuleType('gdb'))
-    with pytest.raises(RuntimeError) as excinfo:
-        oid_resolve_host.current_host()
-    message = str(excinfo.value).lower()
-    assert 'gdb' in message
-    assert 'no supported debugger' not in message
+def test_current_host_with_gdb_present_returns_a_gdb_host(monkeypatch):
+    # gdb is a real, supported backend, and this entry point serves it (see
+    # the module docstring). Routing requires the module to carry gdb's
+    # actual Python API, not merely the name -- _install_fake_gdb (defined
+    # with the gdb tests below) provides the surface GdbHost drives.
+    _install_fake_gdb(monkeypatch, _FakeGdbFrame(_FakeGdbBlock([])), {})
+    host = oid_resolve_host.current_host()
+    assert isinstance(host, oid_resolve_host.GdbHost)
 
 
 def test_current_host_falls_back_to_walking_lldb_debugger_when_frame_attribute_is_absent(monkeypatch):
@@ -75,17 +72,13 @@ def test_current_host_with_importable_but_inert_lldb_prefers_gdb(monkeypatch):
     # case; the probe must not claim lldb is active and must fall through
     # to the real gdb underneath, rather than raising the lldb-specific
     # "no stopped frame" error and masking gdb entirely.
+    _install_fake_gdb(monkeypatch, _FakeGdbFrame(_FakeGdbBlock([])), {})
     inert_lldb = types.ModuleType('lldb')
     monkeypatch.setitem(sys.modules, 'lldb', inert_lldb)
-    monkeypatch.setitem(sys.modules, 'gdb', types.ModuleType('gdb'))
 
-    with pytest.raises(RuntimeError) as excinfo:
-        oid_resolve_host.current_host()
+    host = oid_resolve_host.current_host()
 
-    message = str(excinfo.value).lower()
-    assert 'gdb' in message
-    assert 'lldb' not in message
-    assert 'no supported debugger' not in message
+    assert isinstance(host, oid_resolve_host.GdbHost)
 
 
 def test_current_host_with_lldb_present_but_no_stopped_frame_names_lldb_not_no_debugger(monkeypatch):
@@ -163,3 +156,354 @@ def test_host_observable_symbols_shapes_pairs_into_name_type_dicts(monkeypatch):
         {'name': 'a', 'type': 'int'},
         {'name': 'a.b', 'type': 'Buffer'},
     ]
+
+
+# --- GdbAdapter/GdbHost: the gdb-side mirror of LldbAdapter/LldbHost above.
+# There is no gdbbridge.py-style shared helper for this entry point to
+# delegate to (unlike lldbbridge.py for lldb), so these exercise the gdb
+# idioms directly through a fake `gdb` module installed in sys.modules, the
+# same mechanism fake_lldb_module uses for lldb above.
+
+# Sentinels standing in for gdb's TYPE_CODE_STRUCT: a fake type's `code`
+# defaults to a distinct, non-struct object so only types built with
+# `code=_STRUCT_CODE` (below) are ever treated as struct/class-typed by
+# GdbHost's member-expansion walk.
+_STRUCT_CODE = object()
+_NON_STRUCT_CODE = object()
+# Reference types (Wrapper &) peel to their target before the struct
+# check; the fake module exposes it as gdb.TYPE_CODE_REF.
+_REF_CODE = object()
+
+
+class _FakeGdbType:
+    def __init__(self, name, code=_NON_STRUCT_CODE, fields=None):
+        self._name = name
+        self.code = code
+        self._fields = list(fields) if fields is not None else []
+
+    def __str__(self):
+        return self._name
+
+    def pointer(self):
+        return _FakeGdbType(self._name + ' *')
+
+    def fields(self):
+        return list(self._fields)
+
+
+class _FakeGdbField:
+    """Stand-in for gdb.Field: one member yielded by a struct type's
+    fields(), as seen by GdbHost's member-expansion walk."""
+
+    def __init__(self, name, type_obj):
+        self.name = name
+        self.type = type_obj
+
+
+class _FakeGdbValue:
+    def __init__(self, type_name, payload=None, dereferenced=None):
+        self.type = _FakeGdbType(type_name)
+        self._payload = payload
+        self._dereferenced = dereferenced
+
+    def cast(self, gdb_type):
+        return _FakeGdbValue(str(gdb_type), self._payload)
+
+    def dereference(self):
+        return self._dereferenced
+
+
+class _FakeGdbSymbol:
+    def __init__(self, name, type_name, is_variable=True, is_argument=False):
+        self.name = name
+        self.type = _FakeGdbType(type_name)
+        self.is_variable = is_variable
+        self.is_argument = is_argument
+
+
+class _FakeGdbBlock:
+    def __init__(self, symbols, superblock=None):
+        self._symbols = symbols
+        self.superblock = superblock
+
+    def __iter__(self):
+        return iter(self._symbols)
+
+
+class _FakeGdbFrame:
+    def __init__(self, block):
+        self._block = block
+
+    def block(self):
+        return self._block
+
+
+def _install_fake_gdb(monkeypatch, frame, values):
+    """Fake gdb module: parse_and_eval serves `values`, selected_frame serves
+    `frame`. Installed via sys.modules so `import gdb` inside the module under
+    test resolves to it."""
+    fake = types.ModuleType('gdb')
+    fake.parse_and_eval = lambda expr: values[expr]
+    fake.lookup_type = _FakeGdbType
+    fake.selected_frame = lambda: frame
+    fake.TYPE_CODE_STRUCT = _STRUCT_CODE
+    fake.TYPE_CODE_REF = _REF_CODE
+    monkeypatch.setitem(sys.modules, 'gdb', fake)
+    # current_host() must not mistake an importable-but-inert lldb for the
+    # host; remove any lldb stub other tests installed.
+    monkeypatch.delitem(sys.modules, 'lldb', raising=False)
+    return fake
+
+
+def test_gdb_adapter_evaluate_and_cast(monkeypatch):
+    frame = _FakeGdbFrame(_FakeGdbBlock([]))
+    val = _FakeGdbValue('unsigned char *')
+    _install_fake_gdb(monkeypatch, frame, {'(gray).data': val})
+    adapter = oid_resolve_host.GdbAdapter()
+    assert adapter.evaluate_expression('(gray).data') is val
+    with pytest.raises(RuntimeError):
+        adapter.evaluate_expression('missing')  # KeyError normalised
+    casted = adapter.get_casted_pointer('unsigned char', val)
+    assert str(casted.type) == 'unsigned char *'
+
+
+def test_gdb_host_observable_symbols_ordered_and_deduped(monkeypatch):
+    # Bridge hygiene: force a fresh TypeBridge and disable the user-types
+    # walk-up, so a developer machine's own .oid/types.json cannot change
+    # which types match (the module-level _BRIDGE cache otherwise latches
+    # onto whatever was built by an earlier test).
+    monkeypatch.setattr(oid_resolve_host, '_BRIDGE', None)
+    monkeypatch.setenv('OID_TYPES_PATH', '')
+    # 'mat' is cv::Mat (a builtin declarative type, so it is genuinely
+    # observable); 'i'/'argc' are plain ints, which nothing registers as a
+    # plottable buffer type, so they must be filtered out rather than
+    # merely deduplicated.
+    inner = _FakeGdbBlock(
+        [_FakeGdbSymbol('mat', 'cv::Mat'), _FakeGdbSymbol('i', 'int')],
+        superblock=_FakeGdbBlock(
+            [_FakeGdbSymbol('mat', 'cv::Mat'),  # shadowed duplicate
+             _FakeGdbSymbol('argc', 'int', is_variable=False, is_argument=True)]
+        ),
+    )
+    _install_fake_gdb(monkeypatch, _FakeGdbFrame(inner), {})
+    host = oid_resolve_host.GdbHost()
+    syms = host.observable_symbols()
+    assert syms == [{'name': 'mat', 'type': 'cv::Mat'}]
+
+
+def test_gdb_host_observable_symbols_expands_struct_members(monkeypatch):
+    monkeypatch.setattr(oid_resolve_host, '_BRIDGE', None)
+    monkeypatch.setenv('OID_TYPES_PATH', '')
+    # `wrapper` itself is not a registered buffer type, so it must be
+    # expanded rather than emitted as-is: `img` (cv::Mat) is observable and
+    # surfaces as 'wrapper.img'; `count` (int) is neither observable nor a
+    # struct, so it contributes nothing.
+    wrapper_type = _FakeGdbType('Wrapper', code=_STRUCT_CODE, fields=[
+        _FakeGdbField('img', _FakeGdbType('cv::Mat')),
+        _FakeGdbField('count', _FakeGdbType('int')),
+    ])
+    wrapper_symbol = _FakeGdbSymbol('wrapper', 'Wrapper')
+    wrapper_symbol.type = wrapper_type
+    block = _FakeGdbBlock([wrapper_symbol])
+    _install_fake_gdb(monkeypatch, _FakeGdbFrame(block), {})
+    host = oid_resolve_host.GdbHost()
+    syms = host.observable_symbols()
+    assert syms == [{'name': 'wrapper.img', 'type': 'cv::Mat'}]
+
+
+def test_gdb_host_observable_symbols_expands_this_specially(monkeypatch):
+    monkeypatch.setattr(oid_resolve_host, '_BRIDGE', None)
+    monkeypatch.setenv('OID_TYPES_PATH', '')
+    # A symbol literally named 'this' is expanded through
+    # gdb.parse_and_eval('this').dereference().type.fields(), and its
+    # members surface BARE ('img', never 'this.img' and never a bare
+    # 'this' entry) -- the same names lldbbridge emits, so a client can
+    # feed any list_observable() item straight back into resolve() under
+    # either debugger (bare member names evaluate in method scope through
+    # the implicit this).
+    wrapper_type = _FakeGdbType('Wrapper', code=_STRUCT_CODE, fields=[
+        _FakeGdbField('img', _FakeGdbType('cv::Mat')),
+        _FakeGdbField('count', _FakeGdbType('int')),
+    ])
+    this_symbol = _FakeGdbSymbol('this', 'Wrapper *')
+    this_value = _FakeGdbValue(
+        'Wrapper *', dereferenced=types.SimpleNamespace(type=wrapper_type))
+    block = _FakeGdbBlock([this_symbol])
+    _install_fake_gdb(monkeypatch, _FakeGdbFrame(block), {'this': this_value})
+    host = oid_resolve_host.GdbHost()
+    syms = host.observable_symbols()
+    assert syms == [{'name': 'img', 'type': 'cv::Mat'}]
+
+
+def test_current_host_routes_to_gdb(monkeypatch):
+    _install_fake_gdb(monkeypatch, _FakeGdbFrame(_FakeGdbBlock([])), {})
+    host = oid_resolve_host.current_host()
+    assert isinstance(host, oid_resolve_host.GdbHost)
+
+
+def test_gdb_host_expands_reference_typed_aggregates(monkeypatch):
+    monkeypatch.setattr(oid_resolve_host, '_BRIDGE', None)
+    monkeypatch.setenv('OID_TYPES_PATH', '')
+    # A Wrapper& local (any reference parameter) is field-navigated with
+    # '.' exactly like a value -- the declarative engine already treats
+    # T& as not-a-pointer -- so the walk peels the reference and expands
+    # observable members; without the peel, reference-typed aggregates
+    # would never list at all.
+    wrapper_type = _FakeGdbType('Wrapper', code=_STRUCT_CODE, fields=[
+        _FakeGdbField('img', _FakeGdbType('cv::Mat')),
+        _FakeGdbField('count', _FakeGdbType('int')),
+    ])
+    ref_type = _FakeGdbType('Wrapper &', code=_REF_CODE)
+    ref_type.target = lambda: wrapper_type
+    ref_symbol = _FakeGdbSymbol('wrapper_ref', 'Wrapper &')
+    ref_symbol.type = ref_type
+    block = _FakeGdbBlock([ref_symbol])
+    _install_fake_gdb(monkeypatch, _FakeGdbFrame(block), {})
+    host = oid_resolve_host.GdbHost()
+    assert host.observable_symbols() == [
+        {'name': 'wrapper_ref.img', 'type': 'cv::Mat'}]
+
+
+def test_gdb_host_skips_unnamed_block_symbols(monkeypatch):
+    monkeypatch.setattr(oid_resolve_host, '_BRIDGE', None)
+    monkeypatch.setenv('OID_TYPES_PATH', '')
+    # gdb can yield block symbols without a name; emitting them would put
+    # a JSON null (or a None-parented member path) into the page that
+    # resolve() can never evaluate. lldbbridge skips unnamed symbols the
+    # same way.
+    unnamed = _FakeGdbSymbol(None, 'cv::Mat')
+    named = _FakeGdbSymbol('mat', 'cv::Mat')
+    block = _FakeGdbBlock([unnamed, named])
+    _install_fake_gdb(monkeypatch, _FakeGdbFrame(block), {})
+    host = oid_resolve_host.GdbHost()
+    assert host.observable_symbols() == [{'name': 'mat', 'type': 'cv::Mat'}]
+
+
+def test_gdb_host_buffer_metadata_normalizes_evaluation_errors(monkeypatch):
+    # buffer_metadata evaluates through the adapter so a failed lookup
+    # surfaces the adapter's uniform 'Expression "..." failed' contract --
+    # resolve() stringifies whatever escapes, and a raw backend exception
+    # (KeyError here, gdb.error live) is not a client-facing message.
+    _install_fake_gdb(monkeypatch, _FakeGdbFrame(_FakeGdbBlock([])), {})
+    host = oid_resolve_host.GdbHost()
+    with pytest.raises(RuntimeError) as excinfo:
+        host.buffer_metadata('missing')
+    assert 'Expression "missing" failed' in str(excinfo.value)
+
+
+def test_gdb_host_walks_through_unnamed_and_base_fields(monkeypatch):
+    monkeypatch.setattr(oid_resolve_host, '_BRIDGE', None)
+    monkeypatch.setenv('OID_TYPES_PATH', '')
+    # Anonymous aggregates and base-class subobjects contribute no path
+    # segment: C++ addresses their members directly on the containing
+    # object, so the emitted names must skip the nameless/base hop
+    # ('outer.img', never 'outer.None.img' or 'outer.Base.base_img'
+    # spelled through the base) or resolve() could never evaluate them.
+    inner = _FakeGdbType('', code=_STRUCT_CODE, fields=[
+        _FakeGdbField('img', _FakeGdbType('cv::Mat')),
+    ])
+    base = _FakeGdbType('Base', code=_STRUCT_CODE, fields=[
+        _FakeGdbField('base_img', _FakeGdbType('cv::Mat')),
+    ])
+    base_field = _FakeGdbField('Base', base)
+    base_field.is_base_class = True
+    outer_type = _FakeGdbType('Outer', code=_STRUCT_CODE, fields=[
+        _FakeGdbField(None, inner),
+        base_field,
+        _FakeGdbField('count', _FakeGdbType('int')),
+    ])
+    outer_symbol = _FakeGdbSymbol('outer', 'Outer')
+    outer_symbol.type = outer_type
+    block = _FakeGdbBlock([outer_symbol])
+    _install_fake_gdb(monkeypatch, _FakeGdbFrame(block), {})
+    host = oid_resolve_host.GdbHost()
+    assert host.observable_symbols() == [
+        {'name': 'outer.img', 'type': 'cv::Mat'},
+        {'name': 'outer.base_img', 'type': 'cv::Mat'},
+    ]
+
+
+def test_gdb_host_omits_this_members_shadowed_by_locals(monkeypatch):
+    monkeypatch.setattr(oid_resolve_host, '_BRIDGE', None)
+    monkeypatch.setenv('OID_TYPES_PATH', '')
+    # C++ resolves an unqualified name to a local/argument before an
+    # implicit this-member, so a bare member name colliding with ANY
+    # in-scope symbol would list the member while resolve() evaluates the
+    # local -- the wrong object. Shadowed members are omitted; every
+    # emitted name resolves to exactly what was listed.
+    wrapper_type = _FakeGdbType('Wrapper', code=_STRUCT_CODE, fields=[
+        _FakeGdbField('img', _FakeGdbType('cv::Mat')),
+        _FakeGdbField('img2', _FakeGdbType('cv::Mat')),
+    ])
+    this_symbol = _FakeGdbSymbol('this', 'Wrapper *')
+    this_value = _FakeGdbValue(
+        'Wrapper *', dereferenced=types.SimpleNamespace(type=wrapper_type))
+    shadowing_local = _FakeGdbSymbol('img', 'int')  # non-observable local
+    block = _FakeGdbBlock([this_symbol, shadowing_local])
+    _install_fake_gdb(monkeypatch, _FakeGdbFrame(block), {'this': this_value})
+    host = oid_resolve_host.GdbHost()
+    assert host.observable_symbols() == [{'name': 'img2', 'type': 'cv::Mat'}]
+
+
+def test_gdb_host_skips_an_unevaluable_this_and_lists_the_rest(monkeypatch):
+    monkeypatch.setattr(oid_resolve_host, '_BRIDGE', None)
+    monkeypatch.setenv('OID_TYPES_PATH', '')
+    # `this` is in scope but not evaluable right now (optimized out, frame
+    # prologue, dead frame): its expansion must be skipped, never fatal --
+    # list_observable turns any escaped exception into a full-page error,
+    # which would hide every other observable symbol.
+    this_symbol = _FakeGdbSymbol('this', 'Wrapper *')
+    mat_symbol = _FakeGdbSymbol('mat', 'cv::Mat')
+    block = _FakeGdbBlock([this_symbol, mat_symbol])
+    # No 'this' entry in the values dict: parse_and_eval('this') raises.
+    _install_fake_gdb(monkeypatch, _FakeGdbFrame(block), {})
+    host = oid_resolve_host.GdbHost()
+    assert host.observable_symbols() == [{'name': 'mat', 'type': 'cv::Mat'}]
+
+
+def test_gdb_host_without_a_stopped_frame_names_the_condition(monkeypatch):
+    monkeypatch.setattr(oid_resolve_host, '_BRIDGE', None)
+    monkeypatch.setenv('OID_TYPES_PATH', '')
+    # Before `run` (or after the inferior exits) gdb raises from
+    # selected_frame(); the host must surface the same routine-condition
+    # message the lldb path uses, not an opaque internal error.
+    fake = _install_fake_gdb(monkeypatch, _FakeGdbFrame(_FakeGdbBlock([])), {})
+
+    def no_frame():
+        raise RuntimeError('No frame is currently selected.')
+
+    fake.selected_frame = no_frame
+    host = oid_resolve_host.GdbHost()
+    with pytest.raises(RuntimeError) as excinfo:
+        host.observable_symbols()
+    assert 'no stopped frame' in str(excinfo.value).lower()
+
+
+def test_current_host_rejects_gdb_without_the_full_walk_api(monkeypatch):
+    # The probe must require every attribute the gdb path reads without a
+    # guard: a module carrying the rest of the surface but no
+    # TYPE_CODE_REF would pass selection and then crash mid-walk when
+    # reference peeling runs.
+    monkeypatch.delitem(sys.modules, 'lldb', raising=False)
+    partial = types.ModuleType('gdb')
+    partial.parse_and_eval = lambda expr: None
+    partial.lookup_type = lambda name: None
+    partial.selected_frame = lambda: None
+    partial.TYPE_CODE_STRUCT = object()
+    monkeypatch.setitem(sys.modules, 'gdb', partial)
+    with pytest.raises(RuntimeError) as excinfo:
+        oid_resolve_host.current_host()
+    assert 'no supported debugger' in str(excinfo.value).lower()
+
+
+def test_current_host_with_inert_gdb_names_no_debugger(monkeypatch):
+    # A module merely NAMED gdb (a leftover stub, a foreign package
+    # shadowing the name) does not host this interpreter: without gdb's
+    # actual API the router must end on the terminal no-debugger error
+    # instead of returning a GdbHost that fails later with AttributeError
+    # on its first use.
+    monkeypatch.delitem(sys.modules, 'lldb', raising=False)
+    monkeypatch.setitem(sys.modules, 'gdb', types.ModuleType('gdb'))
+    with pytest.raises(RuntimeError) as excinfo:
+        oid_resolve_host.current_host()
+    assert 'no supported debugger' in str(excinfo.value).lower()

--- a/resources/oidscripts/oid_resolve_host.py
+++ b/resources/oidscripts/oid_resolve_host.py
@@ -4,10 +4,9 @@
 declarative engine needs, plus selection of whichever debugger module is
 present in the host interpreter.
 
-Only lldb is wired in today. gdb is supported elsewhere in this repo
-(debuggers/gdbbridge.py), but routing this entry point through it is
-unproven. A GdbHost slots in beside LldbHost, selected the same way from
-current_host(), with no change to oid_resolve.py."""
+Both debuggers are wired in: LldbHost binds an lldb frame, GdbHost the
+gdb-selected frame, selected by current_host() with no change to
+oid_resolve.py."""
 
 from oidscripts.typebridge import TypeBridge
 
@@ -75,6 +74,187 @@ class LldbHost(object):
                 for name, wrapped in pairs]
 
 
+class GdbAdapter(object):
+    """The whole bridge contract the engine exercises, over gdb idioms:
+    evaluate an expression, and cast a symbol to its buffer address."""
+
+    def evaluate_expression(self, expression):
+        import gdb
+        try:
+            return gdb.parse_and_eval(expression)
+        except Exception as error:
+            raise RuntimeError(
+                'Expression "%s" failed: %s' % (expression, error)) from error
+
+    def get_casted_pointer(self, typename, obj):
+        import gdb
+        return obj.cast(gdb.lookup_type(typename).pointer())
+
+
+def _peel_gdb_type(gdb, node_type):
+    """Typedefs and references peel before the struct check: a `Wrapper&`
+    local (any reference parameter) is field-navigated with '.' exactly
+    like a `Wrapper`, and the declarative engine already treats `T&` as
+    not-a-pointer. Pointers stay pointers -- their members would need a
+    dereference the emitted names do not spell."""
+    peeled = node_type
+    strip = getattr(peeled, 'strip_typedefs', None)
+    if strip is not None:
+        peeled = strip()
+    ref_codes = (gdb.TYPE_CODE_REF,
+                 getattr(gdb, 'TYPE_CODE_RVALUE_REF', None))
+    if peeled.code in ref_codes:
+        peeled = peeled.target()
+        strip = getattr(peeled, 'strip_typedefs', None)
+        if strip is not None:
+            peeled = strip()
+    return peeled
+
+
+def _walk_gdb_members(gdb, bridge, node, parent_name, emit):
+    """Emit `node`'s observable struct/class members, recursively.
+
+    An empty `parent_name` makes members surface BARE -- used for `this`,
+    whose members are directly evaluable in the frame through the implicit
+    this. That matches the names lldbbridge emits, so a client can feed any
+    list_observable() item straight back into resolve() under either
+    debugger."""
+    node_type = _peel_gdb_type(gdb, node.type)
+    if gdb.TYPE_CODE_STRUCT != node_type.code:
+        return
+    for field in node_type.fields():
+        field_name = getattr(field, 'name', None)
+        if not field_name or getattr(field, 'is_base_class', False):
+            # Anonymous aggregates and base-class subobjects contribute no
+            # path segment: C++ addresses their members directly on the
+            # containing object, so an invented segment ('parent.None.x',
+            # 'parent.Base.x') would never evaluate back through
+            # resolve(). Recurse as if their members were direct members.
+            _walk_gdb_members(gdb, bridge, field, parent_name, emit)
+            continue
+        qualified_name = ('%s.%s' % (parent_name, field_name)
+                          if parent_name else field_name)
+        if bridge.is_symbol_observable(field, qualified_name):
+            emit(qualified_name, field.type)
+        else:
+            _walk_gdb_members(gdb, bridge, field, qualified_name, emit)
+
+
+def _gdb_scope_names(block):
+    """Every named local/argument across the block chain -- the names an
+    unqualified C++ expression would resolve BEFORE an implicit
+    this-member."""
+    names = set()
+    while block is not None:
+        for symbol in block:
+            if (getattr(symbol, 'is_argument', False)
+                    or getattr(symbol, 'is_variable', False)):
+                name = getattr(symbol, 'name', None)
+                if name:
+                    names.add(name)
+        block = getattr(block, 'superblock', None)
+    return names
+
+
+def _expand_gdb_symbol(gdb, bridge, symbol, emit, shadowed=frozenset()):
+    """One in-scope symbol: kept when its own type is observable, expanded
+    into its observable members otherwise (`this` dereferenced first, its
+    members emitted bare -- except members whose bare name a local or
+    argument in `shadowed` would capture: C++ resolves the unqualified
+    name to the local, so listing the member would resolve the wrong
+    object)."""
+    name = symbol.name
+    if bridge.is_symbol_observable(symbol, name):
+        emit(name, symbol.type)
+    elif name == 'this':
+        try:
+            this_value = gdb.parse_and_eval('this').dereference()
+        except Exception:                          # noqa: BLE001
+            # `this` is in scope but not evaluable right now (optimized
+            # out, frame prologue, dead frame). Skip its expansion rather
+            # than aborting the whole listing -- the caller turns any
+            # escaped exception into a full-page error payload, which
+            # would hide every other observable symbol.
+            return
+
+        def emit_unshadowed(member_name, member_type):
+            if member_name.split('.', 1)[0] not in shadowed:
+                emit(member_name, member_type)
+
+        _walk_gdb_members(gdb, bridge, this_value, '', emit_unshadowed)
+    else:
+        _walk_gdb_members(gdb, bridge, symbol, name, emit)
+
+
+class GdbHost(object):
+    """Binds oid_resolve's host contract to gdb's selected frame.
+
+    Unlike LldbHost, no frame is captured at construction: gdb's
+    parse_and_eval and selected_frame() always act on the current selection,
+    so a host held across stops stays correct by construction.
+    """
+
+    def __init__(self):
+        self._adapter = GdbAdapter()
+
+    def buffer_metadata(self, name):
+        # Evaluate through the adapter, not gdb.parse_and_eval directly:
+        # resolve() stringifies whatever escapes, and the adapter is the
+        # error-normalization contract ('Expression "..." failed: ...')
+        # shared with the engine's own expression evaluation.
+        picked = self._adapter.evaluate_expression(name)
+        return _type_bridge().get_buffer_metadata(name, picked, self._adapter)
+
+    def observable_symbols(self):
+        """Every observable symbol in the current frame, including buffers
+        held as struct/class members (`holder.image`; members of `this`
+        surface bare, e.g. `image`, exactly as lldbbridge names them) --
+        an innermost-block-first walk of the selected frame's blocks. Each
+        in-scope local/argument is kept when its own type is a registered
+        plottable buffer type; a struct/class symbol that is not itself
+        observable is expanded into its observable members instead.
+        Deduplicated by qualified name (an inner shadowing wins), as
+        {'name','type'} pairs -- the same shape LldbHost returns, so the
+        paging in oid_resolve.list_observable slices it unchanged."""
+        import gdb
+        try:
+            block = gdb.selected_frame().block()
+        except Exception as error:                 # noqa: BLE001
+            # Before `run`, or after the inferior exits, gdb raises here.
+            # Name the routine condition the way the lldb path does
+            # instead of letting gdb's internal message surface as an
+            # opaque endpoint error.
+            raise RuntimeError(
+                'gdb is available in this interpreter, but no stopped '
+                'frame is available') from error
+        bridge = _type_bridge()
+        shadowed = _gdb_scope_names(block)
+        seen = set()
+        out = []
+        processed = set()
+
+        def emit(qualified_name, type_obj):
+            if qualified_name not in seen:
+                seen.add(qualified_name)
+                out.append({'name': qualified_name, 'type': str(type_obj)})
+
+        while block is not None:
+            for symbol in block:
+                if not (getattr(symbol, 'is_argument', False)
+                        or getattr(symbol, 'is_variable', False)):
+                    continue
+                # Unnamed symbols are skipped like lldbbridge does: a null
+                # name (or a None-parented member path) could never be fed
+                # back through resolve().
+                name = getattr(symbol, 'name', None)
+                if not name or name in processed:
+                    continue
+                processed.add(name)
+                _expand_gdb_symbol(gdb, bridge, symbol, emit, shadowed)
+            block = getattr(block, 'superblock', None)
+        return out
+
+
 def _frame_from_lldb_debugger(lldb):
     """Walk from lldb.debugger down to the selected frame, rather than
     trusting lldb.frame -- a convenience global that only exists in some
@@ -82,6 +262,23 @@ def _frame_from_lldb_debugger(lldb):
     helper once lldb.debugger is extracted."""
     from oidscripts.debuggers.lldbbridge import frame_from_debugger
     return frame_from_debugger(getattr(lldb, 'debugger', None))
+
+
+# Every attribute the gdb path reads WITHOUT a guard must be listed here,
+# or a partial module passes selection and crashes mid-walk instead
+# (TYPE_CODE_RVALUE_REF stays out: _peel_gdb_type reads it via getattr).
+_GDB_HOST_API = ('selected_frame', 'parse_and_eval', 'lookup_type',
+                 'TYPE_CODE_STRUCT', 'TYPE_CODE_REF')
+
+
+def _gdb_serves_host(gdb):
+    """A module named gdb only hosts this interpreter when it carries the
+    API this module drives (GdbAdapter, GdbHost, and the member walk). An
+    importable stub -- a leftover test fake, a foreign package shadowing
+    the name -- must fall through to the terminal no-debugger error, the
+    same way an importable-but-inert lldb falls through to the gdb probe,
+    instead of yielding a host that fails later with AttributeError."""
+    return all(hasattr(gdb, attr) for attr in _GDB_HOST_API)
 
 
 def current_host():
@@ -125,13 +322,8 @@ def current_host():
         import gdb
     except ImportError:
         gdb = None
-    if gdb is not None:
-        # gdb is a real, supported backend in this repo (see the module
-        # docstring) -- it just is not served from this entry point yet.
-        # Say so plainly instead of claiming no debugger is available.
-        raise RuntimeError(
-            'gdb is available in this interpreter, but this entry point '
-            'does not serve it yet')
+    if gdb is not None and _gdb_serves_host(gdb):
+        return GdbHost()
 
     raise RuntimeError(
         'no supported debugger module is available in this interpreter')


### PR DESCRIPTION
The declarative resolver's JSON entry point (oid_resolve) now works under gdb as well as lldb: current_host() routes to a GdbHost when gdb hosts the interpreter, so resolve() and list_observable() answer with the same payloads in both debuggers. Members of `this` are listed under their bare names, exactly as the lldb side names them, so any listed symbol can be passed straight back to resolve() on either backend. A CI lane now proves both entry points inside gdb (ubuntu 24.04 and 26.04), including the method-scope list-to-resolve round trip.

Also documents that template matchers should use ',\s*' between template arguments (debug-info readers disagree on the spacing) and adds a regression test keeping the builtin matchers comma-agnostic.
