### PR TITLE
fix: stop walking a container's elements to find its members

### DIFF
--- a/resources/oidmcp/tests/conftest.py
+++ b/resources/oidmcp/tests/conftest.py
@@ -37,18 +37,38 @@ if RESOURCES_DIR not in sys.path:
 # another one.
 _LLDB_STUB = types.ModuleType('lldb')
 _LLDB_STUB.eTypeIsInteger = 1 << 8
+# Type-class bits, carrying lldb's own values. lldbbridge reads these to
+# decide which values it may descend into: a struct's children are its
+# declared members, an array's are elements.
+_LLDB_STUB.eTypeClassArray = 1
+_LLDB_STUB.eTypeClassBuiltin = 4
+_LLDB_STUB.eTypeClassClass = 8
+_LLDB_STUB.eTypeClassPointer = 4096
+_LLDB_STUB.eTypeClassReference = 8192
+_LLDB_STUB.eTypeClassStruct = 16384
+_LLDB_STUB.eTypeClassUnion = 65536
 _LLDB_STUB.SBValue = object
-sys.modules.setdefault('lldb', _LLDB_STUB)
+# Whichever module actually ended up installed: the stub, or a real lldb
+# when this suite runs inside a debugger's interpreter. The fakes below
+# read their type-class constants from it, so they always agree with the
+# ones lldbbridge itself is looking at.
+LLDB = sys.modules.setdefault('lldb', _LLDB_STUB)
 
 from oidscripts import wireframe as wf
 from oidscripts.debuggers.interfaces import raise_if_too_large
 
 
 class FakeSBType:
-    """Just enough of lldb.SBType for SymbolWrapper's constructor."""
+    """Just enough of lldb.SBType for SymbolWrapper's constructor and for
+    lldbbridge's descent guard: a type class, plus the pointer/reference
+    peeling the guard performs before testing it. The default type class
+    is a struct, so a node built without one is descended into."""
 
-    def __init__(self, name):
+    def __init__(self, name, type_class=None, pointee=None):
         self._name = name
+        self._type_class = (LLDB.eTypeClassStruct if type_class is None
+                            else type_class)
+        self._pointee = pointee
 
     def IsValid(self):
         return True
@@ -59,28 +79,86 @@ class FakeSBType:
     def GetName(self):
         return self._name
 
+    def GetTypeClass(self):
+        return self._type_class
+
+    def IsPointerType(self):
+        return self._type_class == LLDB.eTypeClassPointer
+
+    def IsReferenceType(self):
+        return self._type_class == LLDB.eTypeClassReference
+
+    def GetPointeeType(self):
+        # An unspecified pointee is a scalar, the commonest case (`char *`).
+        return self._pointee if self._pointee is not None \
+            else FakeSBType(self._name, LLDB.eTypeClassBuiltin)
+
+    def GetDereferencedType(self):
+        return self.GetPointeeType()
+
 
 class FakeSBValue:
     """A minimal SBValue-like tree node for exercising
     lldbbridge.observable_symbols()'s recursive member traversal without a
     real debugger. `children` may itself reference an ancestor node to
-    build a genuine cycle."""
+    build a genuine cycle.
 
