### PR TITLE
chore: release oid-mcp 0.3.4

### DIFF
--- a/resources/oidmcp/CHANGELOG.md
+++ b/resources/oidmcp/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to `oid-mcp` are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.3.4] — 2026-08-05
+
+### Added
+- The README is now the package's PyPI description. The project page was blank
+  before this, since `pyproject.toml` never declared a `readme`.
+
+### Fixed
+- Corrected the MCP registry ownership marker in the README, which still
+  carried the lowercased namespace. Together with the description above this
+  lets the registry verify the package and list the server, which it refused to
+  do for 0.3.2 and 0.3.3.
+
 ## [0.3.3] — 2026-08-05
 
 ### Fixed

--- a/resources/oidmcp/README.md
+++ b/resources/oidmcp/README.md
@@ -1,6 +1,6 @@
 # oid-mcp
 
-<!-- mcp-name: io.github.openimagedebugger/oid-mcp -->
+<!-- mcp-name: io.github.OpenImageDebugger/oid-mcp -->
 
 MCP server that gives AI agents eyes on OpenImageDebugger buffers in a
 live gdb/lldb session: list observable symbols at a breakpoint, view
@@ -34,7 +34,7 @@ the same directory** (see [Troubleshooting](#troubleshooting)).
 
 - **A built and installed OpenImageDebugger** with a deployed `oid.py`.
   See the top-level README's [Building the Open Image
-  Debugger](../../README.md#building-the-open-image-debugger).
+  Debugger](https://github.com/OpenImageDebugger/OpenImageDebugger#building-the-open-image-debugger).
 - **A debugger with embedded Python**: gdb, or (on macOS) Homebrew
   `lldb` — the same debugger you already use with OID.
 - **[uv](https://docs.astral.sh/uv/)** — runs the server in a managed

--- a/resources/oidmcp/pyproject.toml
+++ b/resources/oidmcp/pyproject.toml
@@ -1,7 +1,11 @@
 [project]
 name = "oid-mcp"
-version = "0.3.3"
+version = "0.3.4"
 description = "MCP server giving AI agents eyes on OpenImageDebugger buffers in live gdb/lldb sessions"
+# Ships the README as the PyPI long description. The MCP registry reads that
+# description to verify package ownership, so without this the registry cannot
+# see the mcp-name marker and refuses to list the server.
+readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "mcp>=1.2",

--- a/resources/oidmcp/server.json
+++ b/resources/oidmcp/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.OpenImageDebugger/oid-mcp",
   "title": "OpenImageDebugger MCP",
   "description": "MCP server giving AI agents eyes on OpenImageDebugger buffers in live gdb/lldb sessions",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "oid-mcp",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "transport": {
         "type": "stdio"
       }

--- a/resources/oidmcp/tests/test_server_manifest.py
+++ b/resources/oidmcp/tests/test_server_manifest.py
@@ -37,6 +37,22 @@ def test_namespace_matches_the_github_organisation():
     assert _manifest()['name'] == f'{GITHUB_NAMESPACE}/oid-mcp'
 
 
+def test_readme_carries_the_ownership_marker():
+    # The registry proves we own the PyPI package by finding this marker in the
+    # package description, and the name after it must match server.json exactly.
+    # The marker has to be followed by a boundary, so it stays on its own line
+    # inside a comment rather than being glued to trailing punctuation.
+    readme = (OIDMCP / 'README.md').read_text()
+    assert f'<!-- mcp-name: {_manifest()["name"]} -->' in readme
+
+
+def test_readme_reaches_pypi_as_the_long_description():
+    # A marker in a README that the wheel does not ship is invisible to the
+    # registry, which is exactly how the 0.3.3 listing failed.
+    pyproject = (OIDMCP / 'pyproject.toml').read_text()
+    assert 'readme = "README.md"' in pyproject
+
+
 def test_manifest_version_matches_pyproject():
     assert _manifest()['version'] == _pyproject_version()
 

--- a/resources/oidmcp/uv.lock
+++ b/resources/oidmcp/uv.lock
@@ -578,7 +578,7 @@ wheels = [
 
 [[package]]
 name = "oid-mcp"
-version = "0.3.3"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
`oid-mcp` 0.3.4 fixes the two reasons the MCP registry refused to list the
server for 0.3.2 and 0.3.3.

The registry proves we own the PyPI package by finding an `mcp-name:` marker
in the package description on PyPI. Two things kept it from finding one:

- `pyproject.toml` never declared `readme`, so the wheel shipped a 251-byte
  METADATA and the PyPI project page carried no description at all. It now
  ships `README.md` as the long description.
- The marker inside that README still had the lowercased namespace
  `io.github.openimagedebugger/oid-mcp`, which matches neither `server.json`
  nor the GitHub organisation the registry authenticates against. Corrected
  to `io.github.OpenImageDebugger/oid-mcp`.

Because the README now reaches PyPI on its own, its one relative link (to the
build instructions in the top-level README) had to become absolute. PyPI has
no repository around the file to resolve `../../README.md`.

`tests/test_server_manifest.py` is new. It guards the metadata that only
matters at publish time and therefore drifts unnoticed: the namespace casing,
the marker's presence and its agreement with `server.json`, the `readme`
declaration, and the version agreeing across `server.json` and
`pyproject.toml`. The two version checks need `tomllib` and skip on Python
3.10, which the package still supports; the namespace and marker checks need
no parser and run on every supported interpreter.

Merging this publishes nothing. The `oid-mcp-v0.3.4` tag does.
