### PR TITLE
fix: bump src/thirdparty/imgui to 1.92.9

### DIFF
--- a/src/host/imgui_layer.cpp
+++ b/src/host/imgui_layer.cpp
@@ -74,20 +74,18 @@ bool ImGuiLayer::initialize(GLFWwindow* window, const float content_scale) {
 
 void ImGuiLayer::begin_frame() {
     // Size the canvas/GLFW window BEFORE ImGui_ImplGlfw_NewFrame: the
-    // backend derives DisplaySize (logical points) and
-    // DisplayFramebufferScale from fresh state. Font-atlas work (display
-    // scale changes) also happens before ImGui_ImplOpenGL3_NewFrame so the
-    // destroyed font texture is recreated in the same frame. Both are
-    // platform no-ops on native.
+    // backend reads DisplaySize and DisplayFramebufferScale from it. On a
+    // display scale change just re-add the fonts; ImGui rebuilds the atlas
+    // and the backend recreates its texture on render. FontSizeBase is
+    // seeded from the font only while zero, so reset it or the old size
+    // sticks. Both are no-ops on native.
     platform::sync_canvas_size(window_);
     if (const auto scale = platform::refresh_display_scale(content_scale_);
         scale.has_value()) {
         content_scale_ = *scale;
-        const ImGuiIO& io = ImGui::GetIO();
-        io.Fonts->Clear();
+        ImGui::GetIO().Fonts->Clear();
         setup_ui_fonts(content_scale_);
-        io.Fonts->Build();
-        ImGui_ImplOpenGL3_DestroyFontsTexture();
+        ImGui::GetStyle().FontSizeBase = 0.0f;
     }
     ImGui_ImplOpenGL3_NewFrame();
     ImGui_ImplGlfw_NewFrame();

--- a/src/host/ui/panels/buffer_list_panel.cpp
+++ b/src/host/ui/panels/buffer_list_panel.cpp
@@ -152,10 +152,6 @@ void draw_buffer_list_row(const BufferListRowContext& ctx,
 
     draw_buffer_row_context_menu(ctx.export_dialog, name, ctx.last_export_dir);
 
-    // Where the Selectable's layout put the next row — restored after
-    // the overlays so consecutive rows stack without extra gaps.
-    const ImVec2 after_row = ImGui::GetCursorScreenPos();
-
     if (tex != 0) {
         ImGui::SetCursorScreenPos(
             ImVec2(row_start.x,
@@ -172,7 +168,11 @@ void draw_buffer_list_row(const BufferListRowContext& ctx,
         row_start.y + (row_h - text_size.y) * 0.5f));
     ImGui::TextUnformatted(label.c_str());
 
-    ImGui::SetCursorScreenPos(after_row);
+    // Put the cursor back where the Selectable's layout left it. Done with
+    // an item rather than a bare cursor move: imgui asserts when the cursor
+    // ends past the content extent.
+    ImGui::SetCursorScreenPos(row_start);
+    ImGui::Dummy(ImVec2(0.0f, row_h));
 
     ImGui::PopID();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -188,10 +188,18 @@ void draw_canvas_pane(oid::host::GlfwCanvas& canvas,
     sel.resize_callback(lw, lh);
     const GLuint tex = view.render(sel);
 
+    // The backend samples every texture through its own linear sampler;
+    // the stage texture is drawn 1:1 in framebuffer pixels and must stay
+    // nearest so a fractional DPI scale doesn't blur it.
+    ImDrawList* draw_list = ImGui::GetWindowDrawList();
+    draw_list->AddCallback(
+        ImGui::GetPlatformIO().DrawCallback_SetSamplerNearest, nullptr);
     ImGui::Image(tex,
                  canvas_size,
                  ImVec2(0, 1),
                  ImVec2(1, 0)); // flip V (FBO origin is bottom-left)
+    draw_list->AddCallback(ImGui::GetPlatformIO().DrawCallback_SetSamplerLinear,
+                           nullptr);
 
     // ImGui mouse coordinates are already in screen (logical) points -- the
     // same pane-logical frame the camera operates in (see PaneRenderSize),


### PR DESCRIPTION
Bumps imgui from 1.91.5 to 1.92.9 (supersedes #1021) and adapts to three behaviour changes:

- Font atlas textures are now managed by imgui: `ImGui_ImplOpenGL3_DestroyFontsTexture` is gone and `ImFontAtlas::Build()` is obsolete. On a display-scale change `ImGuiLayer::begin_frame` now just re-adds the fonts and resets `style.FontSizeBase`, which 1.92 seeds from the font only while zero; without the reset text kept the old size.
- A bare `SetCursorScreenPos` past the content extent now asserts (error tooltip in release). The buffer list restored its row cursor that way on every frame; the row now ends with a `Dummy` of its own size.
- The OpenGL3 backend binds its own linear sampler over every texture, blurring the nearest-sampled stage texture at a fractional DPI scale. The canvas draw is bracketed with the backend's nearest/linear sampler callbacks.

Font sizes on screen are unchanged.
