### PR TITLE
fix: say when there is no buffer to export

### DIFF
--- a/src/host/ui/export_dialog.cpp
+++ b/src/host/ui/export_dialog.cpp
@@ -118,6 +118,13 @@ void open_export_dialog(ExportDialogState& st,
             last_export_dir, std::getenv("HOME"), buffer_name, st.format));
 }
 
+std::string_view export_selected_refusal(const std::size_t buffer_count) {
+    if (buffer_count == 0) {
+        return "Nothing to export: no buffer is loaded";
+    }
+    return {};
+}
+
 BufferExporter::OutputType classify_export_format(const std::string_view path) {
     for (const auto& fmt : EXPORT_FORMATS) {
         if (ends_with_ci(path, fmt.extension)) {

--- a/src/host/ui/export_dialog.h
+++ b/src/host/ui/export_dialog.h
@@ -65,6 +65,17 @@ void open_export_dialog(ExportDialogState& st,
                         const std::string& buffer_name,
                         const std::string& last_export_dir);
 
+// Why an embedding host's "export selected buffer" command cannot be served,
+// or empty when it can. `buffer_count` is the buffer model's size.
+//
+// The viewer has to answer this because nothing else can: a host sends the
+// command and hears nothing back, and it keeps no copy of which buffer is
+// selected, so a request arriving at an empty viewer used to stop at the
+// callback's bounds check with no dialog, no message and no log line. Worded
+// as a situation rather than a failure -- nothing went wrong, there is simply
+// nothing loaded to export.
+std::string_view export_selected_refusal(std::size_t buffer_count);
+
 // One row per supported export format. `extension` includes the leading dot
 // (".png"); `label` is the name shown in the OS save dialog's format filter.
 // Stored as const char* so the nfd filter list (which needs null-terminated C

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1016,11 +1016,22 @@ int main(int argc, char** argv) {
             apply_settings(s);
         },
         [&ui, &model, &export_dialog, &last_export_dir] {
-            if (const std::size_t idx = ui.selected(); idx < model.size()) {
-                oid::host::open_export_dialog(export_dialog,
-                                              model.variable_name_of(idx),
-                                              last_export_dir);
+            // Refused in words rather than by falling out of a bounds check.
+            // The host that sent this hears nothing back and keeps no copy of
+            // the selection, so a command arriving at an empty viewer used to
+            // end here with no dialog, no message and no log line anywhere,
+            // which from the user's side is indistinguishable from a broken
+            // menu entry. The viewer is the only place that can answer, and
+            // answering here covers both hosts at once.
+            if (const std::string_view refusal =
+                    oid::host::export_selected_refusal(model.size());
+                !refusal.empty()) {
+                ui.set_status_message(std::string{refusal});
+                return;
             }
+            oid::host::open_export_dialog(export_dialog,
+                                          model.variable_name_of(ui.selected()),
+                                          last_export_dir);
         }};
 
     // Debounced/atomic settings persistence: the frame lambda

--- a/tests/host/ui/export_dialog_test.cpp
+++ b/tests/host/ui/export_dialog_test.cpp
@@ -42,6 +42,7 @@ using oid::host::classify_export_format;
 using oid::host::default_export_path;
 using oid::host::ensure_export_extension;
 using oid::host::export_formats;
+using oid::host::export_selected_refusal;
 using oid::host::ExportDialogState;
 using oid::host::extension_for;
 using oid::host::open_export_dialog;
@@ -160,4 +161,33 @@ TEST(ExportDialog, SetExportPathTruncatesOverlongPath) {
     set_export_path(st, long_path);
     // path_buf is a fixed 1024-byte buffer: result is NUL-terminated and fits.
     EXPECT_EQ(std::strlen(st.path_buf.data()), st.path_buf.size() - 1);
+}
+
+TEST(ExportDialog, AHostCommandWithNoBuffersIsRefusedInWords) {
+    // A host's "export selected buffer" command used to evaporate here: with
+    // nothing loaded the callback's bounds check failed and it returned,
+    // leaving no dialog, no message and nothing in any log. Neither host can
+    // cover for that, because neither keeps a copy of which buffer the viewer
+    // has selected and the wire carries no reply, so the answer has to come
+    // from the viewer.
+    EXPECT_FALSE(export_selected_refusal(0).empty());
+}
+
+TEST(ExportDialog, ARefusalNamesTheSituationRatherThanBlamingTheExport) {
+    // Wording, pinned because it is the whole point of the change. Nothing
+    // failed: the user asked to export from a viewer holding nothing, and
+    // "Export failed" would send them looking for a fault that is not there.
+    const std::string_view refusal = export_selected_refusal(0);
+    EXPECT_EQ(refusal, "Nothing to export: no buffer is loaded");
+    // Kept alongside the exact match rather than replaced by it: the exact
+    // match is the tighter pin, and this is the rule behind it, so whoever
+    // rewords the sentence and updates the line above is told what the new
+    // wording still has to avoid.
+    EXPECT_EQ(refusal.find("failed"), std::string_view::npos) << refusal;
+}
+
+TEST(ExportDialog, ALoadedBufferIsNotRefused) {
+    // The other half, so the refusal cannot pass by refusing everything.
+    EXPECT_TRUE(export_selected_refusal(1).empty());
+    EXPECT_TRUE(export_selected_refusal(7).empty());
 }


### PR DESCRIPTION
Asking an editor to export the selected buffer while the viewer held
nothing did nothing at all: no dialog, no message, no line in the log. A
menu entry that silently does nothing is indistinguishable from a broken
one, so the viewer now says what the situation is.

It says it in the status bar, which both the standalone window and the
embedded viewer draw, so this fixes it for every editor at once. Neither
of them could have fixed it themselves: they send the command and hear
nothing back, and they do not track which buffer the viewer has selected.

The wording is deliberately not "export failed". Nothing failed, there
was simply nothing loaded to export.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved export behavior when no buffers are loaded or the selected buffer is unavailable.
  * Displays a clear status message instead of opening an unusable export dialog.
  * Valid selections continue to open the export dialog normally.

* **Tests**
  * Added coverage confirming appropriate handling for unavailable and valid export selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->