### PR TITLE
fix: an invalid pixel layout never overwrites a valid one

### DIFF
--- a/src/host/agent/native_view_model.cpp
+++ b/src/host/agent/native_view_model.cpp
@@ -25,7 +25,6 @@
 
 #include "host/agent/native_view_model.h"
 
-#include <array>
 #include <cmath>
 #include <iostream>
 #include <numbers>
@@ -65,9 +64,11 @@ double normalize_degrees(const double radians) {
 
 // Pixel layout that isolates a single channel for Buffer's "specific
 // channel" display mode (set_display_channel_mode(1)): index 0/1/2 -> R/G/B.
+// Reads ISOLATION_LAYOUTS (natural_pixel_layout.h) rather than its own
+// literal array, so this and is_isolation_layout() can never drift apart on
+// what counts as an isolation swizzle.
 const char* isolated_layout(const int index) {
-    static constexpr std::array LAYOUTS{"rrra", "ggga", "bbba"};
-    return LAYOUTS[static_cast<std::size_t>(index)];
+    return ISOLATION_LAYOUTS[static_cast<std::size_t>(index)];
 }
 
 } // namespace
@@ -235,11 +236,22 @@ bool NativeViewModel::set_channel(const std::string_view name,
         // A guess is never stamped onto a buffer that already carries a
         // valid layout of its own: when the record cannot name a valid one
         // (see natural_pixel_layout.h), the buffer's current layout stays,
-        // loudly, rather than being overwritten with a default that may be
-        // wrong.
+        // loudly, unless that current layout is itself an isolation swizzle
+        // installed by the index arm below, in which case leaving it in
+        // place would contradict the very "all channels" switch being
+        // requested here, so the default is restored instead, loudly.
         const BufferRecord& record = model_.at(*idx);
-        if (const auto layout = natural_pixel_layout(record)) {
-            buffer->set_pixel_layout(*layout);
+        const std::string_view current_layout = buffer->get_pixel_layout();
+        if (const auto decision = natural_pixel_layout(record, current_layout);
+            decision.layout) {
+            if (decision.cleared_isolation) {
+                std::cerr << "[OID] set_channel(all) for '" << name
+                          << "': invalid pixel_layout '" << record.pixel_layout
+                          << "' on record; clearing the isolated '"
+                          << current_layout << "' layout, defaulting to '"
+                          << *decision.layout << "'\n";
+            }
+            buffer->set_pixel_layout(*decision.layout);
         } else {
             std::cerr << "[OID] set_channel(all) for '" << name
                       << "': invalid pixel_layout '" << record.pixel_layout

--- a/src/host/agent/native_view_model.cpp
+++ b/src/host/agent/native_view_model.cpp
@@ -32,6 +32,7 @@
 #include "host/agent/natural_pixel_layout.h"
 #include "host/agent/wire_buffer_type.h"
 #include "host/ui/panels/panel_accessors.h"
+#include "host/util/log_preview.h"
 #include "visualization/components/buffer.h"
 #include "visualization/components/camera.h"
 
@@ -245,16 +246,21 @@ bool NativeViewModel::set_channel(const std::string_view name,
         if (const auto decision = natural_pixel_layout(record, current_layout);
             decision.layout) {
             if (decision.cleared_isolation) {
-                std::cerr << "[OID] set_channel(all) for '" << name
-                          << "': invalid pixel_layout '" << record.pixel_layout
+                std::cerr << "[OID] set_channel(all) for '"
+                          << log_preview(name, NAME_PREVIEW_CHARS)
+                          << "': invalid pixel_layout '"
+                          << log_preview(record.pixel_layout)
                           << "' on record; clearing the isolated '"
-                          << current_layout << "' layout, defaulting to '"
-                          << *decision.layout << "'\n";
+                          << log_preview(current_layout)
+                          << "' layout, defaulting to '" << *decision.layout
+                          << "'\n";
             }
             buffer->set_pixel_layout(*decision.layout);
         } else {
-            std::cerr << "[OID] set_channel(all) for '" << name
-                      << "': invalid pixel_layout '" << record.pixel_layout
+            std::cerr << "[OID] set_channel(all) for '"
+                      << log_preview(name, NAME_PREVIEW_CHARS)
+                      << "': invalid pixel_layout '"
+                      << log_preview(record.pixel_layout)
                       << "' on record; keeping the buffer's current layout\n";
         }
         buffer->set_display_channel_mode(-1);

--- a/src/host/agent/native_view_model.cpp
+++ b/src/host/agent/native_view_model.cpp
@@ -27,8 +27,10 @@
 
 #include <array>
 #include <cmath>
+#include <iostream>
 #include <numbers>
 
+#include "host/agent/natural_pixel_layout.h"
 #include "host/agent/wire_buffer_type.h"
 #include "host/ui/panels/panel_accessors.h"
 #include "visualization/components/buffer.h"
@@ -66,20 +68,6 @@ double normalize_degrees(const double radians) {
 const char* isolated_layout(const int index) {
     static constexpr std::array LAYOUTS{"rrra", "ggga", "bbba"};
     return LAYOUTS[static_cast<std::size_t>(index)];
-}
-
-// Layout restored by set_channel(-1, _) ("all"): the buffer's own declared
-// pixel_layout when it's a valid 4-char string, else Buffer's own default
-// ("rgba").
-std::string natural_layout(const BufferRecord& record) {
-    // Mirror Buffer::set_pixel_layout()'s validation so the restore call can
-    // never no-op and leave a stale isolated layout installed when a buffer
-    // declares a 4-char-but-invalid pixel_layout (reachable via a custom
-    // Python type bridge, an unvalidated external input).
-    const bool valid =
-        record.pixel_layout.size() == 4 &&
-        record.pixel_layout.find_first_not_of("rgba") == std::string::npos;
-    return valid ? record.pixel_layout : "rgba";
 }
 
 } // namespace
@@ -244,7 +232,19 @@ bool NativeViewModel::set_channel(const std::string_view name,
     }
 
     if (mode == -1) {
-        buffer->set_pixel_layout(natural_layout(model_.at(*idx)));
+        // A guess is never stamped onto a buffer that already carries a
+        // valid layout of its own: when the record cannot name a valid one
+        // (see natural_pixel_layout.h), the buffer's current layout stays,
+        // loudly, rather than being overwritten with a default that may be
+        // wrong.
+        const BufferRecord& record = model_.at(*idx);
+        if (const auto layout = natural_pixel_layout(record)) {
+            buffer->set_pixel_layout(*layout);
+        } else {
+            std::cerr << "[OID] set_channel(all) for '" << name
+                      << "': invalid pixel_layout '" << record.pixel_layout
+                      << "' on record; keeping the buffer's current layout\n";
+        }
         buffer->set_display_channel_mode(-1);
         return true;
     }

--- a/src/host/agent/natural_pixel_layout.h
+++ b/src/host/agent/natural_pixel_layout.h
@@ -26,20 +26,53 @@
 #ifndef HOST_AGENT_NATURAL_PIXEL_LAYOUT_H_
 #define HOST_AGENT_NATURAL_PIXEL_LAYOUT_H_
 
+#include <algorithm>
+#include <array>
 #include <optional>
 #include <string>
+#include <string_view>
 
 #include "host/ui/buffer_model.h"
 
 namespace oid::host::agent {
 
-// The layout set_channel(-1, _) ("all") should restore on the live buffer, or
-// nullopt when there is nothing valid to restore and the caller must leave
-// the buffer's current layout untouched instead of guessing one.
+// The three pixel layouts set_channel(name, index, _) installs to isolate a
+// single channel for display (index 0/1/2 -> R/G/B; Buffer::set_pixel_layout()
+// then swizzles the shader to read only that duplicated component). The
+// single source of truth for what counts as an isolation swizzle:
+// isolated_layout() (native_view_model.cpp, which installs these) and
+// is_isolation_layout() below (which recognizes them) both read this same
+// array, so the two can never drift apart.
+inline constexpr std::array<const char*, 3> ISOLATION_LAYOUTS{
+    "rrra", "ggga", "bbba"};
+
+// Whether `layout` is one of the three isolation swizzles above.
+[[nodiscard]] inline bool is_isolation_layout(const std::string_view layout) {
+    return std::ranges::any_of(
+        ISOLATION_LAYOUTS, [layout](const char* iso) { return layout == iso; });
+}
+
+// The outcome of deciding what set_channel(-1, _) ("all") should do to the
+// live buffer.
+struct NaturalPixelLayoutResult {
+    // The layout to apply, or nullopt to leave the buffer's current layout
+    // untouched.
+    std::optional<std::string> layout;
+    // True only when `layout` is populated because the buffer's current
+    // layout was itself an isolation swizzle: worth logging on its own,
+    // since clearing that swizzle (not just avoiding a guess) is what makes
+    // "all channels" actually exit isolation for a record with no valid
+    // layout of its own.
+    bool cleared_isolation = false;
+};
+
+// Decides what set_channel(-1, _) ("all") should do to the live buffer,
+// given its model record and the layout the buffer currently renders with.
 //
 // A record's own declared layout is used whenever it is valid. Otherwise,
-// the record's kind is what tells a legitimate "no layout to declare" apart
-// from corruption, not its channel count alone:
+// the record's kind (and, for a DEBUGGER_SYMBOL record whose declared
+// layout is invalid, the buffer's current layout) is what tells a
+// legitimate "no layout to declare" apart from corruption:
 //
 // - A LOCAL_FILE record (opened directly from a file, never wire-validated)
 //   gets DEFAULT_PIXEL_LAYOUT whatever its channel count. layout_for_channels()
@@ -53,29 +86,36 @@ namespace oid::host::agent {
 //   order is meaningless for one channel (shader_pixel_layout.h always
 //   renders a single-channel buffer from red), so an invalid (typically
 //   empty) layout here is not a corruption either.
-// - Only a DEBUGGER_SYMBOL record with more than one channel and an invalid
-//   layout is corrupt data, not a format choice: post-fix,
-//   IpcClient::resolve_pixel_layout guarantees a multi-channel
-//   DEBUGGER_SYMBOL record is always either valid or already defaulted, so
-//   one reaching here with an invalid layout means the live buffer may
-//   already be rendering a valid layout of its own (set explicitly via the
-//   Format combo, or preserved across a replot by Buffer::configure()'s own
-//   guard) that the record just fails to reflect. Returning nullopt tells
-//   the caller to leave it alone rather than stamp a guessed default over
-//   it.
+// - A DEBUGGER_SYMBOL record with more than one channel and an invalid
+//   layout is corrupt data, not a format choice, unless the buffer's
+//   current layout is itself an isolation swizzle: leaving that installed
+//   would contradict the very "all channels" switch being requested, so the
+//   default is restored instead, loudly (the caller names which swizzle was
+//   cleared). Otherwise, the live buffer may already be rendering a valid
+//   layout of its own (set explicitly via the Format combo, or preserved
+//   across a replot by Buffer::configure()'s own guard) that the record
+//   just fails to reflect: post-fix, IpcClient::resolve_pixel_layout
+//   guarantees a multi-channel DEBUGGER_SYMBOL record is always either
+//   valid or already defaulted, so an invalid one reaching here with a
+//   non-isolated current layout really is residue, and nullopt tells the
+//   caller to leave it alone rather than stamp a guessed default over it.
 //
 // Kept as a free function, independent of BufferRecord's Buffer/Stage/GL
 // neighbors, so it is testable without the render-thread-bound
 // NativeViewModel (mirrors wire_buffer_type.h's rationale).
-[[nodiscard]] inline std::optional<std::string>
-natural_pixel_layout(const BufferRecord& record) {
+[[nodiscard]] inline NaturalPixelLayoutResult
+natural_pixel_layout(const BufferRecord& record,
+                     const std::string_view current_layout) {
     if (is_valid_pixel_layout(record.pixel_layout)) {
-        return record.pixel_layout;
+        return {record.pixel_layout, false};
     }
     if (record.kind == BufferKind::LOCAL_FILE || record.channels == 1) {
-        return std::string(DEFAULT_PIXEL_LAYOUT);
+        return {std::string(DEFAULT_PIXEL_LAYOUT), false};
     }
-    return std::nullopt;
+    if (is_isolation_layout(current_layout)) {
+        return {std::string(DEFAULT_PIXEL_LAYOUT), true};
+    }
+    return {std::nullopt, false};
 }
 
 } // namespace oid::host::agent

--- a/src/host/agent/natural_pixel_layout.h
+++ b/src/host/agent/natural_pixel_layout.h
@@ -1,0 +1,83 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef HOST_AGENT_NATURAL_PIXEL_LAYOUT_H_
+#define HOST_AGENT_NATURAL_PIXEL_LAYOUT_H_
+
+#include <optional>
+#include <string>
+
+#include "host/ui/buffer_model.h"
+
+namespace oid::host::agent {
+
+// The layout set_channel(-1, _) ("all") should restore on the live buffer, or
+// nullopt when there is nothing valid to restore and the caller must leave
+// the buffer's current layout untouched instead of guessing one.
+//
+// A record's own declared layout is used whenever it is valid. Otherwise,
+// the record's kind is what tells a legitimate "no layout to declare" apart
+// from corruption, not its channel count alone:
+//
+// - A LOCAL_FILE record (opened directly from a file, never wire-validated)
+//   gets DEFAULT_PIXEL_LAYOUT whatever its channel count. layout_for_channels()
+//   (file_buffer_loader.cpp) legitimately returns an empty layout for any
+//   non-4-channel image, not only single-channel ones (a plain 3-channel RGB
+//   file is the common case), and main.cpp's file-open path upserts straight
+//   into the model, bypassing IpcClient::resolve_pixel_layout entirely, so
+//   nothing else ever fills this in. The default is exactly what such a
+//   buffer already renders with, not a guess.
+// - A DEBUGGER_SYMBOL single-channel record gets the same default: channel
+//   order is meaningless for one channel (shader_pixel_layout.h always
+//   renders a single-channel buffer from red), so an invalid (typically
+//   empty) layout here is not a corruption either.
+// - Only a DEBUGGER_SYMBOL record with more than one channel and an invalid
+//   layout is corrupt data, not a format choice: post-fix,
+//   IpcClient::resolve_pixel_layout guarantees a multi-channel
+//   DEBUGGER_SYMBOL record is always either valid or already defaulted, so
+//   one reaching here with an invalid layout means the live buffer may
+//   already be rendering a valid layout of its own (set explicitly via the
+//   Format combo, or preserved across a replot by Buffer::configure()'s own
+//   guard) that the record just fails to reflect. Returning nullopt tells
+//   the caller to leave it alone rather than stamp a guessed default over
+//   it.
+//
+// Kept as a free function, independent of BufferRecord's Buffer/Stage/GL
+// neighbors, so it is testable without the render-thread-bound
+// NativeViewModel (mirrors wire_buffer_type.h's rationale).
+[[nodiscard]] inline std::optional<std::string>
+natural_pixel_layout(const BufferRecord& record) {
+    if (is_valid_pixel_layout(record.pixel_layout)) {
+        return record.pixel_layout;
+    }
+    if (record.kind == BufferKind::LOCAL_FILE || record.channels == 1) {
+        return std::string(DEFAULT_PIXEL_LAYOUT);
+    }
+    return std::nullopt;
+}
+
+} // namespace oid::host::agent
+
+#endif // HOST_AGENT_NATURAL_PIXEL_LAYOUT_H_

--- a/src/host/ipc/ipc_client.cpp
+++ b/src/host/ipc/ipc_client.cpp
@@ -429,6 +429,13 @@ std::string IpcClient::resolve_pixel_layout(const std::string_view context,
         if (model_.variable_name_of(i) != variable_name) {
             continue;
         }
+        // The kept layout was declared for the record's shape: a replot
+        // that changes the channel count invalidates that premise (the
+        // preserved swizzle would address components the new texture does
+        // not have), so a reshaping replot falls through to the default.
+        if (model_.at(i).channels != channels) {
+            break;
+        }
         if (const std::string& kept = model_.at(i).pixel_layout;
             is_valid_pixel_layout(kept)) {
             std::cerr << "[OID] " << context << " for '"

--- a/src/host/ipc/ipc_client.cpp
+++ b/src/host/ipc/ipc_client.cpp
@@ -200,6 +200,10 @@ void IpcClient::handle_plot_buffer_contents() const {
                   << variable_name << "': payload too small for geometry\n";
         return;
     }
+    pixel_layout = resolve_pixel_layout("PLOT_BUFFER_CONTENTS",
+                                        variable_name,
+                                        std::move(pixel_layout),
+                                        channels);
     model_.upsert(make_buffer_record({.variable_name = std::move(variable_name),
                                       .display_name = std::move(display_name),
                                       .pixel_layout = std::move(pixel_layout),
@@ -308,6 +312,11 @@ void IpcClient::handle_plot_buffer_end() {
     // with nothing in flight is a stray, not a genuine incomplete transfer.
     const bool was_in_progress = assembler_.has_in_progress(name);
     if (auto assembled = assembler_.end(name)) {
+        assembled->pixel_layout =
+            resolve_pixel_layout("PLOT_BUFFER_END",
+                                 assembled->variable_name,
+                                 std::move(assembled->pixel_layout),
+                                 assembled->channels);
         model_.upsert(make_buffer_record(
             {.variable_name = std::move(assembled->variable_name),
              .display_name = std::move(assembled->display_name),
@@ -394,6 +403,47 @@ const std::vector<std::string>& IpcClient::available_symbols() const {
 
 void IpcClient::set_restore_buffers(std::vector<PreviousBuffer> buffers) {
     restore_buffers_ = std::move(buffers);
+}
+
+std::string IpcClient::resolve_pixel_layout(const std::string_view context,
+                                            const std::string& variable_name,
+                                            std::string declared_layout,
+                                            const int channels) const {
+    // Channel order is meaningless for one channel (shader_pixel_layout.h
+    // always renders a single-channel buffer from red regardless): a
+    // single-channel record's declared layout, empty or not, is the
+    // documented convention, not a corruption, and is used exactly as it
+    // arrives.
+    if (channels == 1) {
+        return declared_layout;
+    }
+    if (is_valid_pixel_layout(declared_layout)) {
+        return declared_layout;
+    }
+    // An invalid layout for a multi-channel buffer never overwrites a valid
+    // one already on record: replacing it would be exactly the silent
+    // corruption this guards against (the render survives only by accident,
+    // until anything re-derives from the record).
+    for (std::size_t i = 0; i < model_.size(); ++i) {
+        if (model_.variable_name_of(i) != variable_name) {
+            continue;
+        }
+        if (const std::string& kept = model_.at(i).pixel_layout;
+            is_valid_pixel_layout(kept)) {
+            std::cerr << "[OID] " << context << " for '" << variable_name
+                      << "': invalid pixel_layout '" << declared_layout
+                      << "'; keeping the existing '" << kept << "' layout\n";
+            return kept;
+        }
+        break;
+    }
+    // Nothing valid to keep either (first plot ever, or an equally invalid
+    // existing record): fall back to the documented default, loudly.
+    std::cerr << "[OID] " << context << " for '" << variable_name
+              << "': invalid pixel_layout '" << declared_layout << "' for a "
+              << channels << "-channel buffer; defaulting to \""
+              << DEFAULT_PIXEL_LAYOUT << "\"\n";
+    return std::string(DEFAULT_PIXEL_LAYOUT);
 }
 
 bool IpcClient::model_has(const std::string_view variable_name) const {

--- a/src/host/ipc/ipc_client.cpp
+++ b/src/host/ipc/ipc_client.cpp
@@ -35,6 +35,7 @@
 
 #include "host/ipc/buffer_decode.h"
 #include "host/settings/app_settings.h"
+#include "host/util/log_preview.h"
 #include "ipc/raw_data_decode.h"
 
 namespace oid::host {
@@ -430,8 +431,10 @@ std::string IpcClient::resolve_pixel_layout(const std::string_view context,
         }
         if (const std::string& kept = model_.at(i).pixel_layout;
             is_valid_pixel_layout(kept)) {
-            std::cerr << "[OID] " << context << " for '" << variable_name
-                      << "': invalid pixel_layout '" << declared_layout
+            std::cerr << "[OID] " << context << " for '"
+                      << log_preview(variable_name, NAME_PREVIEW_CHARS)
+                      << "': invalid pixel_layout '"
+                      << log_preview(declared_layout)
                       << "'; keeping the existing '" << kept << "' layout\n";
             return kept;
         }
@@ -439,9 +442,10 @@ std::string IpcClient::resolve_pixel_layout(const std::string_view context,
     }
     // Nothing valid to keep either (first plot ever, or an equally invalid
     // existing record): fall back to the documented default, loudly.
-    std::cerr << "[OID] " << context << " for '" << variable_name
-              << "': invalid pixel_layout '" << declared_layout << "' for a "
-              << channels << "-channel buffer; defaulting to \""
+    std::cerr << "[OID] " << context << " for '"
+              << log_preview(variable_name, NAME_PREVIEW_CHARS)
+              << "': invalid pixel_layout '" << log_preview(declared_layout)
+              << "' for a " << channels << "-channel buffer; defaulting to \""
               << DEFAULT_PIXEL_LAYOUT << "\"\n";
     return std::string(DEFAULT_PIXEL_LAYOUT);
 }

--- a/src/host/ipc/ipc_client.cpp
+++ b/src/host/ipc/ipc_client.cpp
@@ -425,27 +425,25 @@ std::string IpcClient::resolve_pixel_layout(const std::string_view context,
     // one already on record: replacing it would be exactly the silent
     // corruption this guards against (the render survives only by accident,
     // until anything re-derives from the record).
+    const BufferRecord* existing = nullptr;
     for (std::size_t i = 0; i < model_.size(); ++i) {
-        if (model_.variable_name_of(i) != variable_name) {
-            continue;
-        }
-        // The kept layout was declared for the record's shape: a replot
-        // that changes the channel count invalidates that premise (the
-        // preserved swizzle would address components the new texture does
-        // not have), so a reshaping replot falls through to the default.
-        if (model_.at(i).channels != channels) {
+        if (model_.variable_name_of(i) == variable_name) {
+            existing = &model_.at(i);
             break;
         }
-        if (const std::string& kept = model_.at(i).pixel_layout;
-            is_valid_pixel_layout(kept)) {
-            std::cerr << "[OID] " << context << " for '"
-                      << log_preview(variable_name, NAME_PREVIEW_CHARS)
-                      << "': invalid pixel_layout '"
-                      << log_preview(declared_layout)
-                      << "'; keeping the existing '" << kept << "' layout\n";
-            return kept;
-        }
-        break;
+    }
+    // The kept layout was declared for the record's shape: a replot that
+    // changes the channel count invalidates that premise (the preserved
+    // swizzle would address components the new texture does not have), so
+    // a reshaping replot falls through to the default.
+    if (existing != nullptr && existing->channels == channels &&
+        is_valid_pixel_layout(existing->pixel_layout)) {
+        const std::string& kept = existing->pixel_layout;
+        std::cerr << "[OID] " << context << " for '"
+                  << log_preview(variable_name, NAME_PREVIEW_CHARS)
+                  << "': invalid pixel_layout '" << log_preview(declared_layout)
+                  << "'; keeping the existing '" << kept << "' layout\n";
+        return kept;
     }
     // Nothing valid to keep either (first plot ever, or an equally invalid
     // existing record): fall back to the documented default, loudly.

--- a/src/host/ipc/ipc_client.h
+++ b/src/host/ipc/ipc_client.h
@@ -116,6 +116,22 @@ class IpcClient {
 
     [[nodiscard]] bool model_has(std::string_view variable_name) const;
 
+    // Decides the pixel_layout a PLOT_BUFFER_CONTENTS/PLOT_BUFFER_END should
+    // actually be upserted with, given what it arrived with. A single-channel
+    // buffer's declared layout is used as-is (see BufferRecord::pixel_layout,
+    // buffer_model.h; empty is legitimate there). For every other channel
+    // count, an invalid `declared_layout` is never upserted verbatim: it
+    // keeps the existing record's layout if that one is valid, or falls back
+    // to DEFAULT_PIXEL_LAYOUT if not (first plot ever, or an equally invalid
+    // existing record). Either fallback logs to stderr via `context` (e.g.
+    // "PLOT_BUFFER_CONTENTS" or "PLOT_BUFFER_END") so the substitution is
+    // never silent.
+    [[nodiscard]] std::string
+    resolve_pixel_layout(std::string_view context,
+                         const std::string& variable_name,
+                         std::string declared_layout,
+                         int channels) const;
+
     // Sends `composer` over transport_, catching and swallowing
     // std::runtime_error. Mirrors poll()'s tolerance of transport errors on
     // the inbound side: if the peer is gone (e.g. viewer opened with no

--- a/src/host/ui/buffer_model.h
+++ b/src/host/ui/buffer_model.h
@@ -32,6 +32,7 @@
 #include <format>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -66,6 +67,30 @@ struct BufferRecord {
     std::vector<std::byte> bytes;
     BufferKind kind{BufferKind::DEBUGGER_SYMBOL};
 };
+
+// A pixel_layout naming an actual channel order: exactly four characters,
+// each one of 'r', 'g', 'b' or 'a'. This is the mechanical floor
+// Buffer::set_pixel_layout() enforces before copying the string (it writes
+// exactly four bytes) and the alphabet buffer_fs.cpp's fragment shader
+// swizzles by, so a layout failing this check cannot be handed to either one.
+// It is deliberately not what pixel_layout's empty-for-single-channel
+// convention above satisfies: an empty layout is a legitimate "no channel
+// order" for a single-channel buffer, not a layout to validate, so callers
+// that must tell the two apart check channel count themselves alongside
+// this predicate rather than folding it in here.
+[[nodiscard]] constexpr bool
+is_valid_pixel_layout(const std::string_view layout) {
+    return layout.size() == 4 &&
+           layout.find_first_not_of("rgba") == std::string_view::npos;
+}
+
+// The layout a buffer renders with when nothing valid is available to keep:
+// a fresh single-channel buffer (channel order is meaningless for one
+// channel, so this is the documented default, not a guess), or a
+// multi-channel buffer's very first plot arriving with an invalid layout
+// (nothing legitimate has ever been recorded for it to fall back on
+// instead). Every caller that applies this default says so on stderr.
+constexpr std::string_view DEFAULT_PIXEL_LAYOUT = "rgba";
 
 // Read-only view over the set of buffers the chrome should list.
 // IpcBufferModel is backed by live IPC state; MockBufferModel below is the

--- a/src/host/util/log_preview.h
+++ b/src/host/util/log_preview.h
@@ -55,7 +55,8 @@ inline constexpr std::size_t NAME_PREVIEW_CHARS = 64;
         truncated ? value.substr(0, max_chars) : value;
     std::string out;
     out.reserve(shown.size() + 16);
-    for (const char c : shown) {
+    for (std::size_t i = 0; i < shown.size(); ++i) {
+        const char c = shown[i];
         switch (c) {
         case '\n':
             out += "\\n";
@@ -67,8 +68,23 @@ inline constexpr std::size_t NAME_PREVIEW_CHARS = 64;
             out += "\\t";
             break;
         default:
-            if (const auto byte = static_cast<unsigned char>(c);
-                byte < 0x20 || byte == 0x7f) {
+            const auto byte = static_cast<unsigned char>(c);
+            // U+0080..U+009F (the C1 controls, CSI among them) arrive as
+            // the UTF-8 pairs 0xc2 0x80..0x9f: decoded, they steer a
+            // Unicode-aware consumer the way a C0 byte steers a plain one,
+            // and no scan of single bytes below 0x20 ever sees them. Only
+            // the exact pairs are rewritten: lone 0x80..0x9f bytes are the
+            // continuation bytes ordinary non-ASCII text is made of, and
+            // escaping those would mangle every such name.
+            if (byte == 0xc2 && i + 1 < shown.size()) {
+                if (const auto next = static_cast<unsigned char>(shown[i + 1]);
+                    next >= 0x80 && next <= 0x9f) {
+                    out += std::format("\\u{:04x}", next);
+                    ++i;
+                    continue;
+                }
+            }
+            if (byte < 0x20 || byte == 0x7f) {
                 out += std::format("\\x{:02x}", byte);
             } else {
                 out += c;

--- a/src/host/util/log_preview.h
+++ b/src/host/util/log_preview.h
@@ -39,6 +39,52 @@ namespace oid::host {
 // name still has to be findable in the debuggee.
 inline constexpr std::size_t NAME_PREVIEW_CHARS = 64;
 
+namespace detail {
+
+// Appends the escaped form of the character starting at text[i], answering
+// how many source bytes it consumed.
+//
+// C0 controls and DEL land as \xNN escapes. U+0080..U+009F (the C1
+// controls, CSI among them) arrive as the UTF-8 pairs 0xc2 0x80..0x9f:
+// decoded, they steer a Unicode-aware consumer the way a C0 byte steers a
+// plain one, and no scan of single bytes below 0x20 ever sees them, so
+// exactly those pairs land as \u00NN escapes. Lone 0x80..0x9f bytes pass
+// through: they are the continuation bytes ordinary non-ASCII text is made
+// of, and escaping those would mangle every such name.
+[[nodiscard]] inline std::size_t append_escaped(const std::string_view text,
+                                                const std::size_t i,
+                                                std::string& out) {
+    const char c = text[i];
+    if (c == '\n') {
+        out += "\\n";
+        return 1;
+    }
+    if (c == '\r') {
+        out += "\\r";
+        return 1;
+    }
+    if (c == '\t') {
+        out += "\\t";
+        return 1;
+    }
+    const auto byte = static_cast<unsigned char>(c);
+    if (byte == 0xc2 && i + 1 < text.size()) {
+        if (const auto next = static_cast<unsigned char>(text[i + 1]);
+            next >= 0x80 && next <= 0x9f) {
+            out += std::format("\\u{:04x}", next);
+            return 2;
+        }
+    }
+    if (byte < 0x20 || byte == 0x7f) {
+        out += std::format("\\x{:02x}", byte);
+        return 1;
+    }
+    out += c;
+    return 1;
+}
+
+} // namespace detail
+
 // Renders an untrusted string safe to interpolate into one log line.
 //
 // Two hazards, both closed here rather than at each call site: the value may
@@ -55,41 +101,9 @@ inline constexpr std::size_t NAME_PREVIEW_CHARS = 64;
         truncated ? value.substr(0, max_chars) : value;
     std::string out;
     out.reserve(shown.size() + 16);
-    for (std::size_t i = 0; i < shown.size(); ++i) {
-        const char c = shown[i];
-        switch (c) {
-        case '\n':
-            out += "\\n";
-            break;
-        case '\r':
-            out += "\\r";
-            break;
-        case '\t':
-            out += "\\t";
-            break;
-        default:
-            const auto byte = static_cast<unsigned char>(c);
-            // U+0080..U+009F (the C1 controls, CSI among them) arrive as
-            // the UTF-8 pairs 0xc2 0x80..0x9f: decoded, they steer a
-            // Unicode-aware consumer the way a C0 byte steers a plain one,
-            // and no scan of single bytes below 0x20 ever sees them. Only
-            // the exact pairs are rewritten: lone 0x80..0x9f bytes are the
-            // continuation bytes ordinary non-ASCII text is made of, and
-            // escaping those would mangle every such name.
-            if (byte == 0xc2 && i + 1 < shown.size()) {
-                if (const auto next = static_cast<unsigned char>(shown[i + 1]);
-                    next >= 0x80 && next <= 0x9f) {
-                    out += std::format("\\u{:04x}", next);
-                    ++i;
-                    continue;
-                }
-            }
-            if (byte < 0x20 || byte == 0x7f) {
-                out += std::format("\\x{:02x}", byte);
-            } else {
-                out += c;
-            }
-        }
+    std::size_t i = 0;
+    while (i < shown.size()) {
+        i += detail::append_escaped(shown, i, out);
     }
     if (truncated) {
         out += std::format("... ({} bytes)", value.size());

--- a/src/host/util/log_preview.h
+++ b/src/host/util/log_preview.h
@@ -1,0 +1,86 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef HOST_UTIL_LOG_PREVIEW_H_
+#define HOST_UTIL_LOG_PREVIEW_H_
+
+#include <cstddef>
+#include <format>
+#include <string>
+#include <string_view>
+
+namespace oid::host {
+
+// The bound for a variable name echoed into a diagnostic, one policy for
+// every diagnostic that echoes one: wider than log_preview()'s default,
+// since names are legitimately long where layouts are not, and a truncated
+// name still has to be findable in the debuggee.
+inline constexpr std::size_t NAME_PREVIEW_CHARS = 64;
+
+// Renders an untrusted string safe to interpolate into one log line.
+//
+// Two hazards, both closed here rather than at each call site: the value may
+// be arbitrarily long (the wire allows strings far larger than anything a
+// diagnostic should echo, so a preview plus the byte count replaces the
+// tail), and it may carry control characters (a newline forges an extra log
+// line, a terminal escape repaints the one it is on, so both land as visible
+// escapes instead). The bound is applied to the source before escaping, so
+// the escaped output stays within a small constant factor of `max_chars`.
+[[nodiscard]] inline std::string log_preview(const std::string_view value,
+                                             const std::size_t max_chars = 16) {
+    const bool truncated = value.size() > max_chars;
+    const std::string_view shown =
+        truncated ? value.substr(0, max_chars) : value;
+    std::string out;
+    out.reserve(shown.size() + 16);
+    for (const char c : shown) {
+        switch (c) {
+        case '\n':
+            out += "\\n";
+            break;
+        case '\r':
+            out += "\\r";
+            break;
+        case '\t':
+            out += "\\t";
+            break;
+        default:
+            if (const auto byte = static_cast<unsigned char>(c);
+                byte < 0x20 || byte == 0x7f) {
+                out += std::format("\\x{:02x}", byte);
+            } else {
+                out += c;
+            }
+        }
+    }
+    if (truncated) {
+        out += std::format("... ({} bytes)", value.size());
+    }
+    return out;
+}
+
+} // namespace oid::host
+
+#endif // HOST_UTIL_LOG_PREVIEW_H_

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -925,6 +925,19 @@ if(OID_BUILD_IMGUI_FRONTEND)
     target_link_libraries(wire_buffer_type_test PRIVATE GTest::gtest_main GTest::gtest)
     add_test(NAME WireBufferTypeTests COMMAND wire_buffer_type_test)
 
+    # Test natural_pixel_layout(): the decision set_channel(-1, _) ("all")
+    # makes about which layout to restore on the live buffer, extracted out of
+    # NativeViewModel::set_channel so it is testable without the
+    # render-thread-bound NativeViewModel/Stage/Buffer (same rationale as
+    # wire_buffer_type_test above). Header-only, no GL/engine deps.
+    add_executable(natural_pixel_layout_test
+        host/agent/natural_pixel_layout_test.cpp)
+    target_include_directories(natural_pixel_layout_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+    target_link_libraries(natural_pixel_layout_test
+        PRIVATE GTest::gtest_main GTest::gtest)
+    add_test(NAME NaturalPixelLayoutTests COMMAND natural_pixel_layout_test)
+
     # FramePacer: deterministic ordering/count tests for agent-run frame
     # pacing (pending-wake service, burst coalescing, deadline return).
     add_executable(frame_pacer_test host/frame_pacer_test.cpp

--- a/tests/host/agent/natural_pixel_layout_test.cpp
+++ b/tests/host/agent/natural_pixel_layout_test.cpp
@@ -1,0 +1,123 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 OpenImageDebugger contributors
+ * (https://github.com/OpenImageDebugger/OpenImageDebugger)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "host/agent/natural_pixel_layout.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using oid::host::BufferKind;
+using oid::host::BufferRecord;
+using oid::host::agent::natural_pixel_layout;
+
+// The unaffected case: a valid declared layout is what set_channel(-1, _)
+// ("all") should restore, exactly as declared.
+TEST(NaturalPixelLayout, ValidLayoutIsReturnedAsIs) {
+    BufferRecord record;
+    record.pixel_layout = "bgra";
+    record.channels = 3;
+
+    const auto result = natural_pixel_layout(record);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, "bgra");
+}
+
+// Defect: NativeViewModel::set_channel's mode == -1 arm used to stamp the
+// documented default onto the live buffer unconditionally whenever the
+// record's layout failed validation, even for a multi-channel buffer: the
+// exact mechanism that turns a model-level corruption (see
+// IpcClient::handle_plot_buffer_contents) into a permanent, wrong render
+// (Buffer::set_pixel_layout() has no buff_tex_ guard of its own). This is
+// corruption only for a DEBUGGER_SYMBOL record: post-fix, the IPC ingest
+// path guarantees a multi-channel DEBUGGER_SYMBOL record is either valid or
+// already defaulted (see IpcClient::resolve_pixel_layout), so an invalid one
+// reaching here really is residue or corruption, and the caller must leave
+// the live buffer's layout untouched instead of guessing.
+TEST(NaturalPixelLayout,
+     InvalidLayoutForMultiChannelDebuggerSymbolLeavesCurrentLayoutAlone) {
+    BufferRecord record;
+    record.pixel_layout = ""; // corrupted: e.g. a replot missing the hint
+    record.channels = 3;
+    record.kind = BufferKind::DEBUGGER_SYMBOL;
+
+    EXPECT_FALSE(natural_pixel_layout(record).has_value());
+}
+
+// Same corruption, but the record's layout has the mechanical floor (four
+// characters) without the shader's alphabet: still invalid, still hands off
+// to the caller rather than guessing.
+TEST(NaturalPixelLayout,
+     InvalidCharactersForMultiChannelDebuggerSymbolLeavesCurrentLayoutAlone) {
+    BufferRecord record;
+    record.pixel_layout = "xyzq";
+    record.channels = 4;
+    record.kind = BufferKind::DEBUGGER_SYMBOL;
+
+    EXPECT_FALSE(natural_pixel_layout(record).has_value());
+}
+
+// The other half of the discriminator: a LOCAL_FILE record's empty layout is
+// never corruption, whatever its channel count. layout_for_channels()
+// (file_buffer_loader.cpp) returns "" for any non-4-channel file (a plain
+// 3-channel RGB image is the common case), and main.cpp's file-open path
+// upserts straight into the same IpcBufferModel NativeViewModel reads,
+// bypassing IpcClient::resolve_pixel_layout entirely: nothing ever wire-
+// validates this record, so an empty layout here is the documented
+// convention, not residue, and restoring DEFAULT_PIXEL_LAYOUT is exactly
+// what such a buffer already renders with (shader_pixel_layout.h keeps a
+// non-single-channel texture's declared layout, so this must be the buffer's
+// live layout already, not a guess about what it should be).
+TEST(NaturalPixelLayout, LocalFileMultiChannelEmptyLayoutReturnsTheDefault) {
+    BufferRecord record;
+    record.pixel_layout = "";
+    record.channels = 3;
+    record.kind = BufferKind::LOCAL_FILE;
+
+    const auto result = natural_pixel_layout(record);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, "rgba");
+}
+
+// The convention this must not disturb: a single-channel buffer's empty
+// layout is not a corruption (channel order is meaningless for one channel,
+// see shader_pixel_layout.h), so restoring the documented default here is not
+// a guess: it is exactly what a single-channel buffer already renders with.
+// This holds for a DEBUGGER_SYMBOL record too, not only a LOCAL_FILE one.
+TEST(NaturalPixelLayout, EmptyLayoutForSingleChannelReturnsTheDefault) {
+    BufferRecord record;
+    record.pixel_layout = "";
+    record.channels = 1;
+    record.kind = BufferKind::DEBUGGER_SYMBOL;
+
+    const auto result = natural_pixel_layout(record);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, "rgba");
+}
+
+} // namespace

--- a/tests/host/agent/natural_pixel_layout_test.cpp
+++ b/tests/host/agent/natural_pixel_layout_test.cpp
@@ -34,16 +34,18 @@ using oid::host::BufferRecord;
 using oid::host::agent::natural_pixel_layout;
 
 // The unaffected case: a valid declared layout is what set_channel(-1, _)
-// ("all") should restore, exactly as declared.
+// ("all") should restore, exactly as declared, regardless of what the
+// buffer currently renders with.
 TEST(NaturalPixelLayout, ValidLayoutIsReturnedAsIs) {
     BufferRecord record;
     record.pixel_layout = "bgra";
     record.channels = 3;
 
-    const auto result = natural_pixel_layout(record);
+    const auto result = natural_pixel_layout(record, "rgba");
 
-    ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(*result, "bgra");
+    ASSERT_TRUE(result.layout.has_value());
+    EXPECT_EQ(*result.layout, "bgra");
+    EXPECT_FALSE(result.cleared_isolation);
 }
 
 // Defect: NativeViewModel::set_channel's mode == -1 arm used to stamp the
@@ -52,11 +54,16 @@ TEST(NaturalPixelLayout, ValidLayoutIsReturnedAsIs) {
 // exact mechanism that turns a model-level corruption (see
 // IpcClient::handle_plot_buffer_contents) into a permanent, wrong render
 // (Buffer::set_pixel_layout() has no buff_tex_ guard of its own). This is
-// corruption only for a DEBUGGER_SYMBOL record: post-fix, the IPC ingest
-// path guarantees a multi-channel DEBUGGER_SYMBOL record is either valid or
-// already defaulted (see IpcClient::resolve_pixel_layout), so an invalid one
-// reaching here really is residue or corruption, and the caller must leave
-// the live buffer's layout untouched instead of guessing.
+// corruption only for a DEBUGGER_SYMBOL record whose current layout is not
+// itself an isolation swizzle (see the isolation-clearing test below for the
+// other branch): post-fix, the IPC ingest path guarantees a multi-channel
+// DEBUGGER_SYMBOL record is either valid or already defaulted (see
+// IpcClient::resolve_pixel_layout), so an invalid one reaching here really
+// is residue or corruption, and the caller must leave the live buffer's
+// layout untouched instead of guessing. "bgra" is used as the current
+// layout here (a valid, non-isolation layout the buffer might already be
+// correctly rendering with) so this is unambiguously the leave-alone case,
+// not the isolation-clearing one.
 TEST(NaturalPixelLayout,
      InvalidLayoutForMultiChannelDebuggerSymbolLeavesCurrentLayoutAlone) {
     BufferRecord record;
@@ -64,12 +71,16 @@ TEST(NaturalPixelLayout,
     record.channels = 3;
     record.kind = BufferKind::DEBUGGER_SYMBOL;
 
-    EXPECT_FALSE(natural_pixel_layout(record).has_value());
+    const auto result = natural_pixel_layout(record, "bgra");
+
+    EXPECT_FALSE(result.layout.has_value());
+    EXPECT_FALSE(result.cleared_isolation);
 }
 
 // Same corruption, but the record's layout has the mechanical floor (four
 // characters) without the shader's alphabet: still invalid, still hands off
-// to the caller rather than guessing.
+// to the caller rather than guessing. Current layout is again a valid,
+// non-isolation layout, for the same reason as above.
 TEST(NaturalPixelLayout,
      InvalidCharactersForMultiChannelDebuggerSymbolLeavesCurrentLayoutAlone) {
     BufferRecord record;
@@ -77,30 +88,60 @@ TEST(NaturalPixelLayout,
     record.channels = 4;
     record.kind = BufferKind::DEBUGGER_SYMBOL;
 
-    EXPECT_FALSE(natural_pixel_layout(record).has_value());
+    const auto result = natural_pixel_layout(record, "bgra");
+
+    EXPECT_FALSE(result.layout.has_value());
+    EXPECT_FALSE(result.cleared_isolation);
+}
+
+// Defect, other half: exiting isolation must actually exit it. If the user
+// previously isolated a channel (set_channel(name, index, _) installs one of
+// ISOLATION_LAYOUTS: "rrra"/"ggga"/"bbba") and the record's layout is invalid
+// for a multi-channel DEBUGGER_SYMBOL buffer, leaving the buffer's current
+// (isolated) layout alone would silently keep rendering a single channel
+// even though "all channels" was just requested and display_channel_mode
+// resets to -1. This is the one case where an invalid layout is NOT residue
+// to be left alone: the current layout being an isolation swizzle proves it
+// was set by this same class's own index arm, not preserved from a valid
+// declaration, so restoring the default is correct, not a guess, and it must
+// happen loudly.
+TEST(NaturalPixelLayout,
+     InvalidLayoutForMultiChannelDebuggerSymbolClearsIsolatedCurrentLayout) {
+    BufferRecord record;
+    record.pixel_layout = "";
+    record.channels = 3;
+    record.kind = BufferKind::DEBUGGER_SYMBOL;
+
+    const auto result = natural_pixel_layout(record, "rrra");
+
+    ASSERT_TRUE(result.layout.has_value());
+    EXPECT_EQ(*result.layout, "rgba");
+    EXPECT_TRUE(result.cleared_isolation);
 }
 
 // The other half of the discriminator: a LOCAL_FILE record's empty layout is
-// never corruption, whatever its channel count. layout_for_channels()
-// (file_buffer_loader.cpp) returns "" for any non-4-channel file (a plain
-// 3-channel RGB image is the common case), and main.cpp's file-open path
-// upserts straight into the same IpcBufferModel NativeViewModel reads,
-// bypassing IpcClient::resolve_pixel_layout entirely: nothing ever wire-
-// validates this record, so an empty layout here is the documented
-// convention, not residue, and restoring DEFAULT_PIXEL_LAYOUT is exactly
-// what such a buffer already renders with (shader_pixel_layout.h keeps a
-// non-single-channel texture's declared layout, so this must be the buffer's
-// live layout already, not a guess about what it should be).
+// never corruption, whatever its channel count, even when the buffer
+// currently holds an isolation swizzle: the LOCAL_FILE/channel-count check
+// takes precedence over the isolation check, so this is a plain default, not
+// a "cleared isolation" one (there is nothing for this record to lose by
+// leaving isolation alone versus not; the default is simply always correct
+// here). layout_for_channels() (file_buffer_loader.cpp) returns "" for any
+// non-4-channel file (a plain 3-channel RGB image is the common case), and
+// main.cpp's file-open path upserts straight into the same IpcBufferModel
+// NativeViewModel reads, bypassing IpcClient::resolve_pixel_layout entirely:
+// nothing ever wire-validates this record, so an empty layout here is the
+// documented convention, not residue.
 TEST(NaturalPixelLayout, LocalFileMultiChannelEmptyLayoutReturnsTheDefault) {
     BufferRecord record;
     record.pixel_layout = "";
     record.channels = 3;
     record.kind = BufferKind::LOCAL_FILE;
 
-    const auto result = natural_pixel_layout(record);
+    const auto result = natural_pixel_layout(record, "rrra");
 
-    ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(*result, "rgba");
+    ASSERT_TRUE(result.layout.has_value());
+    EXPECT_EQ(*result.layout, "rgba");
+    EXPECT_FALSE(result.cleared_isolation);
 }
 
 // The convention this must not disturb: a single-channel buffer's empty
@@ -108,16 +149,20 @@ TEST(NaturalPixelLayout, LocalFileMultiChannelEmptyLayoutReturnsTheDefault) {
 // see shader_pixel_layout.h), so restoring the documented default here is not
 // a guess: it is exactly what a single-channel buffer already renders with.
 // This holds for a DEBUGGER_SYMBOL record too, not only a LOCAL_FILE one.
+// The current layout is again an isolation swizzle here, to prove the
+// single-channel check takes precedence over the isolation check the same
+// way the LOCAL_FILE one does above.
 TEST(NaturalPixelLayout, EmptyLayoutForSingleChannelReturnsTheDefault) {
     BufferRecord record;
     record.pixel_layout = "";
     record.channels = 1;
     record.kind = BufferKind::DEBUGGER_SYMBOL;
 
-    const auto result = natural_pixel_layout(record);
+    const auto result = natural_pixel_layout(record, "ggga");
 
-    ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(*result, "rgba");
+    ASSERT_TRUE(result.layout.has_value());
+    EXPECT_EQ(*result.layout, "rgba");
+    EXPECT_FALSE(result.cleared_isolation);
 }
 
 } // namespace

--- a/tests/host/ipc/ipc_client_test.cpp
+++ b/tests/host/ipc/ipc_client_test.cpp
@@ -441,6 +441,64 @@ TEST(IpcClient, ReplotWithInvalidLayoutKeepsExistingValidLayout) {
     EXPECT_NE(logged.find("pixel_layout ''"), std::string::npos);
 }
 
+// The kept layout's premise dies with the channel count: a layout declared
+// for the record's OLD shape must not survive onto a replot that changes
+// how many channels there are, or the preserved swizzle addresses
+// components the new texture does not have. A reshaping replot with an
+// invalid layout takes the default instead.
+TEST(IpcClient, AReshapingReplotWithInvalidLayoutTakesTheDefault) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+
+    // First plot: 2x2, 3-channel, valid "bgra" layout.
+    {
+        MessageComposer c;
+        std::vector bytes(12, std::byte{5});
+        c.push(MessageType::PLOT_BUFFER_CONTENTS)
+            .push(std::string("v"))
+            .push(std::string("disp"))
+            .push(std::string("bgra"))
+            .push(false)
+            .push(2)
+            .push(2)
+            .push(3)
+            .push(2)
+            .push(BufferType::UNSIGNED_BYTE)
+            .push(std::span<const std::byte>(bytes));
+        t.feed(frame(c));
+    }
+    host::IpcClient client(t, model);
+    client.poll();
+    ASSERT_EQ(model.at(0).pixel_layout, "bgra");
+
+    // Replot with TWO channels and an invalid layout: the old 3-channel
+    // "bgra" must not be carried onto the reshaped record.
+    {
+        MessageComposer c;
+        std::vector bytes(8, std::byte{9});
+        c.push(MessageType::PLOT_BUFFER_CONTENTS)
+            .push(std::string("v"))
+            .push(std::string("disp"))
+            .push(std::string(""))
+            .push(false)
+            .push(2)
+            .push(2)
+            .push(2)
+            .push(2)
+            .push(BufferType::UNSIGNED_BYTE)
+            .push(std::span<const std::byte>(bytes));
+        t.feed(frame(c));
+    }
+    CerrCapture cap;
+    client.poll();
+
+    ASSERT_EQ(model.size(), 1u);
+    EXPECT_EQ(model.at(0).channels, 2);
+    EXPECT_EQ(model.at(0).pixel_layout, "rgba")
+        << "a layout declared for another channel count is not kept";
+    EXPECT_NE(cap.out.str().find("rgba"), std::string::npos);
+}
+
 // Defect, other half: a variable's very first plot ever, with an invalid
 // layout ("xyzq": four characters, but outside the r/g/b/a alphabet the
 // shader swizzles by) for a multi-channel buffer. There is no existing
@@ -555,6 +613,43 @@ TEST(IpcClient, ControlCharactersInARejectedLayoutAreEchoedVisibly) {
         << "the newline lands as its visible escape";
     EXPECT_NE(logged.find("\\x1b"), std::string::npos)
         << "the escape byte lands as its visible escape";
+}
+
+// The C1 controls are one layer up from the raw bytes: U+009B (CSI) arrives
+// as the UTF-8 pair 0xc2 0x9b, which a Unicode-aware consumer decodes into
+// a control character no C0 byte scan ever sees. Exactly those pairs land
+// as visible escapes; every other multi-byte sequence passes through
+// untouched, since 0x80..0x9f CONTINUATION bytes are how ordinary non-ASCII
+// text is spelled.
+TEST(IpcClient, C1ControlsInARejectedLayoutAreEchoedVisibly) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    MessageComposer c;
+    std::vector bytes(12, std::byte{5});
+    const auto hostile = std::string("a\xc2\x9b"
+                                     "b");
+    c.push(MessageType::PLOT_BUFFER_CONTENTS)
+        .push(std::string("v"))
+        .push(std::string("disp"))
+        .push(hostile)
+        .push(false)
+        .push(2)
+        .push(2)
+        .push(3)
+        .push(2)
+        .push(BufferType::UNSIGNED_BYTE)
+        .push(std::span<const std::byte>(bytes));
+    t.feed(frame(c));
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    const std::string logged = cap.out.str();
+    EXPECT_EQ(logged.find("\xc2\x9b"), std::string::npos)
+        << "the encoded CSI must not reach the log";
+    EXPECT_NE(logged.find("\\u009b"), std::string::npos)
+        << "the C1 control lands as its visible escape";
 }
 
 // The variable name travels the same wire as the layout and lands in the

--- a/tests/host/ipc/ipc_client_test.cpp
+++ b/tests/host/ipc/ipc_client_test.cpp
@@ -210,7 +210,15 @@ static std::vector<std::byte> begin_frame(const std::string& name,
 
 // Like begin_frame, but exposes channels, stride and type: the
 // geometry-vs-payload checks need shapes begin_frame's fixed
-// channels=1/stride=width can't reach.
+// channels=1/stride=width can't reach. Declares "rgba" regardless of
+// `channels` for convenience, not fidelity: a real wire client would send ""
+// for the channels=1 callers instead (see BufferRecord::pixel_layout,
+// buffer_model.h). None of these tests assert on pixel_layout, and a
+// single-channel declared layout is used as-is regardless of validity
+// (ipc_client.cpp), so that mismatch is harmless here; it matters only for
+// the multi-channel callers, where a real layout is always four characters,
+// so "rgba" (not a shorter placeholder like "rgb") avoids spuriously
+// tripping the invalid-layout fallback.
 static std::vector<std::byte>
 begin_frame_ex(const std::string& name,
                const int width,
@@ -223,7 +231,7 @@ begin_frame_ex(const std::string& name,
     c.push(MessageType::PLOT_BUFFER_BEGIN)
         .push(name)
         .push(std::string("disp"))
-        .push(std::string("rgb"))
+        .push(std::string("rgba"))
         .push(false)
         .push(width)
         .push(height)
@@ -271,12 +279,15 @@ TEST(IpcClient, PlotBufferContentsUpsertsModel) {
     host::IpcBufferModel model;
     MessageComposer c;
     // 2x2 rgb8, unpadded: stride counts PIXELS per row, so it equals width
-    // here, and the payload is channels * stride * height = 12 bytes.
+    // here, and the payload is channels * stride * height = 12 bytes. A real
+    // multi-channel layout is always four characters (see
+    // BufferRecord::pixel_layout, buffer_model.h), so "rgba" is used here
+    // even though only 3 channels are declared.
     std::vector bytes(12, std::byte{5});
     c.push(MessageType::PLOT_BUFFER_CONTENTS)
         .push(std::string("v"))
         .push(std::string("disp"))
-        .push(std::string("rgb"))
+        .push(std::string("rgba"))
         .push(false)
         .push(2)
         .push(2)
@@ -360,6 +371,141 @@ TEST(IpcClient, PlotBufferContentsAcceptsLastRowOmittingStridePadding) {
 
     ASSERT_EQ(model.size(), 1u);
     EXPECT_EQ(model.at(0).bytes.size(), 8u);
+    EXPECT_TRUE(cap.out.str().empty());
+}
+
+// Defect: a replot whose pixel_layout is invalid (here, empty, as if a
+// degraded resend dropped the format hint) must never overwrite a valid
+// layout the record already holds. IpcBufferModel::upsert() replaces the
+// whole record, so without this check the corruption would sit silent in
+// the model (Buffer::configure()'s own guard hides it from the render)
+// until something else re-derives from the record and makes it real. The
+// existing valid layout must stand, loudly.
+TEST(IpcClient, ReplotWithInvalidLayoutKeepsExistingValidLayout) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+
+    // First plot: 2x2, 3-channel, valid "bgra" layout.
+    {
+        MessageComposer c;
+        std::vector bytes(12, std::byte{5});
+        c.push(MessageType::PLOT_BUFFER_CONTENTS)
+            .push(std::string("v"))
+            .push(std::string("disp"))
+            .push(std::string("bgra"))
+            .push(false)
+            .push(2)
+            .push(2)
+            .push(3)
+            .push(2)
+            .push(BufferType::UNSIGNED_BYTE)
+            .push(std::span<const std::byte>(bytes));
+        t.feed(frame(c));
+    }
+    host::IpcClient client(t, model);
+    client.poll();
+    ASSERT_EQ(model.size(), 1u);
+    ASSERT_EQ(model.at(0).pixel_layout, "bgra");
+
+    // Replot of the same variable and geometry, but an empty layout: the
+    // degraded resend this test models.
+    {
+        MessageComposer c;
+        std::vector bytes(12, std::byte{9});
+        c.push(MessageType::PLOT_BUFFER_CONTENTS)
+            .push(std::string("v"))
+            .push(std::string("disp"))
+            .push(std::string(""))
+            .push(false)
+            .push(2)
+            .push(2)
+            .push(3)
+            .push(2)
+            .push(BufferType::UNSIGNED_BYTE)
+            .push(std::span<const std::byte>(bytes));
+        t.feed(frame(c));
+    }
+    CerrCapture cap;
+    client.poll();
+
+    ASSERT_EQ(model.size(), 1u);
+    // The corruption this guards against: the valid layout must survive.
+    EXPECT_EQ(model.at(0).pixel_layout, "bgra");
+    // The rest of the replot still lands; only the layout is kept.
+    EXPECT_EQ(model.at(0).bytes[0], std::byte{9});
+    const std::string logged = cap.out.str();
+    EXPECT_NE(logged.find("PLOT_BUFFER_CONTENTS"), std::string::npos);
+    EXPECT_NE(logged.find("'v'"), std::string::npos);
+    EXPECT_NE(logged.find("bgra"), std::string::npos);
+    // The rejected value itself (empty here) is echoed, not just implied.
+    EXPECT_NE(logged.find("pixel_layout ''"), std::string::npos);
+}
+
+// Defect, other half: a variable's very first plot ever, with an invalid
+// layout ("xyzq": four characters, but outside the r/g/b/a alphabet the
+// shader swizzles by) for a multi-channel buffer. There is no existing
+// record to fall back on, so this must land with the documented default,
+// loudly.
+TEST(IpcClient, FirstPlotWithInvalidLayoutForMultiChannelDefaultsLoudly) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    MessageComposer c;
+    std::vector bytes(12, std::byte{5});
+    c.push(MessageType::PLOT_BUFFER_CONTENTS)
+        .push(std::string("v"))
+        .push(std::string("disp"))
+        .push(std::string("xyzq"))
+        .push(false)
+        .push(2)
+        .push(2)
+        .push(3)
+        .push(2)
+        .push(BufferType::UNSIGNED_BYTE)
+        .push(std::span<const std::byte>(bytes));
+    t.feed(frame(c));
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    ASSERT_EQ(model.size(), 1u);
+    EXPECT_EQ(model.at(0).pixel_layout, "rgba"); // the documented default
+    const std::string logged = cap.out.str();
+    EXPECT_NE(logged.find("PLOT_BUFFER_CONTENTS"), std::string::npos);
+    EXPECT_NE(logged.find("'v'"), std::string::npos);
+    EXPECT_NE(logged.find("rgba"), std::string::npos);
+    // The rejected value itself is echoed, not just the fallback it produced.
+    EXPECT_NE(logged.find("xyzq"), std::string::npos);
+}
+
+// The convention this whole check must not disturb: a single-channel
+// buffer's empty pixel_layout is legitimate (see BufferRecord::pixel_layout,
+// buffer_model.h, and layout_for_channels(), file_buffer_loader.cpp), not a
+// corruption, so it must upsert exactly as before: silently, and unchanged.
+TEST(IpcClient, SingleChannelEmptyLayoutStillUpsertsSilently) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    MessageComposer c;
+    std::vector bytes(4, std::byte{5});
+    c.push(MessageType::PLOT_BUFFER_CONTENTS)
+        .push(std::string("v"))
+        .push(std::string("disp"))
+        .push(std::string(""))
+        .push(false)
+        .push(2)
+        .push(2)
+        .push(1)
+        .push(2)
+        .push(BufferType::UNSIGNED_BYTE)
+        .push(std::span<const std::byte>(bytes));
+    t.feed(frame(c));
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    ASSERT_EQ(model.size(), 1u);
+    EXPECT_EQ(model.at(0).pixel_layout, "");
     EXPECT_TRUE(cap.out.str().empty());
 }
 
@@ -488,7 +634,10 @@ TEST(IpcClient, ChunkedRoundTripReassemblesBuffer) {
     FakeTransport t;
     host::IpcBufferModel model;
     // 4x2 rgb8, unpadded: stride counts PIXELS per row, so it equals width
-    // here, and the payload is channels * stride * height = 24 bytes.
+    // here, and the payload is channels * stride * height = 24 bytes. A real
+    // multi-channel layout is always four characters (see
+    // BufferRecord::pixel_layout, buffer_model.h), so "rgba" is used here
+    // even though only 3 channels are declared.
     std::vector bytes(24, std::byte{9});
 
     {
@@ -497,7 +646,7 @@ TEST(IpcClient, ChunkedRoundTripReassemblesBuffer) {
         c.push(MessageType::PLOT_BUFFER_BEGIN)
             .push(std::string("v"))
             .push(std::string("disp"))
-            .push(std::string("rgb"))
+            .push(std::string("rgba"))
             .push(false)
             .push(4)
             .push(2)
@@ -531,6 +680,73 @@ TEST(IpcClient, ChunkedRoundTripReassemblesBuffer) {
     for (auto b : model.at(0).bytes) {
         EXPECT_EQ(b, std::byte{9});
     }
+}
+
+// The BEGIN/CHUNK/END assembly path's sibling of
+// ReplotWithInvalidLayoutKeepsExistingValidLayout above:
+// handle_plot_buffer_end() upserts from the assembled transfer via its own call
+// site, independent of handle_plot_buffer_contents(), so it needs its own guard
+// against the same corruption.
+TEST(IpcClient, ChunkedReplotWithInvalidLayoutKeepsExistingValidLayout) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    // 4x2, 3-channel, valid "bgra" layout.
+    std::vector bytes(24, std::byte{5});
+    {
+        MessageComposer c;
+        c.push(MessageType::PLOT_BUFFER_BEGIN)
+            .push(std::string("v"))
+            .push(std::string("disp"))
+            .push(std::string("bgra"))
+            .push(false)
+            .push(4)
+            .push(2)
+            .push(3)
+            .push(4)
+            .push(static_cast<int>(BufferType::UNSIGNED_BYTE))
+            .push(bytes.size());
+        t.feed(frame(c));
+    }
+    t.feed(chunk_frame("v", 0, 2, bytes));
+    t.feed(end_frame("v"));
+
+    host::IpcClient client(t, model);
+    client.poll();
+    ASSERT_EQ(model.size(), 1u);
+    ASSERT_EQ(model.at(0).pixel_layout, "bgra");
+
+    // Replot of the same variable and geometry, but an empty layout.
+    std::vector bytes2(24, std::byte{9});
+    {
+        MessageComposer c;
+        c.push(MessageType::PLOT_BUFFER_BEGIN)
+            .push(std::string("v"))
+            .push(std::string("disp"))
+            .push(std::string(""))
+            .push(false)
+            .push(4)
+            .push(2)
+            .push(3)
+            .push(4)
+            .push(static_cast<int>(BufferType::UNSIGNED_BYTE))
+            .push(bytes2.size());
+        t.feed(frame(c));
+    }
+    t.feed(chunk_frame("v", 0, 2, bytes2));
+    t.feed(end_frame("v"));
+
+    CerrCapture cap;
+    client.poll();
+
+    ASSERT_EQ(model.size(), 1u);
+    EXPECT_EQ(model.at(0).pixel_layout, "bgra");
+    EXPECT_EQ(model.at(0).bytes[0], std::byte{9});
+    const std::string logged = cap.out.str();
+    EXPECT_NE(logged.find("PLOT_BUFFER_END"), std::string::npos);
+    EXPECT_NE(logged.find("'v'"), std::string::npos);
+    EXPECT_NE(logged.find("bgra"), std::string::npos);
+    // The rejected value itself (empty here) is echoed, not just implied.
+    EXPECT_NE(logged.find("pixel_layout ''"), std::string::npos);
 }
 
 // The reported failure mode: a huge stride paired with a tiny, but

--- a/tests/host/ipc/ipc_client_test.cpp
+++ b/tests/host/ipc/ipc_client_test.cpp
@@ -478,6 +478,120 @@ TEST(IpcClient, FirstPlotWithInvalidLayoutForMultiChannelDefaultsLoudly) {
     EXPECT_NE(logged.find("xyzq"), std::string::npos);
 }
 
+// The echo of the rejected value must stay bounded: the wire allows strings
+// far larger than any legitimate layout, and a diagnostic must not let one
+// malformed message turn into megabytes of synchronous stderr. A long
+// rejected value is echoed as a short preview plus its byte count, never
+// verbatim.
+TEST(IpcClient, ALargeInvalidLayoutIsEchoedBounded) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    MessageComposer c;
+    std::vector bytes(12, std::byte{5});
+    const std::string huge(1024, 'x');
+    c.push(MessageType::PLOT_BUFFER_CONTENTS)
+        .push(std::string("v"))
+        .push(std::string("disp"))
+        .push(huge)
+        .push(false)
+        .push(2)
+        .push(2)
+        .push(3)
+        .push(2)
+        .push(BufferType::UNSIGNED_BYTE)
+        .push(std::span<const std::byte>(bytes));
+    t.feed(frame(c));
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    ASSERT_EQ(model.size(), 1u);
+    EXPECT_EQ(model.at(0).pixel_layout, "rgba");
+    const std::string logged = cap.out.str();
+    EXPECT_EQ(logged.find(huge), std::string::npos)
+        << "the peer-supplied value must never be echoed verbatim";
+    // The exact preview shape, not merely "less than everything": a
+    // regression to a hundreds-of-bytes echo must fail here too.
+    EXPECT_NE(logged.find(std::string(16, 'x') + "... (1024 bytes)"),
+              std::string::npos)
+        << "the echo is the 16-character preview plus the size";
+    EXPECT_EQ(logged.find(std::string(17, 'x')), std::string::npos)
+        << "not one character more than the bound";
+}
+
+// The length bound alone does not make the echo safe: sixteen characters of
+// newlines or terminal escapes still forge log lines. Control characters in
+// the rejected value must land as visible escapes, never raw.
+TEST(IpcClient, ControlCharactersInARejectedLayoutAreEchoedVisibly) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    MessageComposer c;
+    std::vector bytes(12, std::byte{5});
+    const auto hostile = std::string("a\nb\x1b[31m");
+    c.push(MessageType::PLOT_BUFFER_CONTENTS)
+        .push(std::string("v"))
+        .push(std::string("disp"))
+        .push(hostile)
+        .push(false)
+        .push(2)
+        .push(2)
+        .push(3)
+        .push(2)
+        .push(BufferType::UNSIGNED_BYTE)
+        .push(std::span<const std::byte>(bytes));
+    t.feed(frame(c));
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    ASSERT_EQ(model.size(), 1u);
+    EXPECT_EQ(model.at(0).pixel_layout, "rgba");
+    const std::string logged = cap.out.str();
+    EXPECT_EQ(logged.find('\x1b'), std::string::npos)
+        << "no raw escape byte may reach the log";
+    EXPECT_NE(logged.find("\\n"), std::string::npos)
+        << "the newline lands as its visible escape";
+    EXPECT_NE(logged.find("\\x1b"), std::string::npos)
+        << "the escape byte lands as its visible escape";
+}
+
+// The variable name travels the same wire as the layout and lands in the
+// same diagnostic, so it gets the same treatment: a control character in it
+// must not forge log lines just because the layout half is already safe.
+TEST(IpcClient, ControlCharactersInTheNameAreEchoedVisiblyToo) {
+    FakeTransport t;
+    host::IpcBufferModel model;
+    MessageComposer c;
+    std::vector bytes(12, std::byte{5});
+    c.push(MessageType::PLOT_BUFFER_CONTENTS)
+        .push(std::string("evil\nname"))
+        .push(std::string("disp"))
+        .push(std::string("xyzq"))
+        .push(false)
+        .push(2)
+        .push(2)
+        .push(3)
+        .push(2)
+        .push(BufferType::UNSIGNED_BYTE)
+        .push(std::span<const std::byte>(bytes));
+    t.feed(frame(c));
+
+    host::IpcClient client(t, model);
+    CerrCapture cap;
+    client.poll();
+
+    ASSERT_EQ(model.size(), 1u);
+    const std::string logged = cap.out.str();
+    // One trailing newline per message and nothing else: the name's own
+    // newline must land as its visible escape.
+    EXPECT_NE(logged.find("evil\\nname"), std::string::npos)
+        << "the name lands as its visible escape: " << logged;
+    EXPECT_EQ(logged.find("evil\nname"), std::string::npos)
+        << "the raw newline must not reach the log: " << logged;
+}
+
 // The convention this whole check must not disturb: a single-channel
 // buffer's empty pixel_layout is legitimate (see BufferRecord::pixel_layout,
 // buffer_model.h, and layout_for_channels(), file_buffer_loader.cpp), not a


### PR DESCRIPTION
A replot whose header carries an invalid pixel layout silently replaced the record's valid one, and the viewer's all-channels restore then stamped a guessed rgba onto the live buffer. Because replots deliberately preserve a buffer's format choice, the corruption stuck: every later correct send was ignored, and the buffer rendered with swapped channels until closed.

The IPC ingest now resolves the layout before upserting: an invalid multi-channel layout keeps the record's existing valid one, or lands with the documented default on a first plot, loudly either way. The all-channels restore decision moves into natural_pixel_layout(), which applies a record's valid layout, restores the default for file-loaded and single-channel records (where an empty layout is the documented convention), and otherwise leaves the live buffer alone rather than guessing.