### PR TITLE
fix(resolver): let a caller size its own page of observable symbols

### DIFF
--- a/resources/oidmcp/tests/test_oid_resolve.py
+++ b/resources/oidmcp/tests/test_oid_resolve.py
@@ -143,6 +143,70 @@ def test_list_observable_clamps_a_limit_above_the_maximum():
     assert out['total'] == total_symbols
 
 
+def test_list_observable_defaults_to_eight_when_no_limit_is_passed():
+    """Separating the default from the ceiling must not move the default:
+    a caller that asks for nothing still gets eight."""
+    syms = [{'name': 'v%d' % i, 'type': 'cv::Mat'} for i in range(20)]
+    host = FakeHost(symbols=syms)
+
+    out = _payload(oid_resolve.list_observable(host=host))
+
+    assert oid_resolve.DEFAULT_OBSERVABLE_PAGE_LIMIT == 8
+    assert len(out['items']) == oid_resolve.DEFAULT_OBSERVABLE_PAGE_LIMIT
+
+
+def test_list_observable_honors_a_limit_between_the_default_and_the_ceiling():
+    """The whole point of separating the two roles: a caller whose own
+    transport can carry more than the default must no longer be cut down
+    to it, as long as it asks for no more than the ceiling."""
+    limit = oid_resolve.DEFAULT_OBSERVABLE_PAGE_LIMIT + 10
+    assert limit < oid_resolve.MAX_OBSERVABLE_PAGE_LIMIT
+    syms = [{'name': 'v%d' % i, 'type': 'cv::Mat'} for i in range(limit + 5)]
+    host = FakeHost(symbols=syms)
+
+    out = _payload(oid_resolve.list_observable(0, limit, host=host))
+
+    assert len(out['items']) == limit
+
+
+def test_list_observable_honors_a_limit_exactly_at_the_ceiling():
+    ceiling = oid_resolve.MAX_OBSERVABLE_PAGE_LIMIT
+    syms = [{'name': 'v%d' % i, 'type': 'cv::Mat'} for i in range(ceiling + 5)]
+    host = FakeHost(symbols=syms)
+
+    out = _payload(oid_resolve.list_observable(0, ceiling, host=host))
+
+    assert len(out['items']) == ceiling
+
+
+def test_list_observable_clamps_a_limit_one_above_the_ceiling():
+    ceiling = oid_resolve.MAX_OBSERVABLE_PAGE_LIMIT
+    syms = [{'name': 'v%d' % i, 'type': 'cv::Mat'} for i in range(ceiling + 5)]
+    host = FakeHost(symbols=syms)
+
+    out = _payload(oid_resolve.list_observable(0, ceiling + 1, host=host))
+
+    assert len(out['items']) == ceiling
+
+
+def test_list_observable_total_reports_every_symbol_regardless_of_page_size():
+    """total must reflect the true symbol count whether the caller takes
+    a small page, the default, or the whole list in one go."""
+    total_symbols = oid_resolve.MAX_OBSERVABLE_PAGE_LIMIT + 37
+    syms = [{'name': 'v%d' % i, 'type': 'cv::Mat'}
+            for i in range(total_symbols)]
+    host = FakeHost(symbols=syms)
+
+    small_page = _payload(oid_resolve.list_observable(0, 3, host=host))
+    default_page = _payload(oid_resolve.list_observable(host=host))
+    full_page = _payload(
+        oid_resolve.list_observable(0, total_symbols, host=host))
+
+    assert small_page['total'] == total_symbols
+    assert default_page['total'] == total_symbols
+    assert full_page['total'] == total_symbols
+
+
 def test_payloads_always_carry_the_sentinel():
     assert oid_resolve.resolve('m', host=FakeHost(metadata=BASE)).endswith(SENTINEL)
     assert oid_resolve.list_observable(0, 1, host=FakeHost()).endswith(SENTINEL)

--- a/resources/oidscripts/oid_resolve.py
+++ b/resources/oidscripts/oid_resolve.py
@@ -22,8 +22,26 @@ CONTRACT_KEYS = ('display_name', 'width', 'height', 'channels', 'type',
 # Guards against a page overrunning a transport's ~1024-character string
 # ceiling -- the exact failure mode paging exists to prevent. Each item
 # carries a name plus a type string, and a canonical Eigen type name alone
-# can exceed 70 characters, so even a modest item count adds up fast.
-MAX_OBSERVABLE_PAGE_LIMIT = 8
+# can exceed 70 characters, so even a modest item count adds up fast. This
+# is a default, not a hard limit: a caller whose own transport can carry
+# more is free to ask for a bigger page (see MAX_OBSERVABLE_PAGE_LIMIT
+# below). A caller that asks for nothing gets this value.
+DEFAULT_OBSERVABLE_PAGE_LIMIT = 8
+
+# The ceiling any caller's limit is clamped to, kept deliberately separate
+# from the default above: the default protects a caller stuck with a
+# roughly 1024-character transport, but that budget belongs to the
+# caller's transport, not to the engine, so it must not cap every caller.
+# The ceiling exists only to stop a request for something absurd.
+#
+# Sized the same way the default is: each item is JSON with a name plus a
+# type string, and a canonical template type name can run past 70
+# characters, so call it on the order of 100-150 bytes once the
+# surrounding quotes, colon, and comma are counted. 128 items keeps a
+# full page within roughly 16KB, comfortably above what the default
+# guards against, while still a concrete, finite stop rather than no
+# limit at all.
+MAX_OBSERVABLE_PAGE_LIMIT = 128
 
 
 def _emit(payload):
@@ -78,7 +96,7 @@ def resolve(name, host=None):
         return _emit({'error': 'malformed metadata for %r: %s' % (name, exc)})
 
 
-def list_observable(offset=0, limit=MAX_OBSERVABLE_PAGE_LIMIT, host=None):
+def list_observable(offset=0, limit=DEFAULT_OBSERVABLE_PAGE_LIMIT, host=None):
     """A page of plottable symbols, so a long list cannot overrun a
     transport's string ceiling.
 


### PR DESCRIPTION
Listing the observable symbols of a frame is paged, and a page is produced by building the whole list and then slicing the requested range out of it. The cost of one page is therefore the cost of the whole walk, and reading a frame in three pages walks it and resolves every symbol type three times.

Until now a caller could not avoid that, because a single constant was doing two different jobs: it set the default page size and it also capped what any caller was allowed to ask for. The cap exists to protect a caller whose transport truncates long strings, but that budget belongs to the caller, not to the engine, so it should not have applied to everyone.

The default is unchanged. What changes is that it is no longer also the ceiling: a caller that can carry a larger reply may now ask for a larger page and take the frame in one walk. The ceiling stays, raised and still finite, so an absurd request is still refused.

A caller that passes no size, or one at or below the previous value, sees no change at all.