### PR TITLE
feat: only persist the settings a build actually owns

### DIFF
--- a/src/host/settings/app_settings.h
+++ b/src/host/settings/app_settings.h
@@ -55,6 +55,42 @@ struct AppSettings {
     friend bool operator==(const AppSettings&, const AppSettings&) = default;
 };
 
+// Which parts of AppSettings this build is entitled to persist.
+//
+// Natively the viewer owns its window and its session, so it persists all of
+// it to its own settings file. Embedded in a host, the window belongs to that
+// host and the buffer list belongs to whatever restore the host runs, so a
+// build that sends either one is telling somebody else about their own state
+// -- and, in the case of the buffer list, being told it back as an
+// instruction to plot those buffers again.
+enum class SettingsScope { FULL, VIEWER_OWNED };
+
+// `live` as this scope is entitled to persist it. Identity under FULL.
+//
+// Under VIEWER_OWNED the host-owned fields come back at their defaults, which
+// is what keeps them out of SettingsSaver's comparison: the window size does
+// not converge behind an embedded canvas, so a snapshot that still carried it
+// would differ from its predecessor on nearly every frame and the saver would
+// emit for the life of the session whether or not anyone touched a setting.
+//
+// Takes `live` by value so a caller with a temporary or a moved-from local
+// can hand it over without a copy; both branches below return the parameter
+// itself, which moves rather than copies.
+[[nodiscard]] inline AppSettings settings_for_scope(AppSettings live,
+                                                    const SettingsScope scope) {
+    if (scope == SettingsScope::FULL) {
+        return live;
+    }
+
+    const AppSettings defaults{};
+    live.window_w = defaults.window_w;
+    live.window_h = defaults.window_h;
+    live.window_x = defaults.window_x;
+    live.window_y = defaults.window_y;
+    live.previous_buffers = defaults.previous_buffers;
+    return live;
+}
+
 } // namespace oid::host
 
 #endif // HOST_SETTINGS_APP_SETTINGS_H_

--- a/src/host/settings/settings_store.cpp
+++ b/src/host/settings/settings_store.cpp
@@ -117,33 +117,74 @@ void apply_previous_buffers_section(const nlohmann::json& buffers,
     }
 }
 
+// Reports a host-owned key an embedding-host build declined to apply, via
+// `on_ignored` if one was given. A sink that throws is swallowed here,
+// deliberately: it has nothing further to report, and letting the exception
+// escape would be caught by settings_from_json()'s own try/catch and
+// mistaken for a parse failure -- discarding fields (e.g. "ui") that had
+// already parsed cleanly because a diagnostic callback misbehaved.
+void report_ignored(const std::function<void(std::string_view key)>& on_ignored,
+                    const std::string_view key) {
+    if (!on_ignored) {
+        return;
+    }
+    try {
+        on_ignored(key);
+    } catch (...) { // NOSONAR(cpp:S2738,cpp:S2486) -- catch-all is
+        // deliberate here, not careless: narrowing to `const std::exception&`
+        // would let a non-std throw escape into settings_from_json()'s outer
+        // handler and reintroduce the exact defect this function exists to
+        // prevent, a logging fault discarding a "ui" section that had
+        // already parsed cleanly and reporting a parse failure that never
+        // happened. See the comment above.
+    }
+}
+
 } // namespace
 