-    def __init__(self, name, typename, children=()):
+    `children` are the value's DECLARED members, what lldb serves from
+    the non-synthetic view. `synthetic_child_count` puts a data formatter
+    in play: GetNumChildren() then reports that many ELEMENTS and
+    GetChildAtIndex() manufactures them on demand, which is exactly what
+    lldb reports for a std::vector (57600 children for 57600 bytes, over
+    three declared members). Every child served is counted in
+    `child_fetches`, on the owning node whether it came from the
+    formatter or from the declared view, so a test can assert the total
+    does not track the element count."""
+
+    def __init__(self, name, typename, children=(), type_class=None,
+                 pointee_type_class=None, synthetic_child_count=None,
+                 element_typename='Element'):
         self.name = name
         self._typename = typename
         self._children = list(children)
+        self._type_class = type_class
+        self._pointee_type_class = pointee_type_class
+        self._synthetic_child_count = synthetic_child_count
+        self._element_typename = element_typename
+        self._declared_view = None
+        self._fetch_owner = self
+        self.child_fetches = 0
 
     def GetTypeName(self):
         return self._typename
 
     def GetType(self):
-        return FakeSBType(self._typename)
+        pointee = None
+        if self._pointee_type_class is not None:
+            pointee = FakeSBType(self._typename, self._pointee_type_class)
+        return FakeSBType(self._typename, self._type_class, pointee)
+
+    def GetNonSyntheticValue(self):
+        """lldb hands back the same value with formatters switched off,
+        exposing the type's declared members instead of the formatter's
+        elements. Without a formatter in play it is the value itself."""
+        if self._synthetic_child_count is None:
+            return self
+        if self._declared_view is None:
+            view = FakeSBValue(self.name, self._typename, self._children,
+                               type_class=self._type_class,
+                               pointee_type_class=self._pointee_type_class)
+            view._fetch_owner = self
+            self._declared_view = view
+        return self._declared_view
 
     def GetNumChildren(self):
+        if self._synthetic_child_count is not None:
+            return self._synthetic_child_count
         return len(self._children)
 
     def GetChildAtIndex(self, index):
+        self._fetch_owner.child_fetches += 1
+        if self._synthetic_child_count is not None:
+            return FakeSBValue('[%d]' % index, self._element_typename)
         return self._children[index]
 
     def set_children(self, children):

--- a/resources/oidmcp/tests/test_lldbbridge.py
+++ b/resources/oidmcp/tests/test_lldbbridge.py
@@ -457,3 +457,31 @@ def test_importing_with_an_inert_lldb_does_not_raise(monkeypatch):
     monkeypatch.delitem(sys.modules, 'oidscripts.debuggers.lldbbridge')
 
     importlib.import_module('oidscripts.debuggers.lldbbridge')
+
+
+def test_type_class_mask_follows_a_later_real_lldb(monkeypatch):
+    """The mask must come from the lldb in force now, not at import.
+
+    A module-level `import lldb` binds once and permanently, so a module
+    imported while lldb was inert keeps reading the inert one even after a
+    real lldb is in place. The mask would stay empty, no value would be
+    descended into, and buffers held as struct members would go missing
+    from the listing with nothing reported.
+    """
+    import importlib
+    import sys
+    import types
+
+    monkeypatch.setitem(sys.modules, 'lldb', types.ModuleType('lldb'))
+    monkeypatch.delitem(sys.modules, 'oidscripts.debuggers.lldbbridge')
+    imported_while_inert = importlib.import_module(
+        'oidscripts.debuggers.lldbbridge')
+
+    real = types.ModuleType('lldb')
+    real.eTypeClassStruct = 16384
+    real.eTypeClassClass = 8
+    real.eTypeClassUnion = 65536
+    monkeypatch.setitem(sys.modules, 'lldb', real)
+
+    assert imported_while_inert._member_bearing_type_classes() == (
+        16384 | 8 | 65536)

--- a/resources/oidmcp/tests/test_lldbbridge.py
+++ b/resources/oidmcp/tests/test_lldbbridge.py
@@ -438,3 +438,22 @@ def test_evaluate_expression_wraps_a_non_runtime_error_from_the_shared_evaluator
 
     with pytest.raises(RuntimeError):
         bridge.evaluate_expression('x')
+
+
+def test_importing_with_an_inert_lldb_does_not_raise(monkeypatch):
+    """An `lldb` that imports but carries nothing is a supported state.
+
+    A gdb interpreter can have a placeholder `lldb` on its path, and
+    current_host() relies on reaching the gdb probe in that case. Reading
+    any lldb attribute while this module is being imported turns that
+    supported state into a hard failure for callers that never touch the
+    lldb path at all.
+    """
+    import importlib
+    import sys
+    import types
+
+    monkeypatch.setitem(sys.modules, 'lldb', types.ModuleType('lldb'))
+    monkeypatch.delitem(sys.modules, 'oidscripts.debuggers.lldbbridge')
+
+    importlib.import_module('oidscripts.debuggers.lldbbridge')

--- a/resources/oidmcp/tests/test_lldbbridge.py
+++ b/resources/oidmcp/tests/test_lldbbridge.py
@@ -12,6 +12,7 @@ import sys
 
 import pytest
 from conftest import (
+    LLDB,
     FakeDebugger,
     FakeFrame,
     FakeSBType,
@@ -270,6 +271,100 @@ def test_observable_symbols_visits_both_siblings_through_the_same_type():
     found = _observable_names(root, observable_typenames={'Buffer'})
 
     assert found == {'root.a.image', 'root.b.image'}
+
+
+# --- the descent's cost must scale with how many symbols a frame has, not
+# with how much data they hold. A value with a data formatter serves its
+# ELEMENTS as children, so enumerating them costs one wrap and one type
+# test per element (three seconds, on a frame holding one small image),
+# and no element can be a hit the containing value would not already be.
+
+def _container_local(element_count):
+    """A container-shaped local: `element_count` formatter-provided
+    elements over three declared members. That is the shape lldb reports
+    for a std::vector, whose non-synthetic view is the three pointers
+    __begin_/__end_/__end_cap_ however many bytes it holds. Elements are
+    given an observable type, so a walk that enumerates them is caught by
+    what it emits as well as by what it fetches."""
+    members = [FakeSBValue(member_name, 'unsigned char *',
+                           type_class=LLDB.eTypeClassPointer)
+               for member_name in ('__begin_', '__end_', '__end_cap_')]
+    return FakeSBValue('backing', 'std::vector<unsigned char>',
+                       children=members,
+                       synthetic_child_count=element_count,
+                       element_typename='Buffer')
+
+
+def test_a_sequence_shaped_value_is_not_enumerated():
+    backing = _container_local(element_count=100_000)
+
+    found = _observable_names(backing, observable_typenames={'Buffer'})
+
+    # Not one element fetched, and none emitted: an element is reached by
+    # subscripting the container, which no name the walk can spell does.
+    assert backing.child_fetches == 3
+    assert found == set()
+
+
+def test_child_fetches_do_not_grow_with_the_child_count():
+    small = _container_local(element_count=1_000)
+    large = _container_local(element_count=100_000)
+
+    _observable_names(small, observable_typenames={'Buffer'})
+    _observable_names(large, observable_typenames={'Buffer'})
+
+    # A hundredfold more data, the same amount of work.
+    assert large.child_fetches == small.child_fetches
+
+
+def test_an_array_valued_member_is_not_enumerated():
+    # An array's children are declared, not formatter-provided, so the
+    # non-synthetic view does not rescue this one: the type class has to.
+    elements = [FakeSBValue('[%d]' % index, 'Buffer') for index in range(500)]
+    pixels = FakeSBValue('pixels', 'unsigned char[500]', children=elements,
+                         type_class=LLDB.eTypeClassArray)
+    holder = FakeSBValue('holder', 'Holder', children=[pixels])
+
+    found = _observable_names(holder, observable_typenames={'Buffer'})
+
+    assert pixels.child_fetches == 0
+    assert found == set()
+
+
+def test_a_buffer_held_as_a_struct_member_is_still_found_beside_a_container():
+    # The member-held buffer is the reason the descent exists. A refused
+    # sibling must not end the walk, nor cost the struct its own members.
+    image = FakeSBValue('image', 'Buffer')
+    holder = FakeSBValue('holder', 'Holder',
+                         children=[_container_local(element_count=100_000),
+                                   image])
+
+    found = _observable_names(holder, observable_typenames={'Buffer'})
+
+    assert 'holder.image' in found
+
+
+def test_a_member_of_this_still_surfaces_bare():
+    # `this` is a pointer, and lldb serves a pointer-to-class's children
+    # as the pointee's members; observable_symbols() drops the leading
+    # segment so the emitted name is one the frame can evaluate.
+    image = FakeSBValue('image', 'Buffer')
+    this = FakeSBValue('this', 'Holder *', children=[image],
+                       type_class=LLDB.eTypeClassPointer,
+                       pointee_type_class=LLDB.eTypeClassClass)
+
+    found = _observable_names(this, observable_typenames={'Buffer'})
+
+    assert found == {'image'}
+
+
+def test_a_scalar_local_is_not_descended_into():
+    # Nothing to find behind a builtin, and lldb reports one child for a
+    # pointer-to-scalar. Refusing both keeps the walk off the data.
+    scalar = FakeSBValue('width', 'int', type_class=LLDB.eTypeClassBuiltin)
+
+    assert _observable_names(scalar, observable_typenames={'Buffer'}) == set()
+    assert scalar.child_fetches == 0
 
 
 # --- LldbBridge.evaluate_expression / get_available_symbols: thin wrappers

--- a/resources/oidscripts/debuggers/lldbbridge.py
+++ b/resources/oidscripts/debuggers/lldbbridge.py
@@ -22,14 +22,27 @@ instance = None
 # JIT and its trouble resolving heavy templated types (e.g. Eigen).
 _PLAIN_IDENTIFIER_RE = re.compile(r'^[A-Za-z_]\w*$')
 
-# The type classes whose children are the type's own declared members.
-# Anything else (an array above all) has children that are elements, and
-# an element is reached by subscripting, which no name the member walk can
-# spell does. This is the same judgement the gdb path makes with
-# TYPE_CODE_STRUCT before calling fields().
-_MEMBER_BEARING_TYPE_CLASSES = (lldb.eTypeClassStruct |
-                                lldb.eTypeClassClass |
-                                lldb.eTypeClassUnion)
+def _member_bearing_type_classes():
+    # type: () -> int
+    """The type classes whose children are the type's own declared members.
+
+    Anything else (an array above all) has children that are elements, and
+    an element is reached by subscripting, which no name the member walk
+    can spell does. This is the same judgement the gdb path makes with
+    TYPE_CODE_STRUCT before calling fields().
+
+    Read here rather than at import, and with defaults, because an `lldb`
+    that imports and carries nothing is a state this project supports: a
+    gdb interpreter can have a placeholder on its path, and selecting gdb
+    depends on importing this module without incident. Touching an lldb
+    attribute at import turns that into a hard failure for callers that
+    never reach the lldb path at all. A mask of zero then means no value
+    is descended into, which costs nothing: there is no live process to
+    descend in.
+    """
+    return (getattr(lldb, 'eTypeClassStruct', 0) |
+            getattr(lldb, 'eTypeClassClass', 0) |
+            getattr(lldb, 'eTypeClassUnion', 0))
 
 
 def frame_from_debugger(debugger):
@@ -102,7 +115,7 @@ def _children_are_declared_members(symbol):
         if not symbol_type.IsValid():
             return False
         symbol_type = symbol_type.GetCanonicalType()
-    return bool(symbol_type.GetTypeClass() & _MEMBER_BEARING_TYPE_CLASSES)
+    return bool(symbol_type.GetTypeClass() & _member_bearing_type_classes())
 
 
 def _walk_members(symbol, member_name_chain, visited_typenames, type_bridge,

--- a/resources/oidscripts/debuggers/lldbbridge.py
+++ b/resources/oidscripts/debuggers/lldbbridge.py
@@ -22,6 +22,15 @@ instance = None
 # JIT and its trouble resolving heavy templated types (e.g. Eigen).
 _PLAIN_IDENTIFIER_RE = re.compile(r'^[A-Za-z_]\w*$')
 
+# The type classes whose children are the type's own declared members.
+# Anything else (an array above all) has children that are elements, and
+# an element is reached by subscripting, which no name the member walk can
+# spell does. This is the same judgement the gdb path makes with
+# TYPE_CODE_STRUCT before calling fields().
+_MEMBER_BEARING_TYPE_CLASSES = (lldb.eTypeClassStruct |
+                                lldb.eTypeClassClass |
+                                lldb.eTypeClassUnion)
+
 
 def frame_from_debugger(debugger):
     # type: (lldb.SBDebugger) -> lldb.SBFrame
@@ -74,6 +83,28 @@ def evaluate_in_frame(frame, expression):
     return SymbolWrapper(result)
 
 
+def _children_are_declared_members(symbol):
+    # type: (lldb.SBValue) -> bool
+    """Whether `symbol`'s children are its type's declared members rather
+    than the elements of a sequence.
+
+    Pointers and references peel first: `this` is a pointer, and lldb
+    serves a pointer-to-class's children as the pointee's members, which
+    is the only reason a member of `this` surfaces at all."""
+    symbol_type = symbol.GetType()
+    if not symbol_type.IsValid():
+        return False
+    symbol_type = symbol_type.GetCanonicalType()
+    while symbol_type.IsPointerType() or symbol_type.IsReferenceType():
+        symbol_type = symbol_type.GetPointeeType() \
+            if symbol_type.IsPointerType() \
+            else symbol_type.GetDereferencedType()
+        if not symbol_type.IsValid():
+            return False
+        symbol_type = symbol_type.GetCanonicalType()
+    return bool(symbol_type.GetTypeClass() & _MEMBER_BEARING_TYPE_CLASSES)
+
+
 def _walk_members(symbol, member_name_chain, visited_typenames, type_bridge,
                    record_hit):
     # type: (lldb.SBValue, list, frozenset, TypeInspectorInterface, callable) -> None
@@ -81,14 +112,24 @@ def _walk_members(symbol, member_name_chain, visited_typenames, type_bridge,
     `record_hit(qualified_name, SymbolWrapper)` for each observable one."""
     if symbol.GetTypeName() in visited_typenames:
         return  # this type is already on the path from the root
