### PR TITLE
chore: release oid-mcp 0.3.5

### DIFF
--- a/resources/oidmcp/CHANGELOG.md
+++ b/resources/oidmcp/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to `oid-mcp` are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.3.5] — 2026-08-05
+
+### Added
+- The MCP registry listing now links back to the source. `server.json` carries
+  the repository URL, GitHub's numeric repository id and the path to the server
+  inside the repo, so anyone reading the listing can inspect the code the
+  package was built from. The published package is otherwise identical to
+  0.3.4.
+
 ## [0.3.4] — 2026-08-05
 
 ### Added

--- a/resources/oidmcp/pyproject.toml
+++ b/resources/oidmcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oid-mcp"
-version = "0.3.4"
+version = "0.3.5"
 description = "MCP server giving AI agents eyes on OpenImageDebugger buffers in live gdb/lldb sessions"
 # Ships the README as the PyPI long description. The MCP registry reads that
 # description to verify package ownership, so without this the registry cannot

--- a/resources/oidmcp/server.json
+++ b/resources/oidmcp/server.json
@@ -3,12 +3,18 @@
   "name": "io.github.OpenImageDebugger/oid-mcp",
   "title": "OpenImageDebugger MCP",
   "description": "MCP server giving AI agents eyes on OpenImageDebugger buffers in live gdb/lldb sessions",
-  "version": "0.3.4",
+  "repository": {
+    "url": "https://github.com/OpenImageDebugger/OpenImageDebugger",
+    "source": "github",
+    "id": "205714671",
+    "subfolder": "resources/oidmcp"
+  },
+  "version": "0.3.5",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "oid-mcp",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "transport": {
         "type": "stdio"
       }

--- a/resources/oidmcp/tests/test_server_manifest.py
+++ b/resources/oidmcp/tests/test_server_manifest.py
@@ -53,6 +53,21 @@ def test_readme_reaches_pypi_as_the_long_description():
     assert 'readme = "README.md"' in pyproject
 
 
+def test_manifest_links_back_to_the_repository():
+    # Without this block the registry listing has no route to the source, which
+    # is how it read for the first four releases. The numeric id is what lets a
+    # registry tell this repository from one that reused its name, so it has to
+    # be the id GitHub reports (`gh api repos/<owner>/<repo> --jq .id`), and the
+    # subfolder points at the server rather than the repository root.
+    repository = _manifest()['repository']
+    assert repository['url'] == (
+        'https://github.com/OpenImageDebugger/OpenImageDebugger'
+    )
+    assert repository['source'] == 'github'
+    assert repository['id'] == '205714671'
+    assert repository['subfolder'] == 'resources/oidmcp'
+
+
 def test_manifest_version_matches_pyproject():
     assert _manifest()['version'] == _pyproject_version()
 

--- a/resources/oidmcp/uv.lock
+++ b/resources/oidmcp/uv.lock
@@ -578,7 +578,7 @@ wheels = [
 
 [[package]]
 name = "oid-mcp"
-version = "0.3.4"
+version = "0.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
The MCP registry listing for `oid-mcp` has no route back to the source. The
registry shows only what `server.json` declares, and it never declared a
repository, so a reader of the listing cannot get from it to the code the
package was built from.

`server.json` now carries the repository URL, GitHub's numeric repository id
and the path to the server inside the repo (`resources/oidmcp`). The id is the
part that matters for trust: it is stable across renames and changes if a
repository is deleted and recreated, so a registry can tell this project from
one that later claimed its name.

The published package is otherwise identical to 0.3.4. `server.json` reaches
the registry only on a tagged release, which is why this is a version bump
rather than a standalone edit.

`tests/test_server_manifest.py` gains a check for the block, pinning the URL,
the source, the id and the subfolder. The manifest was validated against the
registry's published `2025-12-11` schema before commit.
