### PR TITLE
chore: release oid-mcp 0.3.3

### DIFF
--- a/resources/oidmcp/CHANGELOG.md
+++ b/resources/oidmcp/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to `oid-mcp` are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.3.3] — 2026-08-05
+
+### Fixed
+- Corrected the MCP registry namespace in `server.json` to
+  `io.github.OpenImageDebugger/oid-mcp`. The lowercased spelling did not match
+  the GitHub organisation, so the registry rejected the 0.3.2 listing and the
+  server never appeared there. The published package is otherwise identical to
+  0.3.2.
+
 ## [0.3.2] — 2026-08-05
 
 ### Changed

--- a/resources/oidmcp/pyproject.toml
+++ b/resources/oidmcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oid-mcp"
-version = "0.3.2"
+version = "0.3.3"
 description = "MCP server giving AI agents eyes on OpenImageDebugger buffers in live gdb/lldb sessions"
 requires-python = ">=3.10"
 dependencies = [

--- a/resources/oidmcp/server.json
+++ b/resources/oidmcp/server.json
@@ -1,14 +1,14 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.openimagedebugger/oid-mcp",
+  "name": "io.github.OpenImageDebugger/oid-mcp",
   "title": "OpenImageDebugger MCP",
   "description": "MCP server giving AI agents eyes on OpenImageDebugger buffers in live gdb/lldb sessions",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "oid-mcp",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "transport": {
         "type": "stdio"
       }

--- a/resources/oidmcp/tests/test_server_manifest.py
+++ b/resources/oidmcp/tests/test_server_manifest.py
@@ -1,0 +1,43 @@
+"""server.json is publish-time metadata nothing else reads, so it drifts silently.
+
+Both fields guarded here have already broken a release: a lowercased namespace
+made the MCP registry reject the listing with a 403, and the version appears in
+three files that must agree or the registry advertises a PyPI version that was
+never uploaded.
+"""
+
+import json
+import tomllib
+from pathlib import Path
+
+OIDMCP = Path(__file__).resolve().parents[1]
+
+# The registry derives publish permission from the GitHub OIDC claim, which
+# carries the organisation's canonical casing. A namespace that differs by case
+# is refused.
+GITHUB_NAMESPACE = 'io.github.OpenImageDebugger'
+
+
+def _manifest():
+    return json.loads((OIDMCP / 'server.json').read_text())
+
+
+def _pyproject_version():
+    with open(OIDMCP / 'pyproject.toml', 'rb') as handle:
+        return tomllib.load(handle)['project']['version']
+
+
+def test_namespace_matches_the_github_organisation():
+    assert _manifest()['name'] == f'{GITHUB_NAMESPACE}/oid-mcp'
+
+
+def test_manifest_version_matches_pyproject():
+    assert _manifest()['version'] == _pyproject_version()
+
+
+def test_pypi_package_version_matches_pyproject():
+    packages = _manifest()['packages']
+    assert len(packages) == 1
+    assert packages[0]['registryType'] == 'pypi'
+    assert packages[0]['identifier'] == 'oid-mcp'
+    assert packages[0]['version'] == _pyproject_version()

--- a/resources/oidmcp/tests/test_server_manifest.py
+++ b/resources/oidmcp/tests/test_server_manifest.py
@@ -7,8 +7,9 @@ never uploaded.
 """
 
 import json
-import tomllib
 from pathlib import Path
+
+import pytest
 
 OIDMCP = Path(__file__).resolve().parents[1]
 
@@ -23,6 +24,11 @@ def _manifest():
 
 
 def _pyproject_version():
+    # tomllib is 3.11+ and the package supports 3.10, so the version
+    # comparisons sit out on the older interpreter rather than failing
+    # collection for the whole suite. The namespace check needs no parser and
+    # runs everywhere, which is the half that has actually broken a release.
+    tomllib = pytest.importorskip('tomllib')
     with open(OIDMCP / 'pyproject.toml', 'rb') as handle:
         return tomllib.load(handle)['project']['version']
 

--- a/resources/oidmcp/uv.lock
+++ b/resources/oidmcp/uv.lock
@@ -578,7 +578,7 @@ wheels = [
 
 [[package]]
 name = "oid-mcp"
-version = "0.3.1"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
0.3.2 published to PyPI but never showed up on the MCP registry. `server.json`
spelled the namespace `io.github.openimagedebugger`, and the registry only
accepts `io.github.OpenImageDebugger`, so it refused the listing.

This corrects the namespace and cuts 0.3.3. The published package itself is
unchanged: `server.json` is not part of the wheel.

Also adds a check that the namespace and the advertised version stay right, so a
bad value fails in CI rather than at publish time.