### PR TITLE
chore: the Glama MCP registry can verify this repo's maintainer

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "brunoalr"
+  ]
+}


### PR DESCRIPTION
Glama.ai indexes the `oid-mcp` server this repository ships. Claiming the listing for an organization-owned repository requires a `glama.json` at the repository root naming the maintainer's GitHub account, which is all this adds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added project metadata and configuration for integration with the Glama MCP server ecosystem.
  * Identified the project maintainer in the published configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->