+    if not _children_are_declared_members(symbol):
+        return  # a sequence, a scalar: no named member to reach
     # Mark this symbol's type, not the child's, before descending: the
     # latter trips the recursive call's own guard on its first check,
     # stopping traversal after one hop. Copy rather than mutate, so
     # sibling branches don't block each other from descending a type.
     visited_typenames = visited_typenames | {symbol.GetTypeName()}
 
-    for member_idx in range(symbol.GetNumChildren()):
-        symbol_member = symbol.GetChildAtIndex(member_idx)
+    # The value as the compiler declares it. A data formatter's children
+    # are its own invention: a std::vector's children ARE its elements,
+    # 57600 of them for a 160x120x3 image, so walking the formatted view
+    # makes listing a frame's symbols cost one wrap and one type test per
+    # element of every container in scope. The non-synthetic view of that
+    # same vector has three children however many bytes it holds.
+    declared = symbol.GetNonSyntheticValue()
+
+    for member_idx in range(declared.GetNumChildren()):
+        symbol_member = declared.GetChildAtIndex(member_idx)
         chain = member_name_chain + [str(symbol_member.name)]
         wrapped = SymbolWrapper(symbol_member)
         if type_bridge.is_symbol_observable(wrapped, symbol_member.name):

--- a/resources/oidscripts/debuggers/lldbbridge.py
+++ b/resources/oidscripts/debuggers/lldbbridge.py
@@ -40,6 +40,14 @@ def _member_bearing_type_classes():
     is descended into, which costs nothing: there is no live process to
     descend in.
     """
+    # Local, not the module-level name, for the same reason
+    # frame_from_debugger takes one: that name binds once, permanently, to
+    # whatever was in sys.modules the first time this module was imported.
+    # A module imported while lldb was inert would keep reading the inert
+    # one after a real lldb arrived, the mask would stay empty, nothing
+    # would be descended into, and buffers held as members would vanish
+    # from the listing with nothing said.
+    import lldb
     return (getattr(lldb, 'eTypeClassStruct', 0) |
             getattr(lldb, 'eTypeClassClass', 0) |
             getattr(lldb, 'eTypeClassUnion', 0))


### PR DESCRIPTION
Listing the symbols you can plot got slower the more image data was in scope, which is backwards: the list of names does not depend on how big the images are. On a frame holding a few full size buffers it took about three seconds. The same seventeen symbols with small buffers took a fraction of that.

The scan descends into a value's children to find buffers held as struct or class members. Under a data formatter a container's children are its elements, so a vector holding one 160x120x3 image was visited 57600 times, and none of those visits could ever find a member.

It now reads values as the compiler declares them, and descends only where there are declared members to find. A container is looked at as many times as it has fields rather than bytes.

Measured on a stopped process: 3.1 seconds to 6 milliseconds, returning the same names in the same order.

One visible change: element names such as `vec.[3]` are no longer listed. They could never be resolved back to a buffer, so nothing plottable is lost.