-std::string settings_to_json(const AppSettings& s) {
+std::string settings_to_json(const AppSettings& s, const SettingsScope scope) {
+    const bool emit_host_owned = scope == SettingsScope::FULL;
+
     nlohmann::json j;
     j["version"] = 1;
-    j["window"] = {{"w", s.window_w}, {"h", s.window_h}};
-    if (s.window_x.has_value()) {
-        j["window"]["x"] = *s.window_x;
+
+    if (emit_host_owned) {
+        j["window"] = {{"w", s.window_w}, {"h", s.window_h}};
+        if (s.window_x.has_value()) {
+            j["window"]["x"] = *s.window_x;
+        }
+        if (s.window_y.has_value()) {
+            j["window"]["y"] = *s.window_y;
+        }
     }
-    if (s.window_y.has_value()) {
-        j["window"]["y"] = *s.window_y;
-    }
+
     j["ui"] = {{"leftPaneWidth", s.left_pane_w},
                {"contrastEnabled", s.contrast_enabled},
                {"linkViews", s.link_views},
                {"lastExportDir", s.last_export_dir}};
 
-    auto arr = nlohmann::json::array();
-    for (const auto& [variable_name, expiry_epoch_s] : s.previous_buffers) {
-        arr.push_back({{"name", variable_name}, {"expiry", expiry_epoch_s}});
+    if (emit_host_owned) {
+        auto arr = nlohmann::json::array();
+        for (const auto& [variable_name, expiry_epoch_s] : s.previous_buffers) {
+            arr.push_back(
+                {{"name", variable_name}, {"expiry", expiry_epoch_s}});
+        }
+        j["previousBuffers"] = std::move(arr);
     }
-    j["previousBuffers"] = std::move(arr);
 
-    return j.dump(2);
+    // error_handler_t::replace keeps the "never throws" contract above true:
+    // dump() otherwise throws type_error.316 on invalid UTF-8, and
+    // last_export_dir is a filesystem path, which on Linux need not be
+    // UTF-8. Substituting U+FFFD only changes output for input that would
+    // otherwise have thrown, so this can't affect the byte-identical lock
+    // in settings_store_test.cpp.
+    return j.dump(2, ' ', false, nlohmann::json::error_handler_t::replace);
 }
 
-AppSettings settings_from_json(std::string_view json) {
+AppSettings settings_from_json(
+    std::string_view json,
+    const SettingsScope scope,
+    const std::function<void(std::string_view key)>& on_ignored) {
     const AppSettings defaults{};
 
     try {
@@ -156,17 +197,27 @@ AppSettings settings_from_json(std::string_view json) {
 
         AppSettings out{};
 
-        if (j.contains("window") && j.at("window").is_object()) {
-            apply_window_section(j.at("window"), defaults, out);
+        const bool apply_host_owned = scope == SettingsScope::FULL;
+
+        if (apply_host_owned) {
+            if (j.contains("window") && j.at("window").is_object()) {
+                apply_window_section(j.at("window"), defaults, out);
+            }
+        } else if (j.contains("window")) {
+            report_ignored(on_ignored, "window");
         }
 
         if (j.contains("ui") && j.at("ui").is_object()) {
             apply_ui_section(j.at("ui"), defaults, out);
         }
 
-        if (j.contains("previousBuffers") &&
-            j.at("previousBuffers").is_array()) {
-            apply_previous_buffers_section(j.at("previousBuffers"), out);
+        if (apply_host_owned) {
+            if (j.contains("previousBuffers") &&
+                j.at("previousBuffers").is_array()) {
+                apply_previous_buffers_section(j.at("previousBuffers"), out);
+            }
+        } else if (j.contains("previousBuffers")) {
+            report_ignored(on_ignored, "previousBuffers");
         }
 
         return out;
@@ -189,7 +240,7 @@ AppSettings SettingsStore::load() const {
         }
         const std::string content{std::istreambuf_iterator(is),
                                   std::istreambuf_iterator<char>()};
-        return settings_from_json(content);
+        return settings_from_json(content, SettingsScope::FULL);
     } catch (const std::exception& e) {
         std::cerr << "[OID] settings load failed: " << e.what() << '\n';
         return AppSettings{};
@@ -200,7 +251,8 @@ AppSettings SettingsStore::load() const {
 
 void SettingsStore::save(const AppSettings& settings) const {
     try {
-        const std::string json = settings_to_json(settings);
+        const std::string json =
+            settings_to_json(settings, SettingsScope::FULL);
 
         if (const auto parent = file_.parent_path(); !parent.empty()) {
             std::error_code ec;

--- a/src/host/settings/settings_store.h
+++ b/src/host/settings/settings_store.h
@@ -27,6 +27,7 @@
 #define HOST_SETTINGS_SETTINGS_STORE_H_
 
 #include <filesystem>
+#include <functional>
 #include <string>
 #include <string_view>
 
@@ -34,15 +35,39 @@
 
 namespace oid::host {
 
-// Serializes an AppSettings snapshot to the same JSON shape SettingsStore
+// Serializes an AppSettings snapshot to the JSON shape SettingsStore
 // persists to disk. Never throws.
-[[nodiscard]] std::string settings_to_json(const AppSettings& s);
+//
+// Under SettingsScope::VIEWER_OWNED the host-owned keys are omitted entirely
+// rather than emitted empty: an embedding host that stores what it is given
+// should not be storing a window it owns, nor a buffer list the viewer would
+// read back as an instruction to re-plot.
+[[nodiscard]] std::string settings_to_json(const AppSettings& s,
+                                           SettingsScope scope);
 
 // Parses a JSON snapshot back into AppSettings, tolerant field-by-field: a
 // missing/wrong-typed field (or a malformed/empty document) falls back to
 // that field's default without discarding any other valid field. Never
 // throws.
-[[nodiscard]] AppSettings settings_from_json(std::string_view json);
+//
+// Under SettingsScope::VIEWER_OWNED the host-owned sections are not applied,
+// however well-formed they are: on such a build the window and the buffer
+// list belong to whoever embeds the viewer, and reading them back would let
+// a stored payload drive a restore this build does not own.
+//
+// `on_ignored` is called once per host-owned key found in such a payload.
+// It is a sink rather than a log line so that this stays a pure function
+// with no opinion about logging, the same way SettingsSaver takes its
+// SaveSink -- inject a callback instead of doing I/O here (SaveSink itself
+// is mandatory and unguarded; this sink is optional and guarded, so the
+// likeness is in the shape, not in the contract). An empty sink is not an
+// error and parsing behaves identically without one. A sink that throws is
+// contained and cannot affect the parse result: it cannot discard a field
+// that had already parsed cleanly, nor be mistaken for a parse failure.
+[[nodiscard]] AppSettings settings_from_json(
+    std::string_view json,
+    SettingsScope scope,
+    const std::function<void(std::string_view key)>& on_ignored = {});
 
 // Qt-free JSON settings persistence. load()/save() are thin file-I/O
 // wrappers around settings_from_json()/settings_to_json(): load() reads the

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -346,13 +346,32 @@ bool create_canvas(GLFWwindow* window,
     return true;
 }
 
+// Groups the FrameContext members that exist solely to feed
+// persist_settings_if_dirty below: the per-session dedup set, the merged
+// previous-buffers list, the debounced saver, and the scope saying which
+// slice of settings this build owns. None of the four is read anywhere
+// else in the frame loop -- unlike, say, left_pane_w or last_export_dir,
+// which persist_settings_if_dirty also reads but which stay directly on
+// FrameContext because the pane-splitter layout and the export path read
+// them too.
+struct SettingsPersistence {
+    std::set<std::string, std::less<>>& seen_this_session;
+    std::vector<oid::host::PreviousBuffer>& prev_buffers;
+    oid::host::SettingsSaver& saver;
+    oid::host::SettingsScope settings_scope;
+};
+
 // Aggregates references to the frame loop's per-main() state so the frame
 // lambda's body (originally ~180 lines, all under one capture list) can be
 // split into named helpers below without re-threading each one's own
 // parameter list. Every member is a reference to a main()-local that
 // outlives the frame loop (the loop runs to completion inside main()), so
 // holding references here is safe; nothing here is copied out of the
-// locals the lambda used to mutate through its capture list.
+// locals the lambda used to mutate through its capture list -- except
+// `settings_persistence.settings_scope`, which is a plain value (an enum,
+// cheap to copy) rather than a reference to anything. settings_persistence
+// itself groups the settings-persistence-only state; see its comment
+// above.
 struct FrameContext {
     oid::host::IpcClient& ipc;
     oid::host::UiState& ui;
@@ -368,10 +387,8 @@ struct FrameContext {
     std::shared_ptr<oid::host::GlfwCanvas>& canvas;
     oid::host::StageView& view;
     PaneRenderSize& pane_size;
-    std::set<std::string, std::less<>>& seen_this_session;
-    std::vector<oid::host::PreviousBuffer>& prev_buffers;
     oid::platform::SessionBridge& session_bridge;
-    oid::host::SettingsSaver& saver;
+    SettingsPersistence settings_persistence;
     oid::host::FileOpenQueue& file_open_queue;
 #if !defined(__EMSCRIPTEN__)
     // Non-null only when OID_AGENT=1; see the construction site in main()
@@ -731,7 +748,8 @@ void persist_settings_if_dirty(const FrameContext& ctx) {
         if (ctx.model.at(i).kind == oid::host::BufferKind::LOCAL_FILE) {
             continue;
         }
-        ctx.seen_this_session.insert(ctx.model.variable_name_of(i));
+        ctx.settings_persistence.seen_this_session.insert(
+            ctx.model.variable_name_of(i));
     }
     std::vector<std::string> loaded_names;
     loaded_names.reserve(ctx.model.size());
@@ -744,8 +762,11 @@ void persist_settings_if_dirty(const FrameContext& ctx) {
     const auto now_s = std::chrono::duration_cast<std::chrono::seconds>(
                            std::chrono::system_clock::now().time_since_epoch())
                            .count();
-    ctx.prev_buffers = oid::host::merge_previous_buffers(
-        ctx.prev_buffers, loaded_names, ctx.seen_this_session, now_s);
+    ctx.settings_persistence.prev_buffers = oid::host::merge_previous_buffers(
+        ctx.settings_persistence.prev_buffers,
+        loaded_names,
+        ctx.settings_persistence.seen_this_session,
+        now_s);
 
     oid::host::AppSettings live;
     const auto [ww, wh] = ctx.backend.window_size();
@@ -757,7 +778,7 @@ void persist_settings_if_dirty(const FrameContext& ctx) {
     live.left_pane_w = ctx.left_pane_w;
     live.contrast_enabled = ctx.ui.contrast_enabled();
     live.link_views = ctx.ui.link_views();
-    live.previous_buffers = ctx.prev_buffers;
+    live.previous_buffers = ctx.settings_persistence.prev_buffers;
     live.last_export_dir = ctx.last_export_dir;
     // Hold off saving until the platform says persisting is safe
     // (see SessionBridge::can_persist -- non-native builds gate on the
@@ -765,7 +786,14 @@ void persist_settings_if_dirty(const FrameContext& ctx) {
     // default/empty snapshot doesn't get echoed back and overwrite the
     // persisted buffer list; native is always safe).
     if (ctx.session_bridge.can_persist()) {
-        ctx.saver.update(live, glfwGetTime());
+        // Scoped before the saver, not after: the saver's whole job is
+        // deciding whether anything changed, and on a build that does not own
+        // the window the geometry never settles, so an unscoped snapshot
+        // differs on nearly every frame and it would emit for ever.
+        ctx.settings_persistence.saver.update(
+            oid::host::settings_for_scope(
+                std::move(live), ctx.settings_persistence.settings_scope),
+            glfwGetTime());
     }
 }
 
@@ -853,18 +881,31 @@ int main(int argc, char** argv) {
     // ipc.set_session_state_callback below) -- sharing this lambda means
     // the two call sites can't drift apart.
     auto apply_settings =
-        [&ui, &left_pane_w, &last_export_dir, &prev_buffers, &ipc](
-            const oid::host::AppSettings& s) {
+        [&ui,
+         &left_pane_w,
+         &last_export_dir,
+         &prev_buffers,
+         &ipc,
+         scope = settings_backend.scope()](const oid::host::AppSettings& s) {
             ui.set_contrast_enabled(s.contrast_enabled);
             ui.set_link_views(s.link_views);
             left_pane_w = s.left_pane_w;
             last_export_dir = s.last_export_dir;
-            prev_buffers = s.previous_buffers;
-            // Seed the previous-session buffer list; IpcClient auto-re-requests
-            // each one (if still available and not expired) the next time the
-            // bridge sends SET_AVAILABLE_SYMBOLS, so previously-plotted buffers
-            // reappear once the debugger reconnects.
-            ipc.set_restore_buffers(s.previous_buffers);
+            // Not redundant with the parser's own scope guard: the parser
+            // already declines host-owned keys under VIEWER_OWNED, but it
+            // returns *defaults* for them, and without this check those
+            // defaults would overwrite the viewer's own in-session tracking
+            // on every inbound message, emptying prev_buffers and clearing
+            // the restore list.
+            if (scope == oid::host::SettingsScope::FULL) {
+                prev_buffers = s.previous_buffers;
+                // Seed the previous-session buffer list; IpcClient
+                // auto-re-requests each one (if still available and not
+                // expired) the next time the bridge sends
+                // SET_AVAILABLE_SYMBOLS, so previously-plotted buffers
+                // reappear once the debugger reconnects.
+                ipc.set_restore_buffers(s.previous_buffers);
+            }
         };
     apply_settings(loaded);
 
@@ -998,8 +1039,14 @@ int main(int argc, char** argv) {
     // wiring), which persists it and can push it back as a session-state
     // update (see apply_settings above). No exit flush is needed there -- the
     // frame loop never returns on non-native builds.
-    oid::host::SettingsSaver saver{loaded,
-                                   settings_backend.make_save_sink(ipc)};
+    // Seeded scoped, not with `loaded` as-is: the invariant "the saver never
+    // holds host-owned state under VIEWER_OWNED" should hold by
+    // construction rather than by relying on settings_backend.load() to
+    // have returned defaults for that scope. Identity under FULL, so native
+    // behaviour is unchanged.
+    oid::host::SettingsSaver saver{
+        oid::host::settings_for_scope(loaded, settings_backend.scope()),
+        settings_backend.make_save_sink(ipc)};
     std::set<std::string, std::less<>> seen_this_session;
 
     // Seeded once from the -o/--open CLI flags; File > Open / Ctrl+O also
@@ -1014,25 +1061,25 @@ int main(int argc, char** argv) {
     // parameter list; see the FrameContext comment above. Every referenced
     // object is a main() local declared above, so all of them outlive the
     // frame loop below.
-    FrameContext ctx{ipc,
-                     ui,
-                     thumbnails,
-                     model,
-                     backend,
-                     goto_open,
-                     stages,
-                     svg_icons,
-                     left_pane_w,
-                     export_dialog,
-                     last_export_dir,
-                     canvas,
-                     view,
-                     pane_size,
-                     seen_this_session,
-                     prev_buffers,
-                     session_bridge,
-                     saver,
-                     file_open_queue};
+    FrameContext ctx{
+        ipc,
+        ui,
+        thumbnails,
+        model,
+        backend,
+        goto_open,
+        stages,
+        svg_icons,
+        left_pane_w,
+        export_dialog,
+        last_export_dir,
+        canvas,
+        view,
+        pane_size,
+        session_bridge,
+        SettingsPersistence{
+            seen_this_session, prev_buffers, saver, settings_backend.scope()},
+        file_open_queue};
 #if !defined(__EMSCRIPTEN__)
     ctx.agent = agent_server ? &*agent_server : nullptr;
 #endif

--- a/src/platform/app_services.cpp
+++ b/src/platform/app_services.cpp
@@ -69,6 +69,12 @@ host::AppSettings SettingsBackend::load() const {
     return impl_->store.load();
 }
 
+host::SettingsScope SettingsBackend::scope() const {
+    // This build owns its window and its session, and writes both to its own
+    // settings file.
+    return host::SettingsScope::FULL;
+}
+
 std::function<void(const host::AppSettings&)>
 SettingsBackend::make_save_sink(host::IpcClient& /*ipc*/) const {
     return [this](const host::AppSettings& a) { impl_->store.save(a); };

--- a/src/platform/app_services.h
+++ b/src/platform/app_services.h
@@ -94,6 +94,12 @@ class SettingsBackend {
 
     [[nodiscard]] host::AppSettings load() const;
 
+    // Which parts of AppSettings this build is entitled to persist. Shared
+    // code asks rather than assuming, because the answer differs by platform
+    // and the wrong answer is silent: it sends an embedding host state that
+    // the host already owns, and reads it back as an instruction.
+    [[nodiscard]] host::SettingsScope scope() const;
+
     [[nodiscard]] std::function<void(const host::AppSettings&)>
     make_save_sink(host::IpcClient& ipc) const;
 

--- a/tests/host/settings/settings_store_test.cpp
+++ b/tests/host/settings/settings_store_test.cpp
@@ -25,9 +25,14 @@
 
 #include "host/settings/settings_store.h"
 #include "support/scratch_dir.h"
+#include <algorithm>
+#include <exception>
 #include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
 using namespace oid::host;
 
 static std::filesystem::path temp_file(const std::string& name) {
@@ -141,22 +146,24 @@ TEST(SettingsStore, JsonRoundTrip) {
     s.last_export_dir = "/home/user/exports";
     s.previous_buffers = {{"a", 111}, {"b", 222}};
 
-    const std::string json = settings_to_json(s);
-    const AppSettings out = settings_from_json(json);
+    const std::string json = settings_to_json(s, SettingsScope::FULL);
+    const AppSettings out = settings_from_json(json, SettingsScope::FULL);
     EXPECT_EQ(out, s);
 }
 
 TEST(SettingsStore, JsonFromEmptyStringYieldsDefaults) {
-    EXPECT_EQ(settings_from_json(""), AppSettings{});
+    EXPECT_EQ(settings_from_json("", SettingsScope::FULL), AppSettings{});
 }
 
 TEST(SettingsStore, JsonFromGarbageYieldsDefaults) {
-    EXPECT_EQ(settings_from_json("}{ not json"), AppSettings{});
+    EXPECT_EQ(settings_from_json("}{ not json", SettingsScope::FULL),
+              AppSettings{});
 }
 
 TEST(SettingsStore, JsonFromPartialKeepsPresentFieldsRestDefault) {
-    const AppSettings out = settings_from_json(
-        R"({"ui":{"leftPaneWidth":150.0,"linkViews":true}})");
+    const AppSettings out =
+        settings_from_json(R"({"ui":{"leftPaneWidth":150.0,"linkViews":true}})",
+                           SettingsScope::FULL);
     EXPECT_FLOAT_EQ(out.left_pane_w, 150.0f);
     EXPECT_TRUE(out.link_views);
     EXPECT_TRUE(out.contrast_enabled);      // default kept
@@ -177,8 +184,9 @@ TEST(SettingsStore, StoreLoadSaveDelegateToJsonFunctions) {
     std::ifstream is{p, std::ios::binary};
     const std::string content{std::istreambuf_iterator<char>(is),
                               std::istreambuf_iterator<char>()};
-    EXPECT_EQ(content, settings_to_json(s));
-    EXPECT_EQ(SettingsStore{p}.load(), settings_from_json(content));
+    EXPECT_EQ(content, settings_to_json(s, SettingsScope::FULL));
+    EXPECT_EQ(SettingsStore{p}.load(),
+              settings_from_json(content, SettingsScope::FULL));
 }
 
 TEST(SettingsStore, SaveLeavesNoLeftoverTempFiles) {
@@ -204,4 +212,302 @@ TEST(SettingsStore, SaveLeavesNoLeftoverTempFiles) {
     EXPECT_EQ(tmp_count, 0);  // temp file renamed/cleaned, never left behind
     EXPECT_EQ(json_count, 1); // exactly the settings file
     fs::remove_all(dir);
+}
+
+TEST(SettingsForScope, FullIsIdentity) {
+    AppSettings s;
+    s.window_w = 800;
+    s.window_h = 600;
+    s.window_x = 40;
+    s.window_y = 30;
+    s.previous_buffers = {{"a", 111}};
+    EXPECT_EQ(settings_for_scope(s, SettingsScope::FULL), s);
+}
+
+TEST(SettingsForScope, ViewerOwnedDropsWhatTheHostOwns) {
+    AppSettings s;
+    s.window_w = 800;
+    s.window_h = 600;
+    s.window_x = 40;
+    s.window_y = 30;
+    s.previous_buffers = {{"a", 111}};
+    s.contrast_enabled = false;
+    s.left_pane_w = 300.0f;
+    s.last_export_dir = "/home/user/exports";
+
+    const AppSettings scoped =
+        settings_for_scope(s, SettingsScope::VIEWER_OWNED);
+    const AppSettings defaults{};
+
+    EXPECT_EQ(scoped.window_w, defaults.window_w);
+    EXPECT_EQ(scoped.window_h, defaults.window_h);
+    EXPECT_EQ(scoped.window_x, defaults.window_x);
+    EXPECT_EQ(scoped.window_y, defaults.window_y);
+    EXPECT_TRUE(scoped.previous_buffers.empty());
+
+    // Everything the viewer owns survives untouched.
+    EXPECT_FALSE(scoped.contrast_enabled);
+    EXPECT_FLOAT_EQ(scoped.left_pane_w, 300.0f);
+    EXPECT_EQ(scoped.last_export_dir, "/home/user/exports");
+}
+
+// The traffic fix, stated as an assertion: two snapshots that differ only in
+// geometry must be indistinguishable to the saver's comparison once scoped,
+// because that comparison is the only thing deciding whether a frame goes out.
+TEST(SettingsForScope, GeometryChurnComparesEqualUnderViewerOwned) {
+    AppSettings a;
+    a.window_w = 800;
+    a.window_h = 600;
+    AppSettings b = a;
+    b.window_w = 801;
+    b.window_h = 599;
+
+    EXPECT_NE(a, b);
+    EXPECT_EQ(settings_for_scope(a, SettingsScope::VIEWER_OWNED),
+              settings_for_scope(b, SettingsScope::VIEWER_OWNED));
+}
+
+TEST(SettingsForScope, LeavesItsArgumentAlone) {
+    AppSettings s;
+    s.window_w = 800;
+    s.previous_buffers = {{"a", 111}};
+    const AppSettings before = s;
+
+    (void)settings_for_scope(s, SettingsScope::VIEWER_OWNED);
+
+    EXPECT_EQ(s, before);
+}
+
+TEST(SettingsToJson, FullOutputIsByteIdenticalToWhatWeAlwaysWrote) {
+    AppSettings s;
+    s.window_w = 800;
+    s.window_h = 600;
+    s.window_x = 40;
+    s.window_y = 30;
+    s.left_pane_w = 300.0f;
+    s.contrast_enabled = false;
+    s.link_views = true;
+    s.previous_buffers = {{"a", 111}, {"b", 222}};
+    s.last_export_dir = "/home/user/exports";
+
+    // Byte-for-byte, from the build that shipped before the scope existed.
+    // The on-disk settings file is this format; a diff here is a migration
+    // nobody planned. Weakening this test defeats its only purpose.
+    EXPECT_EQ(settings_to_json(s, SettingsScope::FULL),
+              R"({
+  "previousBuffers": [
+    {
+      "expiry": 111,
+      "name": "a"
+    },
+    {
+      "expiry": 222,
+      "name": "b"
+    }
+  ],
+  "ui": {
+    "contrastEnabled": false,
+    "lastExportDir": "/home/user/exports",
+    "leftPaneWidth": 300.0,
+    "linkViews": true
+  },
+  "version": 1,
+  "window": {
+    "h": 600,
+    "w": 800,
+    "x": 40,
+    "y": 30
+  }
+})");
+}
+
+TEST(SettingsToJson, ViewerOwnedCarriesOnlyVersionAndUi) {
+    AppSettings s;
+    s.window_w = 800;
+    s.window_h = 600;
+    s.window_x = 40;
+    s.window_y = 30;
+    s.previous_buffers = {{"a", 111}};
+    s.contrast_enabled = false;
+
+    const auto j =
+        nlohmann::json::parse(settings_to_json(s, SettingsScope::VIEWER_OWNED));
+
+    EXPECT_TRUE(j.contains("version"));
+    EXPECT_TRUE(j.contains("ui"));
+    EXPECT_FALSE(j.contains("window"));
+    EXPECT_FALSE(j.contains("previousBuffers"));
+    EXPECT_EQ(j.at("ui").at("contrastEnabled").get<bool>(), false);
+}
+
+TEST(SettingsToJson, DoesNotThrowOnInvalidUtf8LastExportDir) {
+    // last_export_dir is filesystem-path-derived, and a filesystem path need
+    // not be valid UTF-8 on Linux. A lone 0xFF is not a valid UTF-8 lead
+    // byte on its own; confirmed against this vendored nlohmann/json (via a
+    // standalone probe against the library directly, not this codebase) that
+    // it makes json::dump() throw type_error.316 under the library's default
+    // (strict) error handler -- the throw settings_to_json's "Never throws"
+    // contract requires nothing ever hits. error_handler_t::replace is what
+    // keeps that contract true for this input.
+    AppSettings s;
+    s.last_export_dir = std::string(1, static_cast<char>(0xFF));
+
+    std::string json;
+    EXPECT_NO_THROW(json = settings_to_json(s, SettingsScope::FULL));
+
+    // The output is still well-formed JSON, with the invalid byte replaced
+    // rather than silently dropped or left to corrupt the document.
+    const auto parsed = nlohmann::json::parse(json, nullptr, false);
+    ASSERT_FALSE(parsed.is_discarded());
+    EXPECT_NE(
+        parsed.at("ui")
+            .at("lastExportDir")
+            .get<std::string>()
+            .find("\xEF\xBF\xBD"), // UTF-8 for U+FFFD, the replacement char
+        std::string::npos);
+}
+
+TEST(SettingsFromJson, ViewerOwnedIgnoresHostOwnedSectionsAndReportsThem) {
+    const auto json = R"({
+      "version": 1,
+      "window": {"w": 800, "h": 600, "x": 40, "y": 30},
+      "ui": {"leftPaneWidth": 300.0, "contrastEnabled": false,
+             "linkViews": true, "lastExportDir": "/home/user/exports"},
+      "previousBuffers": [{"name": "a", "expiry": 111}]
+    })";
+
+    std::vector<std::string> ignored;
+    const AppSettings out = settings_from_json(
+        json,
+        SettingsScope::VIEWER_OWNED,
+        [&ignored](const std::string_view key) { ignored.emplace_back(key); });
+
+    const AppSettings defaults{};
+    EXPECT_EQ(out.window_w, defaults.window_w);
+    EXPECT_EQ(out.window_h, defaults.window_h);
+    EXPECT_EQ(out.window_x, defaults.window_x);
+    EXPECT_EQ(out.window_y, defaults.window_y);
+    EXPECT_TRUE(out.previous_buffers.empty());
+
+    // The viewer's own preferences still arrive.
+    EXPECT_FLOAT_EQ(out.left_pane_w, 300.0f);
+    EXPECT_FALSE(out.contrast_enabled);
+    EXPECT_TRUE(out.link_views);
+    EXPECT_EQ(out.last_export_dir, "/home/user/exports");
+
+    // Reporting order isn't contractual, only the set of reported keys is.
+    std::ranges::sort(ignored);
+    EXPECT_EQ(ignored, (std::vector<std::string>{"previousBuffers", "window"}));
+}
+
+TEST(SettingsFromJson, ViewerOwnedReportsNothingWhenTheHostSendsNothingItOwns) {
+    const auto json = R"({"version": 1, "ui": {"contrastEnabled": true}})";
+
+    std::vector<std::string> ignored;
+    const AppSettings out = settings_from_json(
+        json,
+        SettingsScope::VIEWER_OWNED,
+        [&ignored](const std::string_view key) { ignored.emplace_back(key); });
+
+    EXPECT_TRUE(out.contrast_enabled);
+    EXPECT_TRUE(ignored.empty());
+}
+
+TEST(SettingsFromJson, AMissingSinkIsNotAnError) {
+    const auto json =
+        R"({"window": {"w": 800}, "ui": {"contrastEnabled": true}})";
+
+    const AppSettings out =
+        settings_from_json(json, SettingsScope::VIEWER_OWNED);
+
+    EXPECT_EQ(out.window_w, AppSettings{}.window_w);
+    EXPECT_TRUE(out.contrast_enabled);
+}
+
+TEST(SettingsFromJson, FullStillReadsEverything) {
+    const auto json = R"({
+      "version": 1,
+      "window": {"w": 800, "h": 600},
+      "ui": {"contrastEnabled": false},
+      "previousBuffers": [{"name": "a", "expiry": 111}]
+    })";
+
+    const AppSettings out = settings_from_json(json, SettingsScope::FULL);
+
+    EXPECT_EQ(out.window_w, 800);
+    EXPECT_EQ(out.window_h, 600);
+    EXPECT_FALSE(out.contrast_enabled);
+    ASSERT_EQ(out.previous_buffers.size(), 1u);
+    EXPECT_EQ(out.previous_buffers.front().variable_name, "a");
+}
+
+TEST(SettingsFromJson, ViewerOwnedReportsMalformedHostOwnedKeysToo) {
+    // A host-owned key that is present but not the shape FULL would have
+    // parsed (a number instead of an object/array) is still declined, and
+    // that decline is still reported: under VIEWER_OWNED the shape never
+    // gets looked at, so it can't be the thing that decides whether to
+    // report.
+    const auto json =
+        R"({"window": 5, "previousBuffers": 7, "ui": {"contrastEnabled": true}})";
+
+    std::vector<std::string> ignored;
+    const AppSettings out = settings_from_json(
+        json,
+        SettingsScope::VIEWER_OWNED,
+        [&ignored](const std::string_view key) { ignored.emplace_back(key); });
+
+    EXPECT_TRUE(out.contrast_enabled);
+
+    // Reporting order isn't contractual, only the set of reported keys is.
+    std::ranges::sort(ignored);
+    EXPECT_EQ(ignored, (std::vector<std::string>{"previousBuffers", "window"}));
+}
+
+namespace {
+// Test-local: distinguishes "the sink under test threw" from any exception
+// a real dependency (std::* or otherwise) might raise, so a passing
+// assertion can't be explained by the wrong throw.
+struct SinkFailure : std::exception {
+    [[nodiscard]] const char* what() const noexcept override {
+        return "on_ignored sink failure";
+    }
+};
+} // namespace
+
+TEST(SettingsFromJson, AThrowingSinkDoesNotCostTheCallerItsData) {
+    // AppSettings{}.contrast_enabled defaults to true, so a fall-back to
+    // defaults and a successful parse of "false" are distinguishable.
+    const auto json =
+        R"({"window": {"w": 800}, "ui": {"contrastEnabled": false}})";
+
+    const AppSettings out =
+        settings_from_json(json,
+                           SettingsScope::VIEWER_OWNED,
+                           [](std::string_view) { throw SinkFailure{}; });
+
+    EXPECT_FALSE(out.contrast_enabled);
+}
+
+TEST(SettingsFromJson, AThrowingSinkStillReportsEveryHostOwnedKey) {
+    // The test above pins containment for a single sink call; this one
+    // pins it per-call: a sink that throws on EVERY call must not stop
+    // after the first host-owned key, so a second one is still reported,
+    // and the parse result is still the cleanly-parsed "ui" value rather
+    // than a fall-back to defaults.
+    const auto json = R"({
+      "window": {"w": 800},
+      "previousBuffers": [{"name": "a", "expiry": 111}],
+      "ui": {"contrastEnabled": false}
+    })";
+
+    std::vector<std::string> ignored;
+    const AppSettings out = settings_from_json(
+        json, SettingsScope::VIEWER_OWNED, [&ignored](std::string_view key) {
+            ignored.emplace_back(key);
+            throw SinkFailure{};
+        });
+
+    EXPECT_FALSE(out.contrast_enabled);
+    std::ranges::sort(ignored);
+    EXPECT_EQ(ignored, (std::vector<std::string>{"previousBuffers", "window"}));
 }


### PR DESCRIPTION
The viewer sends the application embedding it a snapshot of its settings, and that snapshot carried two things the embedding application owns rather than the viewer: the window geometry, and the list of buffers plotted in the previous session.

Both cause real trouble. Handed back, the buffer list is read as an instruction to plot those buffers again, so the viewer starts restoring on its own alongside whatever the embedding application already does, on a different expiry clock. And the window size never settles behind a canvas the viewer does not own, so the snapshot looks changed on nearly every frame and a session-state message goes out roughly every 0.75 seconds for the whole session, whether or not anyone touched a setting.

A build now says which settings it is entitled to persist, and that answer reaches the four places that were quietly assuming one. Natively it is all of them, exactly as before: the settings file, its contents, and when it gets written are unchanged, with a byte-for-byte test to keep it that way. Embedded, it is the preferences only, and a snapshot that differs solely in geometry no longer counts as a change.

State a build does not own is also declined on the way in, so the claim holds from both directions rather than depending on every embedder behaving, and a key that gets declined is reported rather than silently dropped.

The platform answer for the embedded case lands separately, in the layer that embeds the viewer.