### PR TITLE
chore: release oid-mcp 0.3.2

### DIFF
--- a/resources/oidmcp/CHANGELOG.md
+++ b/resources/oidmcp/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to `oid-mcp` are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.3.2] — 2026-08-05
+
+### Changed
+- Refreshed the `oidscripts` copy bundled in the wheel (declarative custom
+  buffer types, JSON resolver entry points). The server's own code is
+  unchanged, as is `oidscripts.wireframe`, the one bundled module it imports
+  at runtime, so behaviour against a live session is the same as 0.3.1.
+
+### Packaging
+- First release carrying `server.json`, so this version also lists the server
+  on the MCP registry.
+- Refreshed the dev lockfile (`cryptography`). The published runtime
+  dependencies (`mcp`, `numpy`, `pillow`) are unchanged.
+
 ## [0.2.0] — 2026-07-17
 
 ### Added

--- a/resources/oidmcp/pyproject.toml
+++ b/resources/oidmcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oid-mcp"
-version = "0.3.1"
+version = "0.3.2"
 description = "MCP server giving AI agents eyes on OpenImageDebugger buffers in live gdb/lldb sessions"
 requires-python = ">=3.10"
 dependencies = [

--- a/resources/oidmcp/server.json
+++ b/resources/oidmcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.openimagedebugger/oid-mcp",
   "title": "OpenImageDebugger MCP",
   "description": "MCP server giving AI agents eyes on OpenImageDebugger buffers in live gdb/lldb sessions",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "oid-mcp",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Cuts `oid-mcp` 0.3.2.

The MCP server's own code is unchanged since 0.3.1. The release exists so the package ships with `server.json`: the MCP registry publish job only runs on an `oid-mcp-v*` tag, and `server.json` landed after the 0.3.1 tag, so the server is not listed on the registry today. It also refreshes the `oidscripts` copy bundled in the wheel.

Runtime dependencies are unchanged (`mcp`, `numpy`, `pillow`). The recent `cryptography` bump touched the dev lockfile only, which is not shipped in the wheel.

Release step after merge: tag `oid-mcp-v0.3.2` on the merge commit.