### PR TITLE
ci: build CodeQL's C++ database explicitly instead of guessing

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -124,17 +124,29 @@ jobs:
     # onwards, including with no other analysis running, so it was not
     # contention between piled-up runs.
     #
-    # The commands below are the ones build.yml already uses to build this
-    # project in this same container on this same runner image, so they are
-    # known to work here rather than guessed. Two deliberate differences:
+    # What is shared with build.yml is the ground this stands on: the same
+    # container, the same runner image, the same CMake project, and a build
+    # that is known to succeed there. The commands themselves are NOT the same
+    # and are not meant to be kept in sync. build.yml produces installable
+    # release artifacts; this produces a CodeQL database and nothing else, and
+    # every difference below follows from that.
+    #
+    #   Plain Ninja, not "Ninja Multi-Config", with CMAKE_BUILD_TYPE=Release
+    #   instead of --config Release. Multi-Config exists so build.yml can hold
+    #   several configurations in one tree; the analysis compiles one.
+    #
+    #   No CMAKE_INSTALL_PREFIX and no --target install. The database is built
+    #   from compiler invocations, so installing the result copies files for
+    #   a reader that does not exist.
     #
     #   BUILD_TESTS=OFF, because tests are not what this scan is for and
     #   building them costs time for no analysed code.
     #
-    #   No ccache, unlike build.yml. CodeQL's C++ extractor works by observing
-    #   real compiler invocations, so a cache hit is a translation unit that
-    #   never reaches the database. Adding a compiler launcher here would
-    #   quietly shrink what is analysed while everything still looked green.
+    #   No ccache, unlike build.yml, and this is the one that would do damage
+    #   silently. CodeQL's C++ extractor works by observing real compiler
+    #   invocations, so a cache hit is a translation unit that never reaches
+    #   the database. Adding a compiler launcher here would shrink what is
+    #   analysed while every run stayed green.
     - if: matrix.language == 'c-cpp'
       name: Build for analysis
       shell: bash

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -145,13 +145,25 @@ jobs:
     #   No ccache, unlike build.yml, and this is the one that would do damage
     #   silently. CodeQL's C++ extractor works by observing real compiler
     #   invocations, so a cache hit is a translation unit that never reaches
-    #   the database. Adding a compiler launcher here would shrink what is
-    #   analysed while every run stayed green.
+    #   the database, shrinking what is analysed while every run stays green.
+    #
+    #   The launchers are cleared explicitly rather than merely left out.
+    #   CMake initialises CMAKE_<LANG>_COMPILER_LAUNCHER from the environment
+    #   variable of the same name, so this build would inherit a launcher the
+    #   container happens to export without anything here mentioning ccache.
+    #   Verified rather than assumed: configuring with
+    #   CMAKE_CXX_COMPILER_LAUNCHER=ccache in the environment sets the cache
+    #   variable to `ccache`, and passing -DCMAKE_CXX_COMPILER_LAUNCHER=
+    #   leaves it empty.
     - if: matrix.language == 'c-cpp'
       name: Build for analysis
       shell: bash
       run: |
-        cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF
+        cmake -S . -B build -G Ninja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DBUILD_TESTS=OFF \
+          -DCMAKE_C_COMPILER_LAUNCHER= \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=
         cmake --build build
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -114,20 +114,33 @@ jobs:
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-    # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # 3.29.5
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
+    # The template's Autobuild step is gone, which is what the template
+    # itself tells you to do when it does not work: "If this step fails, then
+    # you should remove it and run the build manually".
+    #
+    # It did not fail, it hung. Autobuild would end up cancelled and
+    # `Post Initialize CodeQL` would then never return, so the job held a
+    # runner until its timeout. That happened on every run from 2026-08-13
+    # onwards, including with no other analysis running, so it was not
+    # contention between piled-up runs.
+    #
+    # The commands below are the ones build.yml already uses to build this
+    # project in this same container on this same runner image, so they are
+    # known to work here rather than guessed. Two deliberate differences:
+    #
+    #   BUILD_TESTS=OFF, because tests are not what this scan is for and
+    #   building them costs time for no analysed code.
+    #
+    #   No ccache, unlike build.yml. CodeQL's C++ extractor works by observing
+    #   real compiler invocations, so a cache hit is a translation unit that
+    #   never reaches the database. Adding a compiler launcher here would
+    #   quietly shrink what is analysed while everything still looked green.
+    - if: matrix.language == 'c-cpp'
+      name: Build for analysis
+      shell: bash
+      run: |
+        cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF
+        cmake --build build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # 3.29.5


### PR DESCRIPTION
CodeQL's C++ lane has not completed since 13 August. Autobuild does not
fail, it hangs: it ends up cancelled and the CodeQL cleanup step then
never returns, so the job holds a runner until its timeout.

The most recent run did this with no other analysis running, so the runs
piling up were making it worse rather than causing it.

The template says what to do about this in the comment above the step:
remove Autobuild and build manually. This uses the commands `build.yml`
already uses for this project, in the same container, on the same runner
image.

Tests are off, since they are not what this scan analyses. There is
deliberately no ccache: CodeQL builds its database by observing real
compiler invocations, so a cache hit is a file that never gets analysed,
and copying `build.yml`'s launcher would have shrunk the scan silently.

`build-mode: none` would also end the hang and would be faster, but it
infers compilation units from file extensions rather than watching a
compiler, which is a weaker database for a security gate. Worth reaching
for if this step ever becomes the slow part of CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated security analysis to use a controlled Release build for C/C++ projects.
  * Improved build consistency by using CMake and Ninja while disabling tests and compiler caching during analysis.
  * Streamlined analysis for Python projects by allowing security checks to proceed without an additional build step.
  * Replaced generic automated build handling with project-specific configuration for more predictable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->