### PR TITLE
fix: a fractional payload size is a protocol error, not a rounded one

### DIFF
--- a/resources/oidmcp/tests/test_endpoint_framing.py
+++ b/resources/oidmcp/tests/test_endpoint_framing.py
@@ -114,3 +114,18 @@ def test_recv_frame_rejects_non_object_frame():
             a.sendall(ep._HEADER.pack(len(data)) + data)
             with pytest.raises(ValueError):
                 ep.recv_frame(b)
+
+
+def test_recv_frame_rejects_non_integer_payload():
+    import json
+    # Shut down + timeout: a truncating reader blocks on a trailer that never
+    # arrives, so without them this hangs instead of failing.
+    for bad in (4.5, 4.0, True, '4', None, [4]):
+        a, b = socket.socketpair()
+        with a, b:
+            b.settimeout(5)
+            data = json.dumps({'ok': True, 'payload': bad}).encode('utf-8')
+            a.sendall(ep._HEADER.pack(len(data)) + data)
+            a.shutdown(socket.SHUT_WR)
+            with pytest.raises(ValueError):
+                ep.recv_frame(b)

--- a/resources/oidscripts/wireframe.py
+++ b/resources/oidscripts/wireframe.py
@@ -84,7 +84,12 @@ def recv_frame(sock, max_payload=None):
         raise ValueError('frame is not a JSON object')
     payload = b''
     if 'payload' in obj:
-        nbytes = int(obj['payload'])
+        declared = obj['payload']
+        # Matches wire_frame.cpp's is_number_integer() and the Kotlin codec.
+        # bool is an int subclass, so {"payload": true} is rejected too.
+        if not isinstance(declared, int) or isinstance(declared, bool):
+            raise ValueError('payload field is not an integer')
+        nbytes = declared
         if nbytes < 0:
             raise ValueError('negative payload size: %d' % nbytes)
         if max_payload is not None and nbytes > max_payload:


### PR DESCRIPTION
`recv_frame` read the declared payload size through `int()`, so `{"payload": 4.5}` became a four-byte trailer instead of an error. `wire_frame.cpp:127-129` checks `is_number_integer()` and throws for the same input.

The reader was the more permissive of the two — the wrong direction when reading from an untrusted peer, who could get four bytes it never framed that way accepted and carried into the reply. Both encoders write integers, so this only matters for a malformed or hostile sender.

Also rejects `bool`, which satisfies `isinstance(x, int)`, so `{"payload": true}` no longer reads as a one-byte trailer.

The test closes the sending half and sets a timeout: a truncating reader blocks forever in `_recv_exact` waiting for a trailer that never arrives, so without that the case hangs the suite instead of failing it. Verified red-first (`ConnectionError`, not `ValueError`); `454 passed, 15 skipped` after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protocol validation by rejecting invalid payload declarations, including fractional values, booleans, strings, null values, and arrays.
  * Invalid payload declarations now fail before any payload data is read, preventing potential blocking or truncated reